### PR TITLE
Ignore outputs from pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+eureka/tests/data
 
 # Translations
 *.mo


### PR DESCRIPTION
Blocking additions to eureka/tests/data by default

Currently people can accidentally upload the outputs from pytest to
GitHub which we don't want. I suggest we add eureka/tests/data to
.gitignore (which I am now doing) and then one must use the -f flag to
force new adds to the tests/data folder