### PR TITLE
Resolving Issue #123

### DIFF
--- a/demos/JWST/S1_miri_template.ecf
+++ b/demos/JWST/S1_miri_template.ecf
@@ -3,8 +3,8 @@
 suffix 						uncal
 
 # Control ramp fitting method
-ramp_fit_algorithm				default 	#Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores 				none  		#Options are 'none', quarter', 'half','all'
+ramp_fit_algorithm				'default' 	#Options are 'default', 'mean', or 'differenced'
+ramp_fit_max_cores 				'none'  		#Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
 skip_group_scale			False

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -3,8 +3,8 @@
 suffix 							uncal
 
 # Control ramp fitting method
-ramp_fit_algorithm				default 	#Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores 				none  		#Options are 'none', quarter', 'half','all'
+ramp_fit_algorithm				'default' 	#Options are 'default', 'mean', or 'differenced'
+ramp_fit_max_cores 				'none'  		#Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
 skip_group_scale				False

--- a/docs/media/S1_template.ecf
+++ b/docs/media/S1_template.ecf
@@ -3,8 +3,8 @@
 suffix 							uncal
 
 # Control ramp fitting method
-ramp_fit_algorithm				default 	#Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores 				none  		#Options are 'none', quarter', 'half','all'
+ramp_fit_algorithm				'default' 	#Options are 'default', 'mean', or 'differenced'
+ramp_fit_max_cores 				'none'  		#Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
 skip_group_scale				False


### PR DESCRIPTION
Without quotation marks, all gets interpreted as the built-in function all. Edited ecf templates to encourage people to use quotation marks. Closes Issue #123 