### PR TITLE
Changing class and instance name for Data and Meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ To install ``Eureka!``, run the setup script:
 
 ## Documentation
 
-Check out the docs at [https://eurekadocs.readthedocs.io/en/](https://eurekadocs.readthedocs.io/en/).
+Check out the docs at [https://eurekadocs.readthedocs.io](https://eurekadocs.readthedocs.io).
 
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ ALERT: Project Eureka! is currently under heavy development. Use at your own ris
 
 ## Installation
 
-To install ``Eureka!``, click on **Code** and **Download ZIP** on GitHub, followed by unpacking the distribution with ``tar -xvf`` in a terminal.
+You can install ``Eureka!`` directly from source on `GitHub <http://github.com/kevin218/Eureka>`_.
 
-Then run the setup script:
+On GitHub, you can click on **Code** and **Download ZIP** followed by unpacking the distribution by opening up a terminal and typing:
+
+``unzip Eureka-main.zip``
+
+To install ``Eureka!``, run the setup script:
 
 ``sudo python setup.py install``
 

--- a/demos/S3/run_eureka.py
+++ b/demos/S3/run_eureka.py
@@ -1,4 +1,3 @@
-
 import sys, os, time
 #sys.path.append('../..')
 #sys.path.append('/Users/stevekb1/Documents/code/Eureka/Eureka')
@@ -14,4 +13,4 @@ reload(s3)
 ev3 = s3.reduceJWST(eventlabel)
 
 reload(s4)
-ev4 = s4.lcJWST(ev3.eventlabel, ev3.workdir, md=ev3)
+ev4 = s4.lcJWST(ev3.eventlabel, ev3.workdir, meta=ev3)

--- a/demos/S3/run_eureka.py
+++ b/demos/S3/run_eureka.py
@@ -2,7 +2,7 @@ import sys, os, time
 #sys.path.append('../..')
 #sys.path.append('/Users/stevekb1/Documents/code/Eureka/Eureka')
 #sys.path.append('/Users/kreidberg/Desktop/Projects/OpenSource/Eureka/')
-sys.path.append('/home/zieba/Desktop/Projects/Open_source/Eureka')
+#sys.path.append('/home/zieba/Desktop/Projects/Open_source/Eureka')
 from importlib import reload
 import eureka.S3_data_reduction.s3_reduce as s3
 import eureka.S4_generate_lightcurves.s4_genLC as s4

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,11 +9,15 @@ From source
 
 You can install ``Eureka!`` directly from source on `GitHub <http://github.com/kevin218/Eureka>`_.
 
-On GitHub, you can either click on **Code** and **Download ZIP** followed by unpacking the distribution with ``tar -xvf`` in a terminal.
+On GitHub, you can either click on **Code** and **Download ZIP** followed by unpacking the distribution by opening up a terminal and typing:
+
+``unzip Eureka-main.zip``
 
 OR
 
-Clone the repository using ``git`` by typing: ``git clone https://github.com/kevin218/Eureka.git``.
+Clone the repository using ``git`` by typing:
+
+``git clone https://github.com/kevin218/Eureka.git``.
 
 To install ``Eureka!``, run the setup script:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -77,6 +77,8 @@ In order for Eureka! to find the control files, you have to change their names:
 If your data directory contains all 21 simulated Stage 2 NIRCam Data segments, this can take around 25 minutes. For a quick look set ``testing`` in the S3 ecf to ``True``.
 This will only reduce and analyze the last segment (=smallest file) in your Stage 2 Data directory.
 
+Note: If you run into a ``matplotlib`` error, you might want to install ``sudo apt install cm-super`` and try it again.
+
 4.2. The code will run and save data and plots in a new directory in ``demos/S3/``.
 Below you see an example for a simulated spectrum which you should get after running the script and having ``is_plotsS3 = 3``:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -3,19 +3,33 @@
 Quickstart
 ============
 
-1. Clone the ``Eureka!`` repository from `GitHub <http://github.com/kevin218/Eureka>`_ in a directory of your choice.
+1. Installation and requirements
+-----------------------------------
+
+1.1. **Download** the ``Eureka!`` repository from `GitHub <http://github.com/kevin218/Eureka>`_.
+Click on **Code** and **Download ZIP** followed by unpacking the distribution by opening up a terminal and typing:
 
 .. code-block::
+	unzip Eureka-main.zip
 
-	git clone git@https://github.com/kevin218/Eureka
 
-2. Install Eureka! by running ``setup.py``:
+1.2. Navigate into the newly created directory and **install** Eureka! by running ``setup.py``:
 
 .. code-block:: python
 
 	sudo python setup.py install
 
-3. Make a directory on your computer to store the simulated data and ancillary files. E.g.:
+1.3. Install additional **requirements** for the package by typing:
+
+.. code-block:: python
+
+	python install -r requirements.txt
+
+
+2. Download data
+-----------------------------------
+
+2.1. Make a new directory on your computer to store the **simulated data and ancillary files**. E.g.:
 
 .. code-block:: python
 
@@ -24,37 +38,47 @@ Quickstart
 	mkdir Stage2
 	mkdir ancil
 
-4. Download the `simulated NIRCam data <https://stsci.app.box.com/s/8r6kqh9m53jkwkff0scmed6zx42g307e/folder/136379342485>`_ from the STScI Box site and save the files in the Stage2 directory.
+2.2. Download the `simulated NIRCam data <https://stsci.app.box.com/s/8r6kqh9m53jkwkff0scmed6zx42g307e/folder/136379342485>`_ from the STScI Box site and save the files in the Stage2 directory.
 You only need the fits files ending with the suffix ``*calints.fits``. The files are large (5 GB total) so the download may take a while.
 If your internet connection is slow, download the `smallest file only <https://stsci.app.box.com/s/8r6kqh9m53jkwkff0scmed6zx42g307e/file/809097167084>`_  and the tutorial will still work.
 
-5. Save the `NIRCam calibration data <https://github.com/ers-transit/hackathon-2021-day2/tree/main/ancil_files/NIRCam>`_ in the `ancil` directory.
+2.3. Save the `NIRCam calibration data <https://github.com/ers-transit/hackathon-2021-day2/tree/main/ancil_files/NIRCam>`_ in the `ancil` directory.
 
+3. Set-up the Eureka! control file (.ecf) and run_script
+-----------------------------------------------------------------
 
-6. Go into the cloned ``Eureka!`` repository and open the file ``Eureka/demos/S3/S3_template.ecf``.
+3.1 Go into the downloaded ``Eureka!`` directory (it is likely called Eureka-main if you downloaded it from GitHub) and open the file ``Eureka-main/demos/S3/S3_template.ecf``.
 Update "topdir + datadir" and "topdir + ancildir" to the location of your Stage2 data and the ancil data, respectively.
 
 You can get more information about the ecf (``Eureka!`` control file) :ref:`here<ecf>`.
 
-7. Go into the ``run_eureka.py`` script and update the path with the location of the cloned repository, like you see here:
+3.2 As the simulated data is containing a transit of WASP-43b, let's call the event 'wasp43b'.
+If you have a look into the ``run_eureka.py`` script, this has been already been set for you (``eventlabel = 'wasp43b'``).
+In order for Eureka to find the control files, you have to change their names:
 
 .. code-block:: python
 
-	sys.path.append('/home/user/Projects/Eureka')
+	S3_template.ecf --> S3_wasp43b.ecf
+	S4_template.ecf --> S4_wasp43b.ecf
 
-8. Now execute the run_eureka.py script which is in the same directory as the ecf by typing:
+
+
+4. Run Eureka!
+-----------------------------------------------------------------
+
+4.1. Now execute the ``run_eureka.py`` script by typing:
 
 .. code-block:: python
 
 	python run_eureka.py
 
 
-If you use all 21 simulated Stage 2 NIRCam Data segments, this can take around 25 minutes. For a quick look set ``testing`` in ecf to ``True``.
+If your data directory contains all 21 simulated Stage 2 NIRCam Data segments, this can take around 25 minutes. For a quick look set ``testing`` in the S3 ecf to ``True``.
 This will only reduce and analyze the last segment (=smallest file) in your Stage 2 Data directory.
 
-9. The code will run and save data and plots in a new directory in ``demos/S3/``.
+4.2. The code will run and save data and plots in a new directory in ``demos/S3/``.
 Below you see an example for a simulated spectrum which you should get after running the script and having ``is_plotsS3 = 3``:
 
-.. image:: fig3001-1281-Image+Background.png
+.. image:: fig3301-1-Image+Background.png
 
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -45,7 +45,7 @@ If your internet connection is slow, download the `smallest file only <https://s
 
 2.3. Save the `NIRCam calibration data <https://github.com/ers-transit/hackathon-2021-day2/tree/main/ancil_files/NIRCam>`_ in the `ancil` directory.
 
-3. Setup the Eureka! control file (.ecf) and run_script.py
+3. Setup the Eureka! control file (.ecf) and run_eureka.py
 -----------------------------------------------------------------
 
 3.1 Go into the downloaded ``Eureka!`` directory (it is likely called Eureka-main if you downloaded it from GitHub) and open the file ``Eureka-main/demos/S3/S3_template.ecf``.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -10,6 +10,7 @@ Quickstart
 Click on **Code** and **Download ZIP** followed by unpacking the distribution by opening up a terminal and typing:
 
 .. code-block::
+
 	unzip Eureka-main.zip
 
 
@@ -38,13 +39,13 @@ Click on **Code** and **Download ZIP** followed by unpacking the distribution by
 	mkdir Stage2
 	mkdir ancil
 
-2.2. Download the `simulated NIRCam data <https://stsci.app.box.com/s/8r6kqh9m53jkwkff0scmed6zx42g307e/folder/136379342485>`_ from the STScI Box site and save the files in the Stage2 directory.
+2.2. Download the `simulated NIRCam data <https://stsci.app.box.com/s/8r6kqh9m53jkwkff0scmed6zx42g307e/folder/136379342485>`_ from the STScI Box site and save the files in the `Stage2` directory.
 You only need the fits files ending with the suffix ``*calints.fits``. The files are large (5 GB total) so the download may take a while.
 If your internet connection is slow, download the `smallest file only <https://stsci.app.box.com/s/8r6kqh9m53jkwkff0scmed6zx42g307e/file/809097167084>`_  and the tutorial will still work.
 
 2.3. Save the `NIRCam calibration data <https://github.com/ers-transit/hackathon-2021-day2/tree/main/ancil_files/NIRCam>`_ in the `ancil` directory.
 
-3. Set-up the Eureka! control file (.ecf) and run_script
+3. Setup the Eureka! control file (.ecf) and run_script.py
 -----------------------------------------------------------------
 
 3.1 Go into the downloaded ``Eureka!`` directory (it is likely called Eureka-main if you downloaded it from GitHub) and open the file ``Eureka-main/demos/S3/S3_template.ecf``.
@@ -54,7 +55,7 @@ You can get more information about the ecf (``Eureka!`` control file) :ref:`here
 
 3.2 As the simulated data is containing a transit of WASP-43b, let's call the event 'wasp43b'.
 If you have a look into the ``run_eureka.py`` script, this has been already been set for you (``eventlabel = 'wasp43b'``).
-In order for Eureka to find the control files, you have to change their names:
+In order for Eureka! to find the control files, you have to change their names:
 
 .. code-block:: python
 

--- a/eureka/S3_data_reduction/plots_s3.py
+++ b/eureka/S3_data_reduction/plots_s3.py
@@ -2,9 +2,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-def image_and_background(dat, md, n):
+def image_and_background(data, meta, n):
 
-    intstart, subdata, submask, subbg = dat.intstart, dat.subdata, dat.submask, dat.subbg
+    intstart, subdata, submask, subbg = data.intstart, data.subdata, data.submask, data.subbg
 
     plt.figure(3301)
     plt.clf()
@@ -19,12 +19,13 @@ def image_and_background(dat, md, n):
     std = np.std(subbg[n])
     plt.imshow(subbg[n], origin='lower', aspect='auto', vmin=median - 3 * std, vmax=median + 3 * std)
     # plt.imshow(submask[n], origin='lower', aspect='auto', vmin=0, vmax=1)
-    plt.savefig(md.workdir + '/figs/fig3301-' + str(intstart + n) + '-Image+Background.png')
+    plt.savefig(meta.workdir + '/figs/fig3301-' + str(intstart + n) + '-Image+Background.png')
     # plt.pause(0.1)
 
-def optimal_spectrum(dat, md, n):
 
-    intstart, subnx, stdspec, optspec, opterr = dat.intstart, md.subnx, dat.stdspec, dat.optspec, dat.opterr
+def optimal_spectrum(data, meta, n):
+
+    intstart, subnx, stdspec, optspec, opterr = data.intstart, meta.subnx, data.stdspec, data.optspec, data.opterr
 
     plt.figure(3302)
     plt.clf()
@@ -33,10 +34,11 @@ def optimal_spectrum(dat, md, n):
     # plt.errorbar(range(subnx), stdspec[n], yerr=np.sqrt(stdvar[n]), fmt='-', color='C1', ecolor='C0', label='Std Spec')
     plt.errorbar(range(subnx), optspec[n], opterr[n], fmt='-', color='C2', ecolor='C2', label='Optimal Spec')
     plt.legend(loc='best')
-    plt.savefig(md.workdir + '/figs/fig3302-' + str(intstart + n) + '-Spectrum.png')
+    plt.savefig(meta.workdir + '/figs/fig3302-' + str(intstart + n) + '-Spectrum.png')
     # plt.pause(0.1)
 
-def lc_nodriftcorr(md, wave_1d, optspec):
+
+def lc_nodriftcorr(meta, wave_1d, optspec):
     plt.figure(3101, figsize=(8, 8))  # ev.n_files/20.+0.8))
     plt.clf()
     wmin = wave_1d.min()
@@ -62,4 +64,4 @@ def lc_nodriftcorr(md, wave_1d, optspec):
     plt.xlabel(r'Wavelength ($\mu m$)')
     plt.colorbar(label='Normalized Flux')
     plt.tight_layout()
-    plt.savefig(md.workdir + '/figs/fig3101-2D_LC.png')
+    plt.savefig(meta.workdir + '/figs/fig3101-2D_LC.png')

--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -254,8 +254,8 @@ def reduceJWST(eventlabel):
     log.writelog('Copy S3 ecf')
     shutil.copy(ecffile, meta.workdir)
 
-    log.writelog('Generating figures')
     if meta.isplots_S3 >= 1:
+        log.writelog('Generating figure')
         # 2D light curve without drift correction
         plots_s3.lc_nodriftcorr(meta, wave_1d, optspec)
 

--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -24,9 +24,9 @@
 # 17. Produce plots DONE
 """
 
-import sys, os, time
+import os, time
 import numpy as np
-import multiprocessing as mp
+import shutil
 from ..lib import logedit
 from ..lib import readECF as rd
 from ..lib import manageevent as me
@@ -35,26 +35,27 @@ from importlib import reload
 from ..lib import astropytable
 from ..lib import util
 from . import plots_s3
+
 reload(optspex)
 
 
-class Metadata():
-  def __init__(self):
+class MetaClass:
+    def __init__(self):
+        # initialize Univ
+        # Univ.__init__(self)
+        # self.initpars(ecf)
+        # self.foo = 2
+        return
 
-    # initialize Univ
-    #Univ.__init__(self)
-    #self.initpars(ecf)
-    #self.foo = 2
-    return
 
-class Data():
-  def __init__(self):
+class DataClass:
+    def __init__(self):
+        # initialize Univ
+        # Univ.__init__(self)
+        # self.initpars(ecf)
+        # self.foo = 2
+        return
 
-    # initialize Univ
-    #Univ.__init__(self)
-    #self.initpars(ecf)
-    #self.foo = 2
-    return
 
 def reduceJWST(eventlabel):
     '''
@@ -66,8 +67,8 @@ def reduceJWST(eventlabel):
 
     Returns
     -------
-    md          : Event object
-    dat         : Data object
+    meta          : Metadata object
+    data         : Data object
 
     Remarks
     -------
@@ -79,92 +80,90 @@ def reduceJWST(eventlabel):
 
     '''
 
-    t0      = time.time()
+    t0 = time.time()
 
     # Initialize metadata object
-    md              = Metadata()
-    md.eventlabel   = eventlabel
+    meta = MetaClass()
+    meta.eventlabel = eventlabel
 
     # Initialize data object
-    dat              = Data()
-
+    data = DataClass()
 
     # Create directories for Stage 3 processing
-    datetime= time.strftime('%Y-%m-%d_%H-%M-%S')
-    md.workdir = 'S3_' + datetime + '_' + md.eventlabel
-    if not os.path.exists(md.workdir):
-        os.makedirs(md.workdir)
-    if not os.path.exists(md.workdir+"/figs"):
-        os.makedirs(md.workdir+"/figs")
+    datetime = time.strftime('%Y-%m-%d_%H-%M-%S')
+    meta.workdir = 'S3_' + datetime + '_' + meta.eventlabel
+    if not os.path.exists(meta.workdir):
+        os.makedirs(meta.workdir)
+    if not os.path.exists(meta.workdir + "/figs"):
+        os.makedirs(meta.workdir + "/figs")
 
     # Load Eureka! control file and store values in Event object
     ecffile = 'S3_' + eventlabel + '.ecf'
-    ecf     = rd.read_ecf(ecffile)
-    rd.store_ecf(md, ecf)
+    ecf = rd.read_ecf(ecffile)
+    rd.store_ecf(meta, ecf)
 
     # Load instrument module
-    exec('from . import ' + md.inst + ' as inst', globals())
+    exec('from . import ' + meta.inst + ' as inst', globals())
     reload(inst)
 
     # Open new log file
-    md.logname  = './'+md.workdir + '/S3_' + md.eventlabel + ".log"
-    log         = logedit.Logedit(md.logname)
+    meta.logname = './' + meta.workdir + '/S3_' + meta.eventlabel + ".log"
+    log = logedit.Logedit(meta.logname)
     log.writelog("\nStarting Stage 3 Reduction")
 
     # Create list of file segments
-    md = util.readfiles(md)
-    num_data_files = len(md.segment_list)
-    log.writelog(f'\nFound {num_data_files} data file(s) ending in {md.suffix}.fits')
+    meta = util.readfiles(meta)
+    num_data_files = len(meta.segment_list)
+    log.writelog(f'\nFound {num_data_files} data file(s) ending in {meta.suffix}.fits')
 
     stdspec = np.array([])
     # Loop over each segment
-    if md.testing_S3 == True:
-        istart = num_data_files-1
+    # Only reduce the last segment/file if testing_S3 is set to True in ecf
+    if meta.testing_S3:
+        istart = num_data_files - 1
     else:
         istart = 0
     for m in range(istart, num_data_files):
         # Report progress
 
         # Read in data frame and header
-        log.writelog(f'Reading file {m+1} of {num_data_files}')
-        dat = inst.read(md.segment_list[m], dat, returnHdr=True)
+        log.writelog(f'Reading file {m + 1} of {num_data_files}')
+        data = inst.read(meta.segment_list[m], data)
         # Get number of integrations and frame dimensions
-        md.n_int, md.ny, md.nx = dat.data.shape
+        meta.n_int, meta.ny, meta.nx = data.data.shape
         # Locate source postion
-        md.src_xpos = dat.shdr['SRCXPOS']-md.xwindow[0]
-        md.src_ypos = dat.shdr['SRCYPOS']-md.ywindow[0]
+        meta.src_xpos = data.shdr['SRCXPOS'] - meta.xwindow[0]
+        meta.src_ypos = data.shdr['SRCYPOS'] - meta.ywindow[0]
         # Record integration mid-times in BJD_TDB
-        dat.bjdtdb = dat.int_times['int_mid_BJD_TDB']
+        data.bjdtdb = data.int_times['int_mid_BJD_TDB']
         # Trim data to subarray region of interest
-        dat, md = util.trim(dat, md)
+        data, meta = util.trim(data, meta)
         # Create bad pixel mask (1 = good, 0 = bad)
         # FINDME: Will want to use DQ array in the future to flag certain pixels
-        dat.submask = np.ones(dat.subdata.shape)
+        data.submask = np.ones(data.subdata.shape)
 
-        #Convert units (eg. for NIRCam: MJy/sr -> DN -> Electrons)
-        dat, md = inst.unit_convert(dat, md, log)
+        # Convert units (eg. for NIRCam: MJy/sr -> DN -> Electrons)
+        data, meta = inst.unit_convert(data, meta, log)
 
         # Check if arrays have NaNs
-        dat.submask = util.check_nans(dat.subdata, dat.submask, log)
-        dat.submask = util.check_nans(dat.suberr, dat.submask, log)
-        dat.submask = util.check_nans(dat.subv0, dat.submask, log)
+        data.submask = util.check_nans(data.subdata, data.submask, log)
+        data.submask = util.check_nans(data.suberr, data.submask, log)
+        data.submask = util.check_nans(data.subv0, data.submask, log)
 
         # Manually mask regions [colstart, colend, rowstart, rowend]
-        if hasattr(md, 'manmask'):
+        if hasattr(meta, 'manmask'):
             log.writelog("  Masking manually identified bad pixels")
-            for i in range(len(md.manmask)):
-                ind, colstart, colend, rowstart, rowend = md.manmask[i]
-                dat.submask[rowstart:rowend,colstart:colend] = 0
+            for i in range(len(meta.manmask)):
+                ind, colstart, colend, rowstart, rowend = meta.manmask[i]
+                data.submask[rowstart:rowend, colstart:colend] = 0
 
         # Perform outlier rejection of sky background along time axis
         log.writelog('Performing background outlier rejection')
-        md.bg_y1    = int(md.src_ypos - md.bg_hw)
-        md.bg_y2    = int(md.src_ypos + md.bg_hw)
-        dat.submask = inst.flag_bg(dat, md)
+        meta.bg_y1 = int(meta.src_ypos - meta.bg_hw)
+        meta.bg_y2 = int(meta.src_ypos + meta.bg_hw)
+        data = inst.flag_bg(data, meta)
 
-
-        dat = util.BGsubtraction(dat, md, log, md.isplots_S3)
-
+        data = util.BGsubtraction(data, meta, log, meta.isplots_S3)
 
         # Calulate drift2D
         # print("Calculating 2D drift...")
@@ -174,83 +173,91 @@ def reduceJWST(eventlabel):
         # Outlier rejection of full frame along time axis
         # print("Performing full-frame outlier rejection...")
 
-        if md.isplots_S3 >= 3:
-            for n in range(md.n_int):
-                #make image+background plots
-                plots_s3.image_and_background(dat, md, n)
-
+        if meta.isplots_S3 >= 3:
+            for n in range(meta.n_int):
+                # make image+background plots
+                plots_s3.image_and_background(data, meta, n)
 
         # print("Performing sub-pixel drift correction...")
 
         # Select only aperture region
-        ap_y1       = int(md.src_ypos - md.spec_hw)
-        ap_y2       = int(md.src_ypos + md.spec_hw)
-        dat.apdata      = dat.subdata[:,ap_y1:ap_y2]
-        dat.aperr       = dat.suberr [:,ap_y1:ap_y2]
-        dat.apmask      = dat.submask[:,ap_y1:ap_y2]
-        dat.apbg        = dat.subbg  [:,ap_y1:ap_y2]
-        dat.apv0        = dat.subv0  [:,ap_y1:ap_y2]
+        ap_y1 = int(meta.src_ypos - meta.spec_hw)
+        ap_y2 = int(meta.src_ypos + meta.spec_hw)
+        data.apdata  = data.subdata[:, ap_y1:ap_y2]
+        data.aperr   = data.suberr[:, ap_y1:ap_y2]
+        data.apmask  = data.submask[:, ap_y1:ap_y2]
+        data.apbg    = data.subbg[:, ap_y1:ap_y2]
+        data.apv0    = data.subv0[:, ap_y1:ap_y2]
         # Extract standard spectrum and its variance
-        dat.stdspec     = np.sum(dat.apdata, axis=1)
-        dat.stdvar      = np.sum(dat.aperr**2, axis=1)  #FINDME: stdvar >> stdspec, which is a problem
+        data.stdspec = np.sum(data.apdata, axis=1)
+        data.stdvar  = np.sum(data.aperr ** 2, axis=1)  # FINDME: stdvar >> stdspec, which is a problem
         # Compute fraction of masked pixels within regular spectral extraction window
-        #numpixels   = 2.*md.spec_width*subnx
-        #fracMaskReg = (numpixels - np.sum(apmask,axis=(2,3)))/numpixels
+        # numpixels   = 2.*meta.spec_width*subnx
+        # fracMaskReg = (numpixels - np.sum(apmask,axis=(2,3)))/numpixels
 
         # Compute median frame
-        md.medsubdata   = np.median(dat.subdata, axis=0)
-        md.medapdata    = np.median(dat.apdata, axis=0)
+        data.medsubdata = np.median(data.subdata, axis=0)
+        data.medapdata  = np.median(data.apdata, axis=0)
 
         # Extract optimal spectrum with uncertainties
         log.writelog("  Performing optimal spectral extraction")
-        dat.optspec     = np.zeros((dat.stdspec.shape))
-        dat.opterr      = np.zeros((dat.stdspec.shape))
-        gain        = 1         #FINDME: need to determine correct gain
-        for n in range(md.n_int):
-            dat.optspec[n], dat.opterr[n], mask = optspex.optimize(dat.apdata[n], dat.apmask[n], dat.apbg[n], dat.stdspec[n], gain, dat.apv0[n], p5thresh=md.p5thresh, p7thresh=md.p7thresh, fittype=md.fittype, window_len=md.window_len, deg=md.prof_deg, n=dat.intstart+n, isplots=md.isplots_S3, eventdir=md.workdir, meddata=md.medapdata)
+        data.optspec = np.zeros(data.stdspec.shape)
+        data.opterr  = np.zeros(data.stdspec.shape)
+        gain = 1  # FINDME: need to determine correct gain
+        for n in range(meta.n_int):
+            data.optspec[n], data.opterr[n], mask = optspex.optimize(data.apdata[n], data.apmask[n], data.apbg[n],
+                                                                     data.stdspec[n], gain, data.apv0[n],
+                                                                     p5thresh=meta.p5thresh, p7thresh=meta.p7thresh,
+                                                                     fittype=meta.fittype, window_len=meta.window_len,
+                                                                     deg=meta.prof_deg, n=data.intstart + n,
+                                                                     isplots=meta.isplots_S3, eventdir=meta.workdir,
+                                                                     meddata=data.medapdata)
 
         # Plotting results
-        if md.isplots_S3 >= 3:
-            for n in range(md.n_int):
-                #make optimal spectrum plot
-                plots_s3.optimal_spectrum(dat, md, n)
+        if meta.isplots_S3 >= 3:
+            for n in range(meta.n_int):
+                # make optimal spectrum plot
+                plots_s3.optimal_spectrum(data, meta, n)
 
         # Append results
         if len(stdspec) == 0:
-            wave_2d  = dat.subwave
-            wave_1d  = dat.subwave[md.src_ypos]
-            stdspec  = dat.stdspec
-            stdvar   = dat.stdvar
-            optspec  = dat.optspec
-            opterr   = dat.opterr
-            bjdtdb   = dat.bjdtdb
+            wave_2d = data.subwave
+            wave_1d = data.subwave[meta.src_ypos]
+            stdspec = data.stdspec
+            stdvar  = data.stdvar
+            optspec = data.optspec
+            opterr  = data.opterr
+            bjdtdb  = data.bjdtdb
         else:
-            stdspec  = np.append(stdspec, dat.stdspec, axis=0)
-            stdvar   = np.append(stdvar, dat.stdvar, axis=0)
-            optspec  = np.append(optspec, dat.optspec, axis=0)
-            opterr   = np.append(opterr, dat.opterr, axis=0)
-            bjdtdb   = np.append(bjdtdb, dat.bjdtdb, axis=0)
+            stdspec = np.append(stdspec, data.stdspec, axis=0)
+            stdvar  = np.append(stdvar, data.stdvar, axis=0)
+            optspec = np.append(optspec, data.optspec, axis=0)
+            opterr  = np.append(opterr, data.opterr, axis=0)
+            bjdtdb  = np.append(bjdtdb, data.bjdtdb, axis=0)
 
     # Calculate total time
-    total = (time.time() - t0)/60.
-    log.writelog('\nTotal time (min): ' + str(np.round(total,2)))
-
-
-    # Save results
-    log.writelog('Saving results')
-    me.saveevent(md, md.workdir + '/S3_' + md.eventlabel + "_Meta_Save", save=[])
+    total = (time.time() - t0) / 60.
+    log.writelog('\nTotal time (min): ' + str(np.round(total, 2)))
 
     # Save results
-    log.writelog('Saving results')
-    me.saveevent(dat, md.workdir + '/S3_' + md.eventlabel + "_Data_Save", save=[])
+    log.writelog('Saving Metadata')
+    me.saveevent(meta, meta.workdir + '/S3_' + meta.eventlabel + "_Meta_Save", save=[])
 
-    log.writelog('Saving results as astropy table...')
-    astropytable.savetable(md, bjdtdb, wave_1d, stdspec, stdvar, optspec, opterr)
+    # Save results
+    #log.writelog('Saving results')
+    #me.saveevent(data, meta.workdir + '/S3_' + meta.eventlabel + "_Data_Save", save=[])
+
+    log.writelog('Saving results as astropy table')
+    astropytable.savetable_S3(meta, bjdtdb, wave_1d, stdspec, stdvar, optspec, opterr)
+
+    # Copy ecf
+    log.writelog('Copy S3 ecf')
+    shutil.copy(ecffile, meta.workdir)
 
     log.writelog('Generating figures')
-    if md.isplots_S3 >= 1:
+    if meta.isplots_S3 >= 1:
         # 2D light curve without drift correction
-        plots_s3.lc_nodriftcorr(md, wave_1d, optspec)
+        plots_s3.lc_nodriftcorr(meta, wave_1d, optspec)
 
     log.closelog()
-    return md
+    return meta

--- a/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/eureka/S4_generate_lightcurves/plots_s4.py
@@ -1,15 +1,16 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-def binned_lightcurve(md, bjdtdb, i):
+
+def binned_lightcurve(meta, bjdtdb, i):
     plt.figure(4100 + i, figsize=(8, 6))
     plt.clf()
-    plt.suptitle(f"Bandpass {i}: %.3f - %.3f" % (md.wave_low[i], md.wave_hi[i]))
+    plt.suptitle(f"Bandpass {i}: %.3f - %.3f" % (meta.wave_low[i], meta.wave_hi[i]))
     ax = plt.subplot(111)
     mjd = np.floor(bjdtdb[0])
     # Normalized light curve
-    norm_lcdata = md.lcdata[i] / md.lcdata[i, -1]
-    norm_lcerr = md.lcerr[i] / md.lcdata[i, -1]
+    norm_lcdata = meta.lcdata[i] / meta.lcdata[i, -1]
+    norm_lcerr = meta.lcerr[i] / meta.lcdata[i, -1]
     plt.errorbar(bjdtdb - mjd, norm_lcdata, norm_lcerr, fmt='o', color=f'C{i}', mec='w')
     plt.text(0.05, 0.1, "MAD = " + str(np.round(1e6 * np.median(np.abs(np.ediff1d(norm_lcdata))))) + " ppm",
              transform=ax.transAxes, color='k')
@@ -17,5 +18,4 @@ def binned_lightcurve(md, bjdtdb, i):
     plt.xlabel(f'Time [MJD + {mjd}]')
 
     plt.subplots_adjust(left=0.10, right=0.95, bottom=0.10, top=0.90, hspace=0.20, wspace=0.3)
-    plt.savefig(md.lcdir + '/figs/Fig' + str(4100 + i) + '-' + md.eventlabel + '-1D_LC.png')
-
+    plt.savefig(meta.lcdir + '/figs/Fig' + str(4100 + i) + '-' + meta.eventlabel + '-1D_LC.png')

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -107,7 +107,7 @@ def lcJWST(eventlabel, workdir, meta=None):
         # Sum flux for each spectroscopic channel
         meta.lcdata[i]    = np.sum(optspec[:,index],axis=1)
         # Add uncertainties in quadrature
-        meta.lcerr[i]     = np.sqrt(np.sum(optspec[:,index]**2,axis=1))/100
+        meta.lcerr[i]     = np.sqrt(np.sum(optspec[:,index]**2,axis=1))
 
         # Plot each spectroscopic light curve
         if meta.isplots_S4 >= 3:

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -24,7 +24,7 @@ from ..lib import manageevent as me
 from ..lib import astropytable
 from . import plots_s4
 
-def lcJWST(eventlabel, workdir, md=None):
+def lcJWST(eventlabel, workdir, meta=None):
     #expand=1, smooth_len=None, correctDrift=True
     '''
     Compute photometric flux over specified range of wavelengths
@@ -33,7 +33,7 @@ def lcJWST(eventlabel, workdir, md=None):
     ----------
     eventlabel  : Unique identifier for these data
     workdir     : Location of save file
-    ev          : event object
+    meta          : metadata object
 
     Returns
     -------
@@ -45,32 +45,33 @@ def lcJWST(eventlabel, workdir, md=None):
 
     '''
     #load savefile
-    if md == None:
-        md = me.load(workdir+'/S3_'+eventlabel+'_Meta_Save.dat')
+    if meta == None:
+        meta = me.load(workdir + '/S3_' + eventlabel + '_Meta_Save.dat')
 
     # Load Eureka! control file and store values in Event object
     ecffile = 'S4_' + eventlabel + '.ecf'
     ecf     = rd.read_ecf(ecffile)
-    rd.store_ecf(md, ecf)
+    rd.store_ecf(meta, ecf)
 
     # Create directories for Stage 3 processing
     datetime= time.strftime('%Y-%m-%d_%H-%M-%S')
-    md.lcdir = md.workdir + '/S4_' + datetime + '_' + str(md.nspecchan) + 'chan'
-    if not os.path.exists(md.lcdir):
-        os.makedirs(md.lcdir)
-    if not os.path.exists(md.lcdir+"/figs"):
-        os.makedirs(md.lcdir+"/figs")
+    meta.lcdir = meta.workdir + '/S4_' + datetime + '_' + str(meta.nspecchan) + 'chan'
+    if not os.path.exists(meta.lcdir):
+        os.makedirs(meta.lcdir)
+    if not os.path.exists(meta.lcdir+"/figs"):
+        os.makedirs(meta.lcdir+"/figs")
 
     # Copy existing S3 log file
-    md.s4_logname  = './'+md.lcdir + '/S4_' + md.eventlabel + ".log"
+    meta.s4_logname  = './' + meta.lcdir + '/S4_' + meta.eventlabel + ".log"
     #shutil.copyfile(ev.logname, ev.s4_logname, follow_symlinks=True)
-    log         = logedit.Logedit(md.s4_logname, read=md.logname)
+    log         = logedit.Logedit(meta.s4_logname, read=meta.logname)
     log.writelog("\nStarting Stage 4: Generate Light Curves\n")
 
-    table = astropytable.readtable(md)
+    table = astropytable.readtable(meta)
 
-    optspec, wave_1d, bjdtdb = np.reshape(table['optspec'].data, (-1, md.subnx)), \
-                               table['wave_1d'].data[0:md.subnx], table['bjdtdb'].data[::md.subnx]
+    # Reverse the reshaping which has been done when saving the astropy table
+    optspec, wave_1d, bjdtdb = np.reshape(table['optspec'].data, (-1, meta.subnx)), \
+                               table['wave_1d'].data[0:meta.subnx], table['bjdtdb'].data[::meta.subnx]
 
     #Replace NaNs with zero
     optspec[np.where(np.isnan(optspec))] = 0
@@ -78,9 +79,9 @@ def lcJWST(eventlabel, workdir, md=None):
 
 
     # Determine wavelength bins
-    binsize     = (md.wave_max - md.wave_min)/md.nspecchan
-    md.wave_low = np.round([i for i in np.linspace(md.wave_min, md.wave_max-binsize, md.nspecchan)],3)
-    md.wave_hi  = np.round([i for i in np.linspace(md.wave_min+binsize, md.wave_max, md.nspecchan)],3)
+    binsize     = (meta.wave_max - meta.wave_min)/meta.nspecchan
+    meta.wave_low = np.round([i for i in np.linspace(meta.wave_min, meta.wave_max-binsize, meta.nspecchan)],3)
+    meta.wave_hi  = np.round([i for i in np.linspace(meta.wave_min+binsize, meta.wave_max, meta.nspecchan)],3)
 
     # Apply 1D drift correction
     # if correctDrift == True:
@@ -96,30 +97,33 @@ def lcJWST(eventlabel, workdir, md=None):
 
     log.writelog("Generating light curves")
     n_int, nx   = optspec.shape
-    md.lcdata   = np.zeros((md.nspecchan, n_int))
-    md.lcerr    = np.zeros((md.nspecchan, n_int))
+    meta.lcdata   = np.zeros((meta.nspecchan, n_int))
+    meta.lcerr    = np.zeros((meta.nspecchan, n_int))
     # ev.eventname2 = ev.eventname
-    for i in range(md.nspecchan):
-        log.writelog(f"Bandpass {i} = %.3f - %.3f" % (md.wave_low[i],md.wave_hi[i]))
+    for i in range(meta.nspecchan):
+        log.writelog(f"Bandpass {i} = %.3f - %.3f" % (meta.wave_low[i], meta.wave_hi[i]))
         # Compute valid indeces within wavelength range
-        index   = np.where((wave_1d >= md.wave_low[i])*(wave_1d <= md.wave_hi[i]))[0]
+        index   = np.where((wave_1d >= meta.wave_low[i])*(wave_1d <= meta.wave_hi[i]))[0]
         # Sum flux for each spectroscopic channel
-        md.lcdata[i]    = np.sum(optspec[:,index],axis=1)
+        meta.lcdata[i]    = np.sum(optspec[:,index],axis=1)
         # Add uncertainties in quadrature
-        md.lcerr[i]     = np.sqrt(np.sum(optspec[:,index]**2,axis=1))
+        meta.lcerr[i]     = np.sqrt(np.sum(optspec[:,index]**2,axis=1))/100
 
         # Plot each spectroscopic light curve
-        if md.isplots_S4 >= 3:
-            plots_s4.binned_lightcurve(md, bjdtdb, i)
+        if meta.isplots_S4 >= 3:
+            plots_s4.binned_lightcurve(meta, bjdtdb, i)
 
     # Save results
     log.writelog('Saving results')
-    me.saveevent(md, md.lcdir + '/S4_' + md.eventlabel + "_Meta_Save", save=[])
+    me.saveevent(meta, meta.lcdir + '/S4_' + meta.eventlabel + "_Meta_Save", save=[])
 
     # if (isplots >= 1) and (correctDrift == True):
     #     # Plot Drift
     #     # Plots corrected 2D light curves
 
+    # Copy ecf
+    log.writelog('Copy S4 ecf')
+    shutil.copy(ecffile, meta.lcdir)
 
     log.closelog()
-    return md
+    return meta

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -53,7 +53,7 @@ def lcJWST(eventlabel, workdir, meta=None):
     ecf     = rd.read_ecf(ecffile)
     rd.store_ecf(meta, ecf)
 
-    # Create directories for Stage 3 processing
+    # Create directories for Stage 4 processing
     datetime= time.strftime('%Y-%m-%d_%H-%M-%S')
     meta.lcdir = meta.workdir + '/S4_' + datetime + '_' + str(meta.nspecchan) + 'chan'
     if not os.path.exists(meta.lcdir):
@@ -61,7 +61,7 @@ def lcJWST(eventlabel, workdir, meta=None):
     if not os.path.exists(meta.lcdir+"/figs"):
         os.makedirs(meta.lcdir+"/figs")
 
-    # Copy existing S3 log file
+    # Copy existing S4 log file
     meta.s4_logname  = './' + meta.lcdir + '/S4_' + meta.eventlabel + ".log"
     #shutil.copyfile(ev.logname, ev.s4_logname, follow_symlinks=True)
     log         = logedit.Logedit(meta.s4_logname, read=meta.logname)

--- a/eureka/S5_lightcurve_fitting/utils.py
+++ b/eureka/S5_lightcurve_fitting/utils.py
@@ -52,7 +52,7 @@ if not ON_TRAVIS_OR_RTD:
         for item in ['exoctk_contam', 'exoctk_log', 'fortney', 'generic', 'groups_integrations', 'modelgrid']:
             if item not in [os.path.basename(item) for item in glob.glob(os.path.join(EXOCTK_DATA, '*'))]:
                 print(
-                    'WARNING: Missing {}/ directory from {}. Please ensure that the ExoCTK data package has been '
+                    'WARNING (only important for Stage 5): Missing {}/ directory from {}. Please ensure that the ExoCTK data package has been '
                     'downloaded. Users may retrieve this package by clicking the "ExoCTK Data Download" '
                     'button on the ExoCTK website, or by using the exoctk.utils.download_exoctk_data() '
                     'function'.format(item, EXOCTK_DATA))

--- a/eureka/S5_lightcurve_fitting/utils.py
+++ b/eureka/S5_lightcurve_fitting/utils.py
@@ -36,7 +36,7 @@ ON_TRAVIS_OR_RTD = HOME_DIR == '/home/travis' or HOME_DIR == '/Users/travis' or 
 if not ON_TRAVIS_OR_RTD:
     if not EXOCTK_DATA:
         print(
-            'WARNING: The $EXOCTK_DATA environment variable is not set.  Please set the '
+            'WARNING (only important for Stage 5): The $EXOCTK_DATA environment variable is not set.  Please set the '
             'value of this variable to point to the location of the exoctk_data '
             'download folder.  Users may retreive this folder by clicking the '
             '"ExoCTK Data Download" button on the ExoCTK website, or by using '
@@ -45,7 +45,7 @@ if not ON_TRAVIS_OR_RTD:
         # If the variable exists but doesn't point to a real location
         if not os.path.exists(EXOCTK_DATA):
             print(
-                'WARNING: The $EXOCTK_DATA environment variable is set to a location that '
+                'WARNING (only important for Stage 5): The $EXOCTK_DATA environment variable is set to a location that '
                 'cannot be accessed.')
 
         # If the variable exists, points to a real location, but is missing contents

--- a/eureka/lib/astropytable.py
+++ b/eureka/lib/astropytable.py
@@ -4,7 +4,7 @@ from astropy.io import ascii
 import numpy as np
 import os
 
-def savetable(md, bjdtdb, wave_1d, stdspec, stdvar, optspec, opterr):
+def savetable_S3(meta, bjdtdb, wave_1d, stdspec, stdvar, optspec, opterr):
     """
       Saves data in an event as .txt using astropy
 
@@ -25,7 +25,7 @@ def savetable(md, bjdtdb, wave_1d, stdspec, stdvar, optspec, opterr):
 
     """
 
-    filename = md.workdir + '/S3_' + md.eventlabel + "_Table_Save.txt"
+    filename = meta.workdir + '/S3_' + meta.eventlabel + "_Table_Save.txt"
 
     dims = stdspec.shape #tuple (integration, wavelength position)
 
@@ -40,6 +40,6 @@ def savetable(md, bjdtdb, wave_1d, stdspec, stdvar, optspec, opterr):
     table = QTable(arr, names=('bjdtdb', 'wave_1d', 'stdspec', 'stdvar', 'optspec', 'opterr'))
     ascii.write(table, filename, format='ecsv', overwrite=True, fast_writer=True)
 
-def readtable(md):
-    t = ascii.read(md.workdir+'/S3_'+md.eventlabel+'_Table_Save.txt', format='ecsv')
+def readtable(meta):
+    t = ascii.read(meta.workdir+'/S3_' + meta.eventlabel+'_Table_Save.txt', format='ecsv')
     return t

--- a/eureka/lib/readECF.py
+++ b/eureka/lib/readECF.py
@@ -209,16 +209,16 @@ def read_ecf(file):
         i += 1
       return ecf
 
-def store_ecf(ev, ecf):
+def store_ecf(meta, ecf):
     '''
-    Store values from Eureka control file as parameters in Event object.
+    Store values from Eureka control file as parameters in Meta object.
     '''
     for key in ecf.__dict__.keys():
         try:
-            exec('ev.' + key + ' = ecf.'+key+'.get(0)', locals())
+            exec('meta.' + key + ' = ecf.'+key+'.get(0)', locals())
         except:
             try:
-                exec('ev.' + key + ' = ecf.'+key+'.getarr(0)', locals())
+                exec('meta.' + key + ' = ecf.'+key+'.getarr(0)', locals())
             except:
                 print("Unable to store parameter: " + key)
     return

--- a/eureka/lib/sort_nicely.py
+++ b/eureka/lib/sort_nicely.py
@@ -1,17 +1,20 @@
 
 import re
 
+
 def tryint(s):
     try:
         return int(s)
     except:
         return s
 
+
 def alphanum_key(s):
     """ Turn a string into a list of string and number chunks.
         "z23a" -> ["z", 23, "a"]
     """
     return [ tryint(c) for c in re.split('([0-9]+)', s) ]
+
 
 def sort_nicely(list1):
     """ Sort the given list in the way that humans expect.

--- a/eureka/tests/test_S3.py
+++ b/eureka/tests/test_S3.py
@@ -2,16 +2,16 @@ import numpy as np
 from ..lib import util
 
 
-class Metadata():
+class MetaClass:
   def __init__(self):
     return
 
-class Data:
+class DataClass:
   def __init__(self):
     return
 
-md = Metadata()
-dat = Data()
+meta= MetaClass()
+data = DataClass()
 
 
 
@@ -22,11 +22,11 @@ n = 7
 ny = 20
 nx = 100
 
-dat.data = np.ones((n, ny, nx))
-dat.err = np.ones((n, ny, nx))
-dat.dq = np.ones((n, ny, nx))
-dat.wave = np.ones((n, ny, nx))
-dat.v0 = np.ones((n, ny, nx))
+data.data = np.ones((n, ny, nx))
+data.err = np.ones((n, ny, nx))
+data.dq = np.ones((n, ny, nx))
+data.wave = np.ones((n, ny, nx))
+data.v0 = np.ones((n, ny, nx))
 
 
 def test_b2f():
@@ -36,10 +36,10 @@ def test_b2f():
     trim_y0 = 2
     trim_y1 = 14
 
-    md.ywindow = [trim_y0,trim_y1]
-    md.xwindow = [trim_x0,trim_x1]
+    meta.ywindow = [trim_y0,trim_y1]
+    meta.xwindow = [trim_x0,trim_x1]
 
-    res_dat, res_md = util.trim(dat, md)
+    res_dat, res_md = util.trim(data, meta)
 
     #Let's check if the dimensions agree
     assert res_dat.subdata.shape == (n, (trim_y1 - trim_y0), (trim_x1 - trim_x0))

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ svo_filters
 nbsphinx
 recommonmark
 myst_parser
-asdf
+astroquery==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ nbsphinx
 recommonmark
 myst_parser
 astroquery==0.4.2
+asdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ svo_filters
 nbsphinx
 recommonmark
 myst_parser
-astroquery==0.4.2
+astroquery>=0.4.2
 asdf


### PR DESCRIPTION
Changes:
- Data & dat and Metadata & md are now: DataClass & data and MetaClass & meta
   - Note that the raw 2D spectrum is now stored in data.data
- fix in s3_reduce.py: median frame is now being saved in data instead of meta
- when the code is run now, a copy of the ecf file is saved into the workdir (if running S3) or lcdir (if running S4) [I think that's a good idea if the user wants to check which settings he used when running Eureka!]
- added astroquery as a requirement (svo_filters needs it)
- added a note in eureka/S5_lightcurve_fitting/utils.py that the EXOCTK_DATA is only important for Stage 5 [might scare people who only want to run S3 or S4]
- docs: more thorough quickstart 
- run_script.py: commented out all sys.path.append

 
