### PR TITLE
Changing installation instructions to pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,11 @@ GitHub following the method described below.
 		git clone https://github.com/kevin218/Eureka.git
 		```
 
-2. Navigate into the newly created directory and **install** Eureka! by running ``setup.py``:
+2. Navigate into the newly created directory and **install** Eureka! by running the following:
 
 	```bash
-	python setup.py install
+	pip install .
 	```
-
-3. Install additional **requirements** for the package by typing:
-
-	```bash
-	pip install -r requirements.txt
-	```
-
 
 ## Documentation
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -7,6 +7,21 @@ In this section you will find frequently asked questions about Eureka! as well a
 **Common Errors**
 -----------------
 
+Missing packages during installation
+''''''''''''''''''''''''''''''''''''
+
+If you are encountering errors when installing Eureka! like missing packages (e.g. extension_helpers), be sure
+that you are following the instructions on the on the :ref:`installation` page. If you are trying to directly
+call setup.py using the ``python setup.py install`` command, you should instead be using ``pip install .`` which
+helps to make sure that all required dependencies are installed in the right order and checks for implicit
+dependencies. If you still encounter issues, you should be sure that you are using a new conda environment as
+other packages you've previously installed could have conflicting requirements with Eureka!.
+
+If you are following the installation instructions and still encounter an error, please open a new Issue on
+`GitHub <https://github.com/kevin218/Eureka/issues>`_ and paste the full error message you are getting along
+with details about which python version and operating system you are using.
+
+
 Matplotlib RuntimeError() whenever Eureka is imported and plt.show() is called
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,6 +2,9 @@
 Installation
 =============================
 
+It is recommended that you install Eureka! in a new conda environment as other packages you've previously
+installed could have conflicting requirements with Eureka!.
+
 With pip
 ---------
 
@@ -37,23 +40,13 @@ With Git/GitHub
 
 			git clone https://github.com/kevin218/Eureka.git
 
-2. Navigate into the newly created directory and **install** Eureka! by running ``setup.py``:
+2. Navigate into the newly created directory and **install** Eureka! by running the following:
 
 	.. code-block:: bash
 
-		python setup.py install
-
-3. Install additional **requirements** for the package by typing:
-
-	.. code-block:: bash
-
-		pip install -r requirements.txt
-
+		pip install .
 
 For the JWST ERS Pre-Launch Data Hackathon
 -----------------------------------------------
 
 Check out the install instructions on the `ERS GitHub <https://github.com/ers-transit/hackathon-2021-day2>`_ if you want to use Eureka! during the hackathon.
-
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-#asdf==2.8.1
 astropy
-#astroquery>=0.4.2
 batman-package
 bokeh
 ccdproc
@@ -17,14 +15,10 @@ myst_parser
 nbsphinx
 numpy>=1.20.0
 pandas
-#photutils>=1.1.0,<1.2
 pytest
-#pyyaml
 recommonmark
 requests
 scipy
-#stdatamodels==0.2.3
-#stpipe==0.2.0
 svo_filters
 tqdm
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-asdf==2.8.1
+#asdf==2.8.1
 astropy
-astroquery>=0.4.2
+#astroquery>=0.4.2
 batman-package
 bokeh
 ccdproc
@@ -17,14 +17,14 @@ myst_parser
 nbsphinx
 numpy>=1.20.0
 pandas
-photutils>=1.1.0,<1.2
+#photutils>=1.1.0,<1.2
 pytest
-pyyaml
+#pyyaml
 recommonmark
 requests
 scipy
-stdatamodels==0.2.3
-stpipe==0.2.0
+#stdatamodels==0.2.3
+#stpipe==0.2.0
 svo_filters
 tqdm
 

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@ from setuptools import setup, find_packages
 with open('requirements.txt') as f:
     REQUIRES = f.read().splitlines()
 
-#DEPENDENCY_LINKS = ['git+https://github.com/spacetelescope/jwst_gtvt.git@cd6bc76f66f478eafbcc71834d3e735c73e03ed5']
-
 FILES = []
 for root, _, files in os.walk("Eureka"):
     FILES += [os.path.join(root.replace("Eureka/", ""), fname) \
@@ -18,7 +16,6 @@ setup(name='Eureka',
       packages=find_packages(".", exclude=["*.tests"]),
       package_data={'Eureka': FILES},
       install_requires=REQUIRES,
-#      dependency_links=DEPENDENCY_LINKS,
       author='Section 5',
       author_email='kbstevenson@gmail.com',
       license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 with open('requirements.txt') as f:
     REQUIRES = f.read().splitlines()
 
-DEPENDENCY_LINKS = ['git+https://github.com/spacetelescope/jwst_gtvt.git@cd6bc76f66f478eafbcc71834d3e735c73e03ed5']
+#DEPENDENCY_LINKS = ['git+https://github.com/spacetelescope/jwst_gtvt.git@cd6bc76f66f478eafbcc71834d3e735c73e03ed5']
 
 FILES = []
 for root, _, files in os.walk("Eureka"):
@@ -18,7 +18,7 @@ setup(name='Eureka',
       packages=find_packages(".", exclude=["*.tests"]),
       package_data={'Eureka': FILES},
       install_requires=REQUIRES,
-      dependency_links=DEPENDENCY_LINKS,
+#      dependency_links=DEPENDENCY_LINKS,
       author='Section 5',
       author_email='kbstevenson@gmail.com',
       license='MIT',


### PR DESCRIPTION
Now telling people to do pip install rather than calling setup.py
directly which is becoming deprecated and requires extra maintenance
efforts. Also added some help details in the faq page to make sure
people are reading the installation page