### PR TITLE
Resolving shape mismatch for shared fits

### DIFF
--- a/eureka/S5_lightcurve_fitting/models/Model.py
+++ b/eureka/S5_lightcurve_fitting/models/Model.py
@@ -28,6 +28,10 @@ class Model:
         self._parameters = Parameters()
         self.components = None
         self.fmt = None
+        if hasattr(kwargs, 'nchan'):
+            self.nchan = kwargs.get('nchan')
+        else:
+            self.nchan = 1
 
         # Store the arguments as attributes
         for arg, val in kwargs.items():
@@ -253,7 +257,7 @@ class CompositeModel(Model):
             self.time = kwargs.get('time')
         
         # Evaluate flux at each model
-        flux = np.ones_like(self.time)
+        flux = np.ones(len(self.time)*self.nchan)
         for model in self.components:
             if model.time is None:
                 model.time = self.time
@@ -268,7 +272,7 @@ class CompositeModel(Model):
             self.time = kwargs.get('time')
         
         # Evaluate flux at each model
-        flux = np.ones_like(self.time)
+        flux = np.ones(len(self.time)*self.nchan)
         for model in self.components:
             if model.modeltype == 'systematic':
                 if model.time is None:
@@ -291,7 +295,7 @@ class CompositeModel(Model):
             new_time = self.time
 
         # Evaluate flux at each model
-        flux = np.ones_like(self.time)
+        flux = np.ones(len(self.time)*self.nchan)
         for model in self.components:
             if model.modeltype == 'physical':
                 if model.time is None:

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -206,7 +206,7 @@ def fit_channel(meta,time,flux,chan,flux_err,eventlabel,sharedp,params,log,longp
     if 'expramp' in meta.run_myfuncs:
         t_ramp = m.ExpRampModel(parameters=params, name='ramp', fmt='r--', longparamlist=lc_model.longparamlist, nchan=lc_model.nchannel_fitted, paramtitles=paramtitles)
         modellist.append(t_ramp)
-    model = m.CompositeModel(modellist)
+    model = m.CompositeModel(modellist, nchan=lc_model.nchannel_fitted)
     
     # Fit the models using one or more fitters
     log.writelog("=========================")


### PR DESCRIPTION
CompositeModel was making an array of ones that had the wrong dimensions for shared fits in the eval-type functions. This bug arose when I made edits in PR #130 and didn't test with a shared fit. This explains the error I encountered in PR #131, although that PR will still have separate issues with shared fits