### PR TITLE
Updating to jwst 1.3.3

### DIFF
--- a/eureka/S2_calibrations/s2_calibrate.py
+++ b/eureka/S2_calibrations/s2_calibrate.py
@@ -116,9 +116,10 @@ def calibrateJWST(eventlabel):
         filename = meta.segment_list[m]
 
         with fits.open(filename, mode='update') as hdulist:
-            # jwst 1.3.3 breaks unless NDITHPTS and NRIMDTPT are integers rather than the strings that they are in the old simulated NIRCam data
-            hdulist[0].header['NDITHPTS'] = 1
-            hdulist[0].header['NRIMDTPT'] = 1
+            if hdulist[0].header['INSTRUME']=='NIRCam':
+                # jwst 1.3.3 breaks unless NDITHPTS and NRIMDTPT are integers rather than the strings that they are in the old simulated NIRCam data
+                hdulist[0].header['NDITHPTS'] = 1
+                hdulist[0].header['NRIMDTPT'] = 1
 
         pipeline.run_eurekaS2(filename, meta, log)
 

--- a/eureka/S2_calibrations/s2_calibrate.py
+++ b/eureka/S2_calibrations/s2_calibrate.py
@@ -115,6 +115,11 @@ def calibrateJWST(eventlabel):
         log.writelog(f'Starting file {m + 1} of {meta.num_data_files}')
         filename = meta.segment_list[m]
 
+        with fits.open(filename, mode='update') as hdulist:
+            # jwst 1.3.3 breaks unless NDITHPTS and NRIMDTPT are integers rather than the strings that they are in the old simulated NIRCam data
+            hdulist[0].header['NDITHPTS'] = 1
+            hdulist[0].header['NRIMDTPT'] = 1
+
         pipeline.run_eurekaS2(filename, meta, log)
 
     # Calculate total run time

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,10 @@ myst_parser
 astroquery>=0.4.2
 asdf
 gwcs
-jwst==1.1.0
+jwst==1.3.3
 tqdm
 dynesty
-photutils<=1.0.2
+photutils>=1.1.0,<1.2
 ccdproc
 emcee
 corner


### PR DESCRIPTION
Alright, I've tested NIRCam, NIRSpec, and MIRI with `jwst` v1.3.3 using these only very minor tweaks. I tested MIRI simulations from the previous ERS challenge as well as some simulations I made with the newest version of MIRISIM that will be used for the upcoming ERS showcase, and both worked well. The constraint on `photutils` comes directly from the requirements of the `jwst` v1.3.3 requirements