### PR TITLE
Fixing S4 uncertainty calculation

### DIFF
--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -166,11 +166,13 @@ def lcJWST(eventlabel, s3_meta=None):
 
             # Reverse the reshaping which has been done when saving the astropy table
             optspec = np.reshape(table['optspec'].data, (-1, meta.subnx))
+            opterr = np.reshape(table['opterr'].data, (-1, meta.subnx))
             wave_1d = table['wave_1d'].data[0:meta.subnx]
             bjdtdb = table['bjdtdb'].data[::meta.subnx]
 
             #Replace NaNs with zero
             optspec[np.where(np.isnan(optspec))] = 0
+            opterr[np.where(np.isnan(opterr))] = 0
             meta.n_int, meta.subnx   = optspec.shape
 
             # Determine wavelength bins
@@ -187,7 +189,9 @@ def lcJWST(eventlabel, s3_meta=None):
                 # Correct for drift/jitter
                 for n in range(meta.n_int):
                     spline     = spi.UnivariateSpline(np.arange(meta.subnx), optspec[n], k=3, s=0)
+                    spline2    = spi.UnivariateSpline(np.arange(meta.subnx), opterr[n],  k=3, s=0)
                     optspec[n] = spline(np.arange(meta.subnx)+meta.drift1d[n])
+                    opterr[n]  = spline2(np.arange(meta.subnx)+meta.drift1d[n])
                 # Plot Drift
                 if meta.isplots_S4 >= 1:
                     plots_s4.drift1d(meta)
@@ -204,7 +208,7 @@ def lcJWST(eventlabel, s3_meta=None):
                 # Sum flux for each spectroscopic channel
                 meta.lcdata[i]    = np.sum(optspec[:,index],axis=1)
                 # Add uncertainties in quadrature
-                meta.lcerr[i]     = np.sqrt(np.sum(optspec[:,index],axis=1))
+                meta.lcerr[i]     = np.sqrt(np.sum(opterr[:,index]**2,axis=1))
 
                 # Plot each spectroscopic light curve
                 if meta.isplots_S4 >= 3:


### PR DESCRIPTION
The uncertainties on each data point from Stage 4 appear to be far too large because the errorbars are vastly larger than the point-to-point scatter. The uncertainties are currently calculated [here](https://github.com/kevin218/Eureka/blob/01061a3dd3e6169fbabd32f301403e2a576f0fe5/eureka/S4_generate_lightcurves/s4_genLC.py#L207) with the code written as follows:

`# Compute valid indeces within wavelength range`
`index   = np.where((wave_1d >= meta.wave_low[i])*(wave_1d <= meta.wave_hi[i]))[0]`
`# Sum flux for each spectroscopic channel`
`meta.lcdata[i]    = np.sum(optspec[:,index],axis=1)`
`# Add uncertainties in quadrature`
`meta.lcerr[i]     = np.sqrt(np.sum(optspec[:,index]**2,axis=1))`

That last line doesn't make sense to me - if we're assuming Poisson dominated noise, then the uncertainty would be `np.sqrt(optspec[:,index])`, so if we're adding uncertainties in quadrature I suspect this line should instead be:

`# Add uncertainties in quadrature`
`meta.lcerr[i]     = np.sqrt(np.sum(optspec[:,index],axis=1))`

This gives uncertainties that are quite close to the standard deviation of the data points (I'm using only the last NIRCam segment, so there should be no astrophysical signal) and also fairly close to the MAD