### PR TITLE
Adding photometry to S2

### DIFF
--- a/demos/S2/S2_imaging_template.ecf
+++ b/demos/S2/S2_imaging_template.ecf
@@ -1,0 +1,20 @@
+# Eureka! Control File for Stage 2: Data Reduction
+
+suffix      rateints     # Data file suffix
+
+# Note: different instruments and modes will use different steps by default
+skip_bkg_subtract		True	# Not run for TSO observations
+skip_flat_field			False
+skip_photom				True
+skip_resample			True	# Not run for TSO observations
+
+# Diagnostics
+testing_S2	False
+hide_plots	False	# If True, plots will automatically be closed rather than popping up
+
+# Project directory
+topdir      /home/User/
+
+# Directories relative to project dir
+inputdir    /Data/JWST-Sim/NIRCam/Stage1
+outputdir	/Data/JWST-Sim/NIRCam/Stage2

--- a/demos/S2/S2_miri_lrs_template.ecf
+++ b/demos/S2/S2_miri_lrs_template.ecf
@@ -24,7 +24,7 @@ skip_fringe				True	# Not run for MIRI LRS Slitless
 skip_pathloss			True	# Not run for MIRI LRS Slitless
 skip_barshadow			True	# Not run for MIRI LRS Slitless
 skip_photom				False
-skip_resample_spec		True	# Not run for MIRI LRS Slitless
+skip_resample			True	# Not run for MIRI LRS Slitless
 skip_cube_build			True	# Not run for MIRI LRS Slitless
 skip_extract_1d			False
 

--- a/demos/S2/S2_nircam_wfss_template.ecf
+++ b/demos/S2/S2_nircam_wfss_template.ecf
@@ -24,7 +24,7 @@ skip_fringe				True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
 skip_pathloss			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
 skip_barshadow			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
 skip_photom				False
-skip_resample_spec		True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_resample			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
 skip_cube_build			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
 skip_extract_1d			False
 

--- a/demos/S2/S2_nirspec_fs_template.ecf
+++ b/demos/S2/S2_nirspec_fs_template.ecf
@@ -24,7 +24,7 @@ skip_fringe				True	# Not run for NIRSpec Fixed Slit
 skip_pathloss			False	# Not run for TSO observations
 skip_barshadow			True	# Not run for NIRSpec Fixed Slit
 skip_photom				False
-skip_resample_spec		False	# Not run for TSO observations
+skip_resample			False	# Not run for TSO observations
 skip_cube_build			True	# Not run for NIRSpec Fixed Slit
 skip_extract_1d			False
 

--- a/demos/S2/run_eureka.py
+++ b/demos/S2/run_eureka.py
@@ -4,7 +4,7 @@ import eureka.S2_calibrations.s2_calibrate as s2
 import eureka.S3_data_reduction.s3_reduce as s3
 import eureka.S4_generate_lightcurves.s4_genLC as s4
 
-# eventlabel = 'imaging'
+# eventlabel = 'imaging_template'
 # eventlabel = 'miri_lrs_template'
 # eventlabel = 'nirspec_fs_template'
 eventlabel = 'nircam_wfss_template'

--- a/demos/S2/run_eureka.py
+++ b/demos/S2/run_eureka.py
@@ -1,15 +1,15 @@
 import sys
 sys.path.append('../../')
-from eureka.S2_calibrations.s2_calibrate import EurekaS2Pipeline
+import eureka.S2_calibrations.s2_calibrate as s2
 import eureka.S3_data_reduction.s3_reduce as s3
 import eureka.S4_generate_lightcurves.s4_genLC as s4
 
+# eventlabel = 'imaging'
 # eventlabel = 'miri_lrs_template'
 # eventlabel = 'nirspec_fs_template'
 eventlabel = 'nircam_wfss_template'
 
-s2 = EurekaS2Pipeline()
-s2_meta = s2.run_eurekaS2(eventlabel)
+s2_meta = s2.calibrateJWST(eventlabel)
 
 s3_meta = s3.reduceJWST(eventlabel, s2_meta=s2_meta)
 

--- a/eureka/S2_calibrations/s2_calibrate.py
+++ b/eureka/S2_calibrations/s2_calibrate.py
@@ -18,6 +18,7 @@ import matplotlib.pyplot as plt
 from astropy.io import fits
 from jwst import datamodels
 from jwst.pipeline.calwebb_spec2 import Spec2Pipeline
+from jwst.pipeline.calwebb_image2 import Image2Pipeline
 from ..lib import logedit, util
 from ..lib import manageevent as me
 from ..lib import readECF as rd
@@ -30,8 +31,105 @@ class MetaClass:
     def __init__(self):
         return
 
+def calibrateJWST(eventlabel):
+    '''Reduces rateints spectrum or image files ouput from Stage 1 of the JWST pipeline into calints and x1dints.
 
-class EurekaS2Pipeline(Spec2Pipeline):
+    This function does the preparation for running the STScI's JWST pipeline and decides whether to run the
+    Spec2Pipeline or Image2Pipeline.
+
+    Parameters
+    ----------
+    eventlabel: str
+        Unique label for this dataset
+
+    Returns
+    -------
+    meta:   MetaClass
+        The metadata object
+
+    Notes
+    ------
+    History:
+
+    - 03 Nov 2021 Taylor Bell
+        Initial version
+    '''
+
+    t0 = time.time()
+
+    # Initialize metadata object
+    meta = MetaClass()
+    meta.eventlabel = eventlabel
+
+    # Load Eureka! control file and store values in Event object
+    ecffile = 'S2_' + eventlabel + '.ecf'
+    ecf     = rd.read_ecf(ecffile)
+    rd.store_ecf(meta, ecf)
+
+    # Create directories for Stage 2 processing outputs
+    meta.inputdir_raw = meta.inputdir
+    meta.outputdir_raw = meta.outputdir
+    run = util.makedirectory(meta, 'S2')
+    meta.outputdir = util.pathdirectory(meta, 'S2', run)
+
+    # Output S2 log file
+    meta.logname = meta.outputdir + 'S2_' + meta.eventlabel + ".log"
+    log = logedit.Logedit(meta.logname)
+    log.writelog("\nStarting Stage 2 Reduction")
+
+    # Copy ecf
+    log.writelog('Copying S2 control file')
+    shutil.copy(ecffile, meta.outputdir)
+
+    # Create list of file segments
+    meta = util.readfiles(meta)
+    num_data_files = len(meta.segment_list)
+    if num_data_files==0:
+        rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
+        if rootdir[-1]!='/':
+            rootdir += '/'
+            raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files in the inputdir: \n"{rootdir}"!')
+    else:
+        log.writelog(f'\nFound {num_data_files} data file(s) ending in {meta.suffix}.fits')
+
+    # If testing, only run the last file
+    if meta.testing_S2:
+        istart = num_data_files - 1
+    else:
+        istart = 0
+
+    # Figure out which pipeline we need to use (spectra or images)
+    with fits.open(meta.segment_list[0]) as hdulist:
+        # Figure out which instrument we are using
+        exp_type = hdulist[0].header['EXP_TYPE']
+    if 'image' in exp_type.lower():
+        # EXP_TYPE header is either MIR_IMAGE, NRC_IMAGE, NRC_TSIMAGE, NIS_IMAGE, or NRS_IMAGING
+        pipeline = EurekaImage2Pipeline()
+    else:
+        # EXP_TYPE doesn't say image, so it should be a spectrum (or someone is putting weird files into Eureka!)
+        pipeline = EurekaSpec2Pipeline()
+
+    # Run the pipeline on each file sequentially
+    for m in range(istart, num_data_files):
+        # Report progress
+        log.writelog(f'Starting file {m + 1} of {num_data_files}')
+        filename = meta.segment_list[m]
+
+        pipeline.run_eurekaS2(filename, meta, log)
+
+    # Calculate total run time
+    total = (time.time() - t0) / 60.
+    log.writelog('\nTotal time (min): ' + str(np.round(total, 2)))
+
+    # Save results
+    if not meta.testing_S2:
+        log.writelog('Saving Metadata')
+        me.saveevent(meta, meta.outputdir + 'S2_' + meta.eventlabel + "_Meta_Save", save=[])
+
+    return meta
+
+
+class EurekaSpec2Pipeline(Spec2Pipeline):
     '''A wrapper class for the jwst.pipeline.calwebb_spec2.Spec2Pipeline.
 
     This wrapper class can allow non-standard changes to Stage 2 steps for Eureka!.
@@ -44,18 +142,21 @@ class EurekaS2Pipeline(Spec2Pipeline):
         Initial version
     '''
 
