### PR TITLE
Fixing typo in Models.py

### DIFF
--- a/eureka/S5_lightcurve_fitting/models/Model.py
+++ b/eureka/S5_lightcurve_fitting/models/Model.py
@@ -108,7 +108,7 @@ class Model:
             params = Parameters(params)
 
         # Or a Parameters instance
-        if (params is not None) and (type(params).__name__ != Parameters.__name):
+        if (params is not None) and (type(params).__name__ != Parameters.__name__):
             raise TypeError("'params' argument must be a JSON file, ascii\
                              file, or parameters.Parameters instance.")
 

--- a/eureka/S5_lightcurve_fitting/models/Model.py
+++ b/eureka/S5_lightcurve_fitting/models/Model.py
@@ -108,7 +108,7 @@ class Model:
             params = Parameters(params)
 
         # Or a Parameters instance
-        if (params is not None) and (type(params).__name__ != type(Parameters).__name):
+        if (params is not None) and (type(params).__name__ != Parameters.__name):
             raise TypeError("'params' argument must be a JSON file, ascii\
                              file, or parameters.Parameters instance.")
 


### PR DESCRIPTION
Accidentally wrote `type(Parameters).__name` rather than `Parameters.__name__`