### PR TITLE
Fixing error message for S3 when no files found

### DIFF
--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -206,10 +206,7 @@ def reduceJWST(eventlabel, s2_meta=None):
             meta = util.readfiles(meta)
             meta.num_data_files = len(meta.segment_list)
             if meta.num_data_files==0:
-                rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-                if rootdir[-1]!='/':
-                    rootdir += '/'
-                raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files in the inputdir: \n"{rootdir}"!')
+                raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files in the inputdir: \n"{meta.inputdir}"!')
             else:
                 log.writelog(f'\nFound {meta.num_data_files} data file(s) ending in {meta.suffix}.fits')
 

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -153,7 +153,7 @@ def plot_spectra(eventlabel, s5_meta=None):
                 ylabel = r'$(R_{\rm p}/R_{\rm *})^2$'
             elif meta.y_unit in ['Rp/Rs', 'Rp/R*']:
                 ylabel = r'$R_{\rm p}/R_{\rm *}$'
-            elif meta.y_unit in ['Fp/Rs', 'Fp/R*']:
+            elif meta.y_unit in ['Fp/Fs', 'Fp/F*']:
                 ylabel = r'$F_{\rm p}/F_{\rm *}$'
             else:
                 raise AssertionError(f'Unknown y_unit {meta.y_unit} is none of ['+', '.join(accepted_y_units)+']')


### PR DESCRIPTION
The error message in S3 when no S2 files were found is out-of-date, and this tiny PR fixes that issue