### PR TITLE
New 2D light curve with drift/jitter correction

### DIFF
--- a/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/eureka/S4_generate_lightcurves/plots_s4.py
@@ -91,23 +91,17 @@ def lc_driftcorr(meta, wave_1d, optspec):
     wmin = wave_1d.min()
     wmax = wave_1d.max()
     n_int, nx = optspec.shape
-    # iwmin       = np.where(ev.wave[src_ypos]>wmin)[0][0]
-    # iwmax       = np.where(ev.wave[src_ypos]>wmax)[0][0]
     vmin = 0.97
     vmax = 1.03
-    # normspec    = np.mean(ev.optspec,axis=1)/np.mean(ev.optspec[ev.inormspec[0]:ev.inormspec[1]],axis=(0,1))
     normspec = optspec / np.mean(optspec, axis=0)
     plt.imshow(normspec, origin='lower', aspect='auto', extent=[wmin, wmax, 0, n_int], vmin=vmin, vmax=vmax,
                cmap=plt.cm.RdYlBu_r)
     ediff = np.zeros(n_int)
     for m in range(n_int):
         ediff[m] = 1e6 * np.median(np.abs(np.ediff1d(normspec[m])))
-        # plt.scatter(ev.wave[src_ypos], np.zeros(nx)+m, c=normspec[m],
-        #             s=14,linewidths=0,vmin=vmin,vmax=vmax,marker='s',cmap=plt.cm.RdYlBu_r)
     plt.title("MAD = " + str(np.round(np.mean(ediff), 0).astype(int)) + " ppm")
-    # plt.xlim(wmin,wmax)
-    # plt.ylim(0,n_int)
     if meta.nspecchan > 1:
+        # Insert vertical dashed lines at spectroscopic channel edges
         xticks = np.unique(np.concatenate([meta.wave_low,meta.wave_hi]))
         plt.xticks(xticks,xticks)
         plt.vlines(xticks,0,n_int,'0.3','dashed')

--- a/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/eureka/S4_generate_lightcurves/plots_s4.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 
 def binned_lightcurve(meta, time, i):
     '''Plot each spectroscopic light curve.
-    
+
     Parameters
     ----------
     meta:   MetaClass
@@ -13,7 +13,7 @@ def binned_lightcurve(meta, time, i):
         The time in meta.time_units of each data point.
     i:  int
         The current bandpass number.
-    
+
     Returns
     -------
     None
@@ -41,12 +41,12 @@ def binned_lightcurve(meta, time, i):
 
 def drift1d(meta):
     '''Plot the 1D drift/jitter results.
-    
+
     Parameters
     ----------
     meta:   MetaClass
         The metadata object.
-    
+
     Returns
     -------
     None
@@ -70,9 +70,60 @@ def drift1d(meta):
     else:
         plt.pause(0.2)
 
+def lc_driftcorr(meta, wave_1d, optspec):
+    '''Plot a 2D light curve with drift correction.
+
+    Parameters
+    ----------
+    meta:   MetaClass
+        The metadata object.
+    wave_1d:
+        Wavelength array with trimmed edges depending on xwindow and ywindow which have been set in the S3 ecf
+    optspec:
+        The optimally extracted spectrum.
+
+    Returns
+    -------
+    None
+    '''
+    plt.figure(4102, figsize=(8, 8))  # ev.n_files/20.+0.8))
+    plt.clf()
+    wmin = wave_1d.min()
+    wmax = wave_1d.max()
+    n_int, nx = optspec.shape
+    # iwmin       = np.where(ev.wave[src_ypos]>wmin)[0][0]
+    # iwmax       = np.where(ev.wave[src_ypos]>wmax)[0][0]
+    vmin = 0.97
+    vmax = 1.03
+    # normspec    = np.mean(ev.optspec,axis=1)/np.mean(ev.optspec[ev.inormspec[0]:ev.inormspec[1]],axis=(0,1))
+    normspec = optspec / np.mean(optspec, axis=0)
+    plt.imshow(normspec, origin='lower', aspect='auto', extent=[wmin, wmax, 0, n_int], vmin=vmin, vmax=vmax,
+               cmap=plt.cm.RdYlBu_r)
+    ediff = np.zeros(n_int)
+    for m in range(n_int):
+        ediff[m] = 1e6 * np.median(np.abs(np.ediff1d(normspec[m])))
+        # plt.scatter(ev.wave[src_ypos], np.zeros(nx)+m, c=normspec[m],
+        #             s=14,linewidths=0,vmin=vmin,vmax=vmax,marker='s',cmap=plt.cm.RdYlBu_r)
+    plt.title("MAD = " + str(np.round(np.mean(ediff), 0).astype(int)) + " ppm")
+    # plt.xlim(wmin,wmax)
+    # plt.ylim(0,n_int)
+    if meta.nspecchan > 1:
+        xticks = np.unique(np.concatenate([meta.wave_low,meta.wave_hi]))
+        plt.xticks(xticks,xticks)
+        plt.vlines(xticks,0,n_int,'0.3','dashed')
+    plt.ylabel('Integration Number')
+    plt.xlabel(r'Wavelength ($\mu m$)')
+    plt.colorbar(label='Normalized Flux')
+    plt.tight_layout()
+    plt.savefig(meta.outputdir + 'figs/fig4102-2D_LC.png')
+    if meta.hide_plots:
+        plt.close()
+    else:
+        plt.pause(0.2)
+
 def cc_spec(meta, ref_spec, fit_spec, n):
     '''Compare the spectrum used for cross-correlation with the current spectrum.
-    
+
     Parameters
     ----------
     meta:   MetaClass
@@ -104,7 +155,7 @@ def cc_spec(meta, ref_spec, fit_spec, n):
 
 def cc_vals(meta, vals, n):
     '''Make the cross-correlation strength plot.
-    
+
     Parameters
     ----------
     meta:   MetaClass

--- a/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/eureka/S4_generate_lightcurves/plots_s4.py
@@ -103,7 +103,7 @@ def lc_driftcorr(meta, wave_1d, optspec):
     if meta.nspecchan > 1:
         # Insert vertical dashed lines at spectroscopic channel edges
         xticks = np.unique(np.concatenate([meta.wave_low,meta.wave_hi]))
-        plt.xticks(xticks,xticks)
+        plt.xticks(xticks, xticks, rotation=90)
         plt.vlines(xticks,0,n_int,'0.3','dashed')
     plt.ylabel('Integration Number')
     plt.xlabel(r'Wavelength ($\mu m$)')

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -166,7 +166,6 @@ def lcJWST(eventlabel, s3_meta=None):
                 for n in range(meta.n_int):
                     # Need to zero-out the weights of masked data
                     weights = (~np.ma.getmaskarray(optspec[n])).astype(int)
-                    #weights    = np.ones(meta.subnx)
                     spline     = spi.UnivariateSpline(np.arange(meta.subnx), optspec[n], k=3, s=0, w=weights)
                     spline2    = spi.UnivariateSpline(np.arange(meta.subnx), opterr[n],  k=3, s=0, w=weights)
                     optspec[n] = spline(np.arange(meta.subnx)+meta.drift1d[n])

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -165,8 +165,8 @@ def lcJWST(eventlabel, s3_meta=None):
                 # Correct for drift/jitter
                 for n in range(meta.n_int):
                     # Need to zero-out the weights of masked data
-                    #weights = (~optspec[n].mask).astype(int)
-                    weights    = np.ones(meta.subnx)
+                    weights = (~np.ma.getmaskarray(optspec[n])).astype(int)
+                    #weights    = np.ones(meta.subnx)
                     spline     = spi.UnivariateSpline(np.arange(meta.subnx), optspec[n], k=3, s=0, w=weights)
                     spline2    = spi.UnivariateSpline(np.arange(meta.subnx), opterr[n],  k=3, s=0, w=weights)
                     optspec[n] = spline(np.arange(meta.subnx)+meta.drift1d[n])

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -165,7 +165,8 @@ def lcJWST(eventlabel, s3_meta=None):
                 # Correct for drift/jitter
                 for n in range(meta.n_int):
                     # Need to zero-out the weights of masked data
-                    weights = (~optspec[n].mask).astype(int)
+                    #weights = (~optspec[n].mask).astype(int)
+                    weights    = np.ones(meta.subnx)
                     spline     = spi.UnivariateSpline(np.arange(meta.subnx), optspec[n], k=3, s=0, w=weights)
                     spline2    = spi.UnivariateSpline(np.arange(meta.subnx), opterr[n],  k=3, s=0, w=weights)
                     optspec[n] = spline(np.arange(meta.subnx)+meta.drift1d[n])
@@ -173,6 +174,7 @@ def lcJWST(eventlabel, s3_meta=None):
                 # Plot Drift
                 if meta.isplots_S4 >= 1:
                     plots_s4.drift1d(meta)
+                    plots_s4.lc_driftcorr(meta, wave_1d, optspec)
 
 
             log.writelog("Generating light curves")
@@ -214,7 +216,7 @@ def lcJWST(eventlabel, s3_meta=None):
     return meta
 
 def read_s3_meta(meta):
-    
+
     # Search for the S2 output metadata in the inputdir provided in
     # First just check the specific inputdir folder
     rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))


### PR DESCRIPTION
Added figure 4102, which is nearly identical to 3101, but includes the benefits of drift/jitter correction.  The plot also draws vertical dashed lines to indicate breaks between spectroscopic channels.

![fig4102-2D_LC](https://user-images.githubusercontent.com/21340541/156389814-d32ca562-6d0c-4b1d-bad2-1d399c5b1c02.png)

To get the drift/jitter correction working, I set the weights to unity for now.  The previous mask was the wrong size.