-    def run_eurekaS2(self, eventlabel):
-        '''Reduces rateints files ouput from Stage 1 of the JWST pipeline into calints and x1dints.
+    def run_eurekaS2(self, filename, meta, log):
+        '''Reduces rateints spectrum files ouput from Stage 1 of the JWST pipeline into calints and x1dints.
 
         Parameters
         ----------
-        eventlabel  : str
-            Unique label for this dataset
+        filename:   str
+            A string pointing to the rateint or rateints file to be operated on.
+        meta:   MetaClass
+            The metadata object
+        log:    logedit.Logedit
+            The open log in which notes from this step can be added.
 
         Returns
         -------
-        meta        : MetaClass
-                The metadata object
+        None
 
         Notes
         ------
@@ -65,116 +166,65 @@ class EurekaS2Pipeline(Spec2Pipeline):
             Code fragments written
         - October 2021 Taylor Bell
             Significantly overhauled code formatting
+        - 03 Nov 2021 Taylor Bell
+            Fragmented code to allow reuse of code between spectral and image analysis.
         '''
-        t0 = time.time()
+        if meta.slit_y_low != None:
+            #Controls the cross-dispersion extraction
+            self.assign_wcs.slit_y_low = meta.slit_y_low
 
-        # Initialize metadata object
-        meta = MetaClass()
-        meta.eventlabel = eventlabel
+        if meta.slit_y_high != None:
+            #Controls the cross-dispersion extraction
+            self.assign_wcs.slit_y_high = meta.slit_y_high
 
-        # Load Eureka! control file and store values in Event object
-        ecffile = 'S2_' + eventlabel + '.ecf'
-        ecf     = rd.read_ecf(ecffile)
-        rd.store_ecf(meta, ecf)
+        if meta.waverange_start != None:
+            #Control the dispersion extraction - FIX: Does not actually change dispersion direction extraction
+            log.writelog('Editing (in place) the waverange in the input file')
+            with datamodels.open(filename) as m:
+                m.meta.wcsinfo.waverange_start = meta.waverange_start
+                m.save(filename)
 
-        # Create directories for Stage 2 processing outputs
-        meta.inputdir_raw = meta.inputdir
-        meta.outputdir_raw = meta.outputdir
-        run = util.makedirectory(meta, 'S2')
-        meta.outputdir = util.pathdirectory(meta, 'S2', run)
-
-        # Output S2 log file
-        meta.logname = meta.outputdir + 'S2_' + meta.eventlabel + ".log"
-        log = logedit.Logedit(meta.logname)
-        log.writelog("\nStarting Stage 2 Reduction")
-
-        # Copy ecf
-        log.writelog('Copying S2 control file')
-        shutil.copy(ecffile, meta.outputdir)
-
-        # Create list of file segments
-        meta = util.readfiles(meta)
-        num_data_files = len(meta.segment_list)
-        if num_data_files==0:
-            rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-            if rootdir[-1]!='/':
-                rootdir += '/'
-                raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files in the inputdir: \n"{rootdir}"!')
-        else:
-            log.writelog(f'\nFound {num_data_files} data file(s) ending in {meta.suffix}.fits')
-
-        # If testing, only run the last file
-        if meta.testing_S2:
-            istart = num_data_files - 1
-        else:
-            istart = 0
-
-        # Run the pipeline on each file sequentially
-        for m in range(istart, num_data_files):
-            # Report progress
-            log.writelog(f'Starting file {m + 1} of {num_data_files}')
-            filename = meta.segment_list[m]
-
-            with fits.open(filename) as hdulist:
-                # Figure out which instrument we are using
-                inst = hdulist[0].header['INSTRUME']
-
-            if meta.slit_y_low != None:
-                #Controls the cross-dispersion extraction
-                self.assign_wcs.slit_y_low = meta.slit_y_low
-
-            if meta.slit_y_high != None:
-                #Controls the cross-dispersion extraction
-                self.assign_wcs.slit_y_high = meta.slit_y_high
-
-            if meta.waverange_start != None:
-                #Control the dispersion extraction - FIX: Does not actually change dispersion direction extraction
+        if meta.waverange_end != None:
+            #Control the dispersion extraction - FIX: Does not actually change dispersion direction extraction
+            if meta.waverange_start == None:
+                # Only log this once
                 log.writelog('Editing (in place) the waverange in the input file')
-                with datamodels.open(filename) as m:
-                    m.meta.wcsinfo.waverange_start = meta.waverange_start
-                    m.save(filename)
+            with datamodels.open(filename) as m:
+                m.meta.wcsinfo.waverange_end = meta.waverange_end
+                m.save(filename)
+        
+        # Skip steps according to input ecf file
+        self.bkg_subtract.skip = meta.skip_bkg_subtract
+        self.imprint_subtract.skip = meta.skip_imprint_subtract
+        self.msa_flagging.skip = meta.skip_msa_flagging
+        self.extract_2d.skip = meta.skip_extract_2d
+        self.srctype.skip = meta.skip_srctype
+        self.master_background.skip = meta.skip_master_background
+        self.wavecorr.skip = meta.skip_wavecorr
+        self.flat_field.skip = meta.skip_flat_field
+        self.straylight.skip = meta.skip_straylight
+        self.fringe.skip = meta.skip_fringe
+        self.pathloss.skip = meta.skip_pathloss
+        self.barshadow.skip = meta.skip_barshadow
+        self.photom.skip = meta.skip_photom
+        self.resample_spec.skip = meta.skip_resample
+        self.cube_build.skip = meta.skip_cube_build
+        self.extract_1d.skip = meta.skip_extract_1d
+        # Save outputs if requested to the folder specified in the ecf
+        self.save_results = (not meta.testing_S2)
+        self.output_dir = meta.outputdir
+        # This needs to be reset to None to permit the pipeline to be run on multiple files
+        self.suffix = None
 
-            if meta.waverange_end != None:
-                #Control the dispersion extraction - FIX: Does not actually change dispersion direction extraction
-                if meta.waverange_start == None:
-                    # Only log this once
-                    log.writelog('Editing (in place) the waverange in the input file')
-                with datamodels.open(filename) as m:
-                    m.meta.wcsinfo.waverange_end = meta.waverange_end
-                    m.save(filename)
-            
-            # Skip steps according to input ecf file
-            self.bkg_subtract.skip = meta.skip_bkg_subtract
-            self.imprint_subtract.skip = meta.skip_imprint_subtract
-            self.msa_flagging.skip = meta.skip_msa_flagging
-            self.extract_2d.skip = meta.skip_extract_2d
-            self.srctype.skip = meta.skip_srctype
-            self.master_background.skip = meta.skip_master_background
-            self.wavecorr.skip = meta.skip_wavecorr
-            self.flat_field.skip = meta.skip_flat_field
-            self.straylight.skip = meta.skip_straylight
-            self.fringe.skip = meta.skip_fringe
-            self.pathloss.skip = meta.skip_pathloss
-            self.barshadow.skip = meta.skip_barshadow
-            self.photom.skip = meta.skip_photom
-            self.resample_spec.skip = meta.skip_resample_spec
-            self.cube_build.skip = meta.skip_cube_build
-            self.extract_1d.skip = meta.skip_extract_1d
-            # Save outputs if requested to the folder specified in the ecf
-            self.save_results = (not meta.testing_S2)
-            self.output_dir = meta.outputdir
-            # This needs to be reset to None to permit the pipeline to be run on multiple files
-            self.suffix = None
+        # Call the main Spec2Pipeline function (defined in the parent class)
+        log.writelog('Running the Spec2Pipeline\n')
+        # Must call the pipeline in this way to ensure the skip booleans are respected
+        self(filename)
 
-            # Call the main Spec2Pipeline function (defined in the parent class)
-            log.writelog('Running the Spec2Pipeline\n')
-            # Must call the pipeline in this way to ensure the skip booleans are respected
-            self(filename)
-
-            # Produce some summary plots if requested
-            if not meta.testing_S2 and not self.extract_1d.skip:
-                log.writelog('\nGenerating x1dints figure')
-                fname = '_'.join(filename.split('/')[-1].split('_')[:-1])+'_x1dints'
+        # Produce some summary plots if requested
+        if not meta.testing_S2 and not self.extract_1d.skip:
+            log.writelog('\nGenerating x1dints figure')
+            fname = '_'.join(filename.split('/')[-1].split('_')[:-1])+'_x1dints'
             with datamodels.open(meta.outputdir+fname+'.fits') as sp1d:
                 fig, ax = plt.subplots(1,1, figsize=[15,5])
                 
@@ -190,13 +240,60 @@ class EurekaS2Pipeline(Spec2Pipeline):
                 else:
                     plt.pause(2)
 
-        # Calculate total run time
-        total = (time.time() - t0) / 60.
-        log.writelog('\nTotal time (min): ' + str(np.round(total, 2)))
+        return
 
-        # Save results
-        if not meta.testing_S2:
-            log.writelog('Saving Metadata')
-            me.saveevent(meta, meta.outputdir + 'S2_' + meta.eventlabel + "_Meta_Save", save=[])
 
-        return meta
+class EurekaImage2Pipeline(Image2Pipeline):
+    '''A wrapper class for the jwst.pipeline.calwebb_image2.Image2Pipeline.
+
+    This wrapper class can allow non-standard changes to Stage 2 steps for Eureka!.
+
+    Notes
+    ------
+    History:
+
+    - October 2021 Taylor Bell
+        Initial version
+    '''
+
+    def run_eurekaS2(self, filename, meta, log):
+        '''Reduces rateints image files ouput from Stage 1 of the JWST pipeline into calints.
+
+        Parameters
+        ----------
+        filename:   str
+            A string pointing to the rateint or rateints file to be operated on.
+        meta:   MetaClass
+            The metadata object
+        log:    logedit.Logedit
+            The open log in which notes from this step can be added.
+
+        Returns
+        -------
+        None
+
+        Notes
+        ------
+        History:
+
+        - 03 Nov 2021 Taylor Bell
+            Initial version
+        '''
+
+        # Skip steps according to input ecf file
+        self.bkg_subtract.skip = meta.skip_bkg_subtract
+        self.flat_field.skip = meta.skip_flat_field
+        self.photom.skip = meta.skip_photom
+        self.resample.skip = meta.skip_resample
+        # Save outputs if requested to the folder specified in the ecf
+        self.save_results = (not meta.testing_S2)
+        self.output_dir = meta.outputdir
+        # This needs to be reset to None to permit the pipeline to be run on multiple files
+        self.suffix = None
+
+        # Call the main Image2Pipeline function (defined in the parent class)
+        log.writelog('Running the Image2Pipeline\n')
+        # Must call the pipeline in this way to ensure the skip booleans are respected
+        self(filename)
+
+        return

--- a/eureka/S2_calibrations/s2_calibrate.py
+++ b/eureka/S2_calibrations/s2_calibrate.py
@@ -88,7 +88,7 @@ def calibrateJWST(eventlabel):
         rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
         if rootdir[-1]!='/':
             rootdir += '/'
-            raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files in the inputdir: \n"{rootdir}"!')
+        raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files in the inputdir: \n"{rootdir}"!')
     else:
         log.writelog(f'\nFound {num_data_files} data file(s) ending in {meta.suffix}.fits')
 


### PR DESCRIPTION
I have reorganized the S2 code I wrote to allow for the reuse of some code between photometry and spectroscopy modes. I then added a small little wrapper around the STScI's Image2Pipeline that allows the relevant steps to be skipped if requested in the ecf. I've also added a new ecf template for imaging mode observations and slightly tweaked the other templates. I have tested the pipeline step on my simulated MIRI full-frame image as well as my SUB64 simulation, and both worked fine.

This PR resolves Issue #70 (which I closed prematurely having forgotten to make this PR).