### PR TITLE
Update limb_darkening_fit.py to correct matplotlib/TeX errors

### DIFF
--- a/eureka/S2_calibrations/__init__.py
+++ b/eureka/S2_calibrations/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import s2_calibrate

--- a/eureka/S5_lightcurve_fitting/limb_darkening_fit.py
+++ b/eureka/S5_lightcurve_fitting/limb_darkening_fit.py
@@ -22,9 +22,6 @@ from bokeh.models.widgets import Panel, Tabs
 from . import utils
 from . import modelgrid
 
-rc('font', **{'family': 'sans-serif', 'sans-serif': ['Helvetica'], 'size': 16})
-rc('text', usetex=True)
-
 warnings.simplefilter('ignore', category=AstropyWarning)
 warnings.simplefilter('ignore', category=FutureWarning)
 

--- a/eureka/lib/plots.py
+++ b/eureka/lib/plots.py
@@ -2,15 +2,35 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import rc, rcdefaults
 
-#PLOT SETTINGS
-def use_tex_fonts(toggle, family='sans-serif', font='Helvetica', fontsize=16):
-    if toggle == True:
-        rc('font', **{'family': family, family: [font], 'size': fontsize})
-        rc('text', usetex=True)
-    elif toggle == False:
+# Function to adjust matplotlib rcParams for plotting procedures.
+def set_rc(style='preserve', usetex=False, from_scratch=False, **kwargs):
+    if not (isinstance(usetex, bool) and isinstance(from_scratch, bool)):
+        raise ValueError('"usetex" and "from_scratch" arguments must be boolean.')
+
+    if from_scratch:
+        # Reset all rcParams prior to making changes. 
         rcdefaults()
-    else: 
-        raise ValueError('TeX font toggle must be a boolean.')
+
+    # Apply the desired style...
+    if style == 'custom':
+        # Custom user font, kwargs must be from the 'font' rcParams group at the moment. 
+        # https://matplotlib.org/stable/api/matplotlib_configuration_api.html#matplotlib.rcParams
+        rc('font', **kwargs)
+    elif style == 'eureka':
+        # Apply default Eureka! font settings.
+        family='sans-serif'
+        font='Helvetica'
+        fontsize=16
+        rc('font', **{'family': family, family: [font], 'size': fontsize})
+    elif style == 'default':
+        # Use default matplotlib settings
+        rcdefaults()
+    elif style == 'preserve':
+        pass
+    else:
+        raise ValueError('Input style must be one of: "custom", "eureka", "preserve", or "default".')
+
+    rc('text', usetex=usetex) # TeX fonts may not work on all machines. 
 
 #SET PLOTTING FORMAT
 ebfmt   = ['bo',  'go',  'ro',  'co',  'mo',  'yo',

--- a/eureka/lib/plots.py
+++ b/eureka/lib/plots.py
@@ -1,6 +1,10 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
+#PLOT SETTINGS
+def use_tex_fonts(family='sans-serif', font='Helvetica', fontsize=16):
+    rc('font', **{'family': family, family: [font], 'size': fontsize})
+    rc('text', usetex=True)
 
 #SET PLOTTING FORMAT
 ebfmt   = ['bo',  'go',  'ro',  'co',  'mo',  'yo',

--- a/eureka/lib/plots.py
+++ b/eureka/lib/plots.py
@@ -1,10 +1,16 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib import rc, rcdefaults
 
 #PLOT SETTINGS
-def use_tex_fonts(family='sans-serif', font='Helvetica', fontsize=16):
-    rc('font', **{'family': family, family: [font], 'size': fontsize})
-    rc('text', usetex=True)
+def use_tex_fonts(toggle, family='sans-serif', font='Helvetica', fontsize=16):
+    if toggle == True:
+        rc('font', **{'family': family, family: [font], 'size': fontsize})
+        rc('text', usetex=True)
+    elif toggle == False:
+        rcdefaults()
+    else: 
+        raise ValueError('TeX font toggle must be a boolean.')
 
 #SET PLOTTING FORMAT
 ebfmt   = ['bo',  'go',  'ro',  'co',  'mo',  'yo',


### PR DESCRIPTION
I created this branch to directly address issue #42 where matplotlib/TeX causes crashes at a variety of different stages in the pipeline depending on the user. 

After some testing, I'm almost certain that the following lines on one of the Stage 5 files has been editing the underlying matplotlib rcParams whenever Eureka is imported, and is directly causing these issues. I've attached some images below of what a plot looks like with and without these lines. Personally, I actually prefer the default matplotlib font, although we might need to make some changes to the font sizes directly in our plotting routines. 

```
rc('font', **{'family': 'sans-serif', 'sans-serif': ['Helvetica'], 'size': 16})
rc('text', usetex=True)
```

@taylorbell57 Could you install this branch and remove the additional lines you added to the jwst package file to see if the previous error disappears for you? The same issue cropped up again for me this morning (spurring me to try and fix things once and for all) and removing these two lines fixed things. 

@kevin218 @lkreidberg Changing the overall plotting style for Eureka seems pretty significant, but I think it's worth it for broader usability. Given you're leading things I'll let you decide whether to merge this or not!

![ERS_DATASIMv2_NIRSpec_PRISM_TINY_x1dints](https://user-images.githubusercontent.com/23636747/138347120-1a9b1a31-94a9-4fe3-af44-4c05e6fb2673.png)
![ERS_DATASIMv2_NIRSpec_PRISM_TINY_x1dints](https://user-images.githubusercontent.com/23636747/138347197-376a9563-1746-403b-abfd-c374fce68911.png)