### PR TITLE
Patching bug with plotting chain, saving chain as HDF5

### DIFF
--- a/demos/JWST/S3_miri_lrs_template.ecf
+++ b/demos/JWST/S3_miri_lrs_template.ecf
@@ -34,4 +34,3 @@ topdir      /home/User
 # Directories relative to project dir
 inputdir    /Data/JWST-Sim/MIRI/Stage2	# The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
 outputdir	/Data/JWST-Sim/MIRI/Stage3
-ancildir    /Data/JWST-Sim/MIRI/ancil

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -34,4 +34,3 @@ topdir      /home/User
 # Directories relative to project dir
 inputdir    /Data/JWST-Sim/NIRCam/Stage2	# The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
 outputdir	/Data/JWST-Sim/NIRCam/Stage3
-ancildir    /Data/JWST-Sim/NIRCam/ancil

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -34,4 +34,3 @@ topdir      /home/User
 # Directories relative to project dir
 inputdir    /Data/JWST-Sim/NIRSpec/Stage2	# The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
 outputdir	/Data/JWST-Sim/NIRSpec/Stage3
-ancildir    /Data/JWST-Sim/NIRSpec/ancil

--- a/docs/media/S3_template.ecf
+++ b/docs/media/S3_template.ecf
@@ -34,4 +34,3 @@ topdir      /home/User/
 # Directories relative to project dir
 inputdir    /Data/JWST-Sim/NIRCam/Stage2/	# The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
 outputdir	/Data/JWST-Sim/NIRCam/Stage3/
-ancildir    /Data/JWST-Sim/NIRCam/ancil/

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -320,12 +320,6 @@ topdir + outputdir
 The path to the directory in which to output the Stage 3 JWST data and plots.
 
 
-topdir + ancildir
-''''''''''''''''''
-The path to the directory containing the ancillary data.
-
-E.g.: NIRCam needs a photometic file and a gainfile file to convert MJy/sr to DN (Data Numbers) and from DN to Electrons, respectively.
-The names of the the files needed are given in the header as ``hdulist[0].header['R_PHOTOM']`` and ``hdulist[0].header['R_GAIN']`` and can be downloaded here: `<https://jwst-crds.stsci.edu/browse_db/>`_
 
 
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -30,7 +30,7 @@ If your internet connection is slow, download the `smallest file only <https://s
 -----------------------------------------------------------------
 
 3.1 Go into the downloaded ``Eureka!`` directory (it is likely called Eureka-main if you downloaded it from GitHub) and open the file ``Eureka-main/demos/S3/S3_template.ecf``.
-Update "topdir + inputdir" and "topdir + ancildir" to the location of your Stage2 data and the ancil data, respectively.
+Update "topdir + inputdir" to the location of your Stage2 data.
 
 You can get more information about the ecf (``Eureka!`` control file) :ref:`here<ecf>`.
 

--- a/eureka/S3_data_reduction/bright2flux.py
+++ b/eureka/S3_data_reduction/bright2flux.py
@@ -1,5 +1,3 @@
-import sys
-from io import StringIO
 import numpy as np
 import scipy.interpolate as spi
 from scipy.constants import arcsec

--- a/eureka/S3_data_reduction/bright2flux.py
+++ b/eureka/S3_data_reduction/bright2flux.py
@@ -5,6 +5,39 @@ from astropy.io import fits
 from jwst import datamodels
 from jwst.photom import PhotomStep
 
+def rate2count(data):
+    """This function converts the data, uncertainty, and variance arrays from rate units (#/s) to counts (#).
+
+    Parameters
+    ----------
+    data:   DataClass
+        Data object containing data, uncertainty, and variance arrays in rate units (#/s).
+
+    Returns
+    -------
+    data:   DataClass
+        Data object containing data, uncertainty, and variance arrays in count units (#).
+
+    Notes
+    -----
+    History:
+    
+    - Mar 7, 2022 Taylor J Bell
+        Initial version
+    """
+    if "EFFINTTM" in data.mhdr.keys():
+        int_time = data.mhdr['EFFINTTM']
+    elif "EXPTIME" in data.mhdr.keys():
+        int_time = data.mhdr['EXPTIME']
+    else:
+        raise ValueError('No FITS header keys found to permit conversion from rate units (#/s) to counts (#)')
+    
+    data.subdata *= int_time
+    data.suberr  *= int_time
+    data.subv0   *= int_time
+
+    return data
+
 def dn2electrons(data, meta):
     """This function converts the data, uncertainty, and variance arrays from raw units (DN) to electrons.
 
@@ -86,8 +119,10 @@ def bright2dn(data, meta):
     foo = fits.getdata(meta.photfile)
     if meta.inst == 'nircam':
         ind = np.where((foo['filter'] == data.mhdr['FILTER']) * (foo['pupil'] == data.mhdr['PUPIL']) * (foo['order'] == 1))[0][0]
-    if meta.inst == 'miri':
+    elif meta.inst == 'miri':
         ind = np.where((foo['filter'] == data.mhdr['FILTER']) * (foo['subarray'] == data.mhdr['SUBARRAY']))[0][0]
+    else:
+        raise ValueError(f'The bright2dn function has not been edited to handle the instrument {meta.inst}, and can currently only handle miri and nircam observations.')
 
     response_wave = foo['wavelength'][ind]
     response_vals = foo['relresponse'][ind]
@@ -103,11 +138,6 @@ def bright2dn(data, meta):
     data.subdata /= scalar * response
     data.suberr  /= scalar * response
     data.subv0   /= (scalar * response)**2
-    # From DN/sec to DN
-    int_time = data.mhdr['EFFINTTM']
-    data.subdata *= int_time
-    data.suberr  *= int_time
-    data.subv0   *= int_time
 
     return data
 
@@ -189,20 +219,24 @@ def convert_to_e(data, meta, log):
         if data.mhdr['TELESCOP'] != 'JWST':
             raise ValueError('Currently unable to automatically download reference files for non-jwst observations!')
         meta.photfile, meta.gainfile = retrieve_ancil(data.filename)
-    
+    else:
+        log.writelog('  Converting from electrons per second (e/s) to electrons')
+
     if data.shdr['BUNIT'] == 'MJy/sr':
-        # Convert from brightness units (MJy/sr) to flux units (uJy/pix)
-        # log.writelog('Converting from brightness to flux units')
-        # data = b2f.bright2flux(data, data.shdr['PIXAR_A2'])
-        # Convert from brightness units (MJy/sr) to DNs
+        # Convert from brightness units (MJy/sr) to DN/s
         log.writelog('  Converting from brightness units (MJy/sr) to electrons')
         data = bright2dn(data, meta)
         data = dn2electrons(data, meta)
-    if data.shdr['BUNIT'] == 'DN/s':
+    elif data.shdr['BUNIT'] == 'DN/s':
         # Convert from DN/s to e/s
         log.writelog('  Converting from data numbers per second (DN/s) to electrons')
         data = dn2electrons(data, meta)
+    elif data.shdr['BUNIT'] != 'ELECTRONS/S':
+        raise ValueError(f'Currently unable to convert from input units {data.shdr["BUNIT"]} to electrons - try running Stage 2 again without the photom step.')
     
+    # Convert from e/s to e
+    data = rate2count(data)
+
     return data, meta
 
 def retrieve_ancil(fitsname):

--- a/eureka/S3_data_reduction/miri.py
+++ b/eureka/S3_data_reduction/miri.py
@@ -41,6 +41,7 @@ def read(filename, data, meta):
     hdulist = fits.open(filename)
 
     # Load main and science headers
+    data.filename = filename
     data.mhdr    = hdulist[0].header
     data.shdr    = hdulist['SCI',1].header
 

--- a/eureka/S3_data_reduction/nircam.py
+++ b/eureka/S3_data_reduction/nircam.py
@@ -39,6 +39,7 @@ def read(filename, data, meta):
     hdulist = fits.open(filename)
 
     # Load master and science headers
+    data.filename = filename
     data.mhdr    = hdulist[0].header
     data.shdr    = hdulist['SCI',1].header
 

--- a/eureka/S3_data_reduction/niriss.py
+++ b/eureka/S3_data_reduction/niriss.py
@@ -63,6 +63,7 @@ def read(filename, f277_filename, data, meta):
     f277= fits.open(f277_filename)
 
     # loads in all the header data
+    data.filename = filename
     data.mhdr = hdu[0].header
     data.shdr = hdu['SCI',1].header
 

--- a/eureka/S3_data_reduction/nirspec.py
+++ b/eureka/S3_data_reduction/nirspec.py
@@ -36,6 +36,7 @@ def read(filename, data, meta):
 
     # Now we can start working with the data.
     hdulist 		= fits.open(filename)
+    data.filename = filename
     data.mhdr 		= hdulist[0].header
     data.shdr 		= hdulist['SCI',1].header
 

--- a/eureka/S3_data_reduction/plots_s3.py
+++ b/eureka/S3_data_reduction/plots_s3.py
@@ -18,6 +18,7 @@ def lc_nodriftcorr(meta, wave_1d, optspec, log):
     -------
     None
     '''
+    optspec = np.ma.masked_invalid(optspec)
     plt.figure(3101, figsize=(8, 8))
     plt.clf()
     wmin = wave_1d.min()
@@ -25,13 +26,13 @@ def lc_nodriftcorr(meta, wave_1d, optspec, log):
     n_int, nx = optspec.shape
     vmin = 0.97
     vmax = 1.03
-    normspec = optspec / np.mean(optspec, axis=0)
+    normspec = optspec / np.ma.mean(optspec, axis=0)
     plt.imshow(normspec, origin='lower', aspect='auto', extent=[wmin, wmax, 0, n_int], vmin=vmin, vmax=vmax,
                cmap=plt.cm.RdYlBu_r)
-    ediff = np.zeros(n_int)
+    ediff = np.ma.zeros(n_int)
     for m in range(n_int):
-        ediff[m] = 1e6 * np.median(np.abs(np.ediff1d(normspec[m])))
-    MAD = np.mean(ediff)
+        ediff[m] = 1e6 * np.ma.median(np.ma.abs(np.ma.ediff1d(normspec[m])))
+    MAD = np.ma.mean(ediff)
     log.writelog("MAD = " + str(np.round(MAD, 0).astype(int)) + " ppm")
     plt.title("MAD = " + str(np.round(MAD, 0).astype(int)) + " ppm")
     plt.ylabel('Integration Number')

--- a/eureka/S3_data_reduction/plots_s3.py
+++ b/eureka/S3_data_reduction/plots_s3.py
@@ -13,6 +13,8 @@ def lc_nodriftcorr(meta, wave_1d, optspec, log):
         Wavelength array with trimmed edges depending on xwindow and ywindow which have been set in the S3 ecf
     optspec:    
         The optimally extracted spectrum.
+    log: logedit.Logedit
+        The open log in which notes from this step can be added.
 
     Returns
     -------

--- a/eureka/S3_data_reduction/plots_s3.py
+++ b/eureka/S3_data_reduction/plots_s3.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from .source_pos import gauss
 
-def lc_nodriftcorr(meta, wave_1d, optspec):
+def lc_nodriftcorr(meta, wave_1d, optspec, log):
     '''Plot a 2D light curve without drift correction.
     
     Parameters
@@ -18,27 +18,22 @@ def lc_nodriftcorr(meta, wave_1d, optspec):
     -------
     None
     '''
-    plt.figure(3101, figsize=(8, 8))  # ev.n_files/20.+0.8))
+    plt.figure(3101, figsize=(8, 8))
     plt.clf()
     wmin = wave_1d.min()
     wmax = wave_1d.max()
     n_int, nx = optspec.shape
-    # iwmin       = np.where(ev.wave[src_ypos]>wmin)[0][0]
-    # iwmax       = np.where(ev.wave[src_ypos]>wmax)[0][0]
     vmin = 0.97
     vmax = 1.03
-    # normspec    = np.mean(ev.optspec,axis=1)/np.mean(ev.optspec[ev.inormspec[0]:ev.inormspec[1]],axis=(0,1))
     normspec = optspec / np.mean(optspec, axis=0)
     plt.imshow(normspec, origin='lower', aspect='auto', extent=[wmin, wmax, 0, n_int], vmin=vmin, vmax=vmax,
                cmap=plt.cm.RdYlBu_r)
     ediff = np.zeros(n_int)
     for m in range(n_int):
         ediff[m] = 1e6 * np.median(np.abs(np.ediff1d(normspec[m])))
-        # plt.scatter(ev.wave[src_ypos], np.zeros(nx)+m, c=normspec[m],
-        #             s=14,linewidths=0,vmin=vmin,vmax=vmax,marker='s',cmap=plt.cm.RdYlBu_r)
-    plt.title("MAD = " + str(np.round(np.mean(ediff), 0).astype(int)) + " ppm")
-    # plt.xlim(wmin,wmax)
-    # plt.ylim(0,n_int)
+    MAD = np.mean(ediff)
+    log.writelog("MAD = " + str(np.round(MAD, 0).astype(int)) + " ppm")
+    plt.title("MAD = " + str(np.round(MAD, 0).astype(int)) + " ppm")
     plt.ylabel('Integration Number')
     plt.xlabel(r'Wavelength ($\mu m$)')
     plt.colorbar(label='Normalized Flux')
@@ -74,16 +69,13 @@ def image_and_background(data, meta, n):
     plt.title('Background-Subtracted Flux')
     max = np.max(subdata[n] * submask[n])
     plt.imshow(subdata[n] * submask[n], origin='lower', aspect='auto', vmin=0, vmax=max / 10)
-    # plt.imshow(subdata[n], origin='lower', aspect='auto', vmin=0, vmax=10000)
     plt.colorbar()
     plt.ylabel('Pixel Position')
     plt.subplot(212)
     plt.title('Subtracted Background')
-    # plt.imshow(submask[i], origin='lower', aspect='auto', vmax=1)
     median = np.median(subbg[n])
     std = np.std(subbg[n])
     plt.imshow(subbg[n], origin='lower', aspect='auto', vmin=median - 3 * std, vmax=median + 3 * std)
-    # plt.imshow(submask[n], origin='lower', aspect='auto', vmin=0, vmax=1)
     plt.colorbar()
     plt.ylabel('Pixel Position')
     plt.xlabel('Pixel Position')
@@ -117,7 +109,6 @@ def optimal_spectrum(data, meta, n):
     plt.clf()
     plt.suptitle(f'1D Spectrum - Integration {intstart + n}')
     plt.semilogy(range(subnx), stdspec[n], '-', color='C1', label='Standard Spec')
-    # plt.errorbar(range(subnx), stdspec[n], yerr=np.sqrt(stdvar[n]), fmt='-', color='C1', ecolor='C0', label='Std Spec')
     plt.errorbar(range(subnx), optspec[n], opterr[n], fmt='-', color='C2', ecolor='C2', label='Optimal Spec')
     plt.ylabel('Flux')
     plt.xlabel('Pixel Position')

--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -332,7 +332,7 @@ def reduceJWST(eventlabel, ecf_path='./', s2_meta=None):
             if meta.isplots_S3 >= 1:
                 log.writelog('Generating figure')
                 # 2D light curve without drift correction
-                plots_s3.lc_nodriftcorr(meta, wave_1d, optspec)
+                plots_s3.lc_nodriftcorr(meta, wave_1d, optspec, log)
 
             # Save results
             if meta.save_output == True:

--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -96,59 +96,17 @@ def reduceJWST(eventlabel, ecf_path='./', s2_meta=None):
     rd.store_ecf(meta, ecf)
     meta.eventlabel=eventlabel
 
-    # S3 is not being called right after S2 - try to load a metadata in case S2 was previously run
     if s2_meta == None:
-        # Search for the S2 output metadata in the inputdir provided in
-        rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-        if rootdir[-1]!='/':
-            rootdir += '/'
-        fnames = glob.glob(rootdir+'**/S2_'+meta.eventlabel+'_Meta_Save.dat', recursive=True)
-        
-        if len(fnames)>=1:
-            # get the folder with the latest modified time
-            fname = max(fnames, key=os.path.getmtime)
+        #load savefile
+        s2_meta = read_s2_meta(meta)
 
-        if len(fnames)==0:
-            # There may be no metafiles in the inputdir - raise an error and give a helpful message
-            print('WARNING: Unable to find an output metadata file from Eureka!\'s S2 step '
-                 +'in the inputdir: \n"{}"!\n'.format(meta.inputdir)
-                 +'Assuming this S2 data was produced by the JWST pipeline instead.')
-        else:
-            if len(fnames)>1:
-                # There may be multiple runs - use the most recent but warn the user
-                print('WARNING: There are multiple metadata save files in your inputdir: \n"{}"\n'.format(meta.inputdir)
-                     +'Using the metadata file: \n"{}"'.format(fname))
-
-            fname = fname[:-4] # Strip off the .dat ending
-            s2_meta = me.loadevent(fname)
-
-    # Locate the exact output folder from the previous S2 run (since there is a procedurally generated subdirectory for each run)
     if s2_meta != None:
-        # Need to remove the topdir from the outputdir
-        if os.path.isdir(s2_meta.outputdir):
-            s2_outputdir = s2_meta.outputdir[len(s2_meta.topdir):]
-            if s2_outputdir[0]=='/':
-                s2_outputdir = s2_outputdir[1:]
-
-            meta = s2_meta
-
-            # Load Eureka! control file and store values in the S2 metadata object
-            ecffile = 'S3_' + eventlabel + '.ecf'
-            ecf = rd.read_ecf(ecf_path, ecffile)
-            rd.store_ecf(meta, ecf)
-
-            # Overwrite the inputdir with the exact output directory from S2
-            meta.inputdir = s2_outputdir
-        else:
-            raise AssertionError("Unable to find output data files from Eureka!'s S2 step! "
-                                 + "Looked in the folder: \n{}".format(s2_meta.outputdir))
-
-    if hasattr(meta, 'datetime'):
-        meta.old_datetime = meta.datetime # Capture the date used by S2
-        meta.datetime = None # Reset the datetime in case we're running this on a different day
-
-    meta.inputdir_raw = meta.inputdir
-    meta.outputdir_raw = meta.outputdir
+        meta = load_general_s2_meta_info(meta, ecf_path, s2_meta)
+    else:
+        meta.inputdir_raw = meta.inputdir
+        meta.outputdir_raw = meta.outputdir
+        meta.inputdir = os.path.join(meta.topdir, *meta.inputdir_raw.split(os.sep))
+        meta.outputdir = os.path.join(meta.topdir, *meta.outputdir_raw.split(os.sep))
 
     # check for range of spectral apertures
     if isinstance(meta.spec_hw, list):
@@ -382,5 +340,65 @@ def reduceJWST(eventlabel, ecf_path='./', s2_meta=None):
                 me.saveevent(meta, meta.outputdir + 'S3_' + event_ap_bg + "_Meta_Save", save=[])
 
             log.closelog()
+
+    return meta
+
+def read_s2_meta(meta):
+
+    # Search for the S2 output metadata in the inputdir provided in
+    # First just check the specific inputdir folder
+    rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
+    if rootdir[-1]!='/':
+        rootdir += '/'
+    fnames = glob.glob(rootdir+'S2_'+meta.eventlabel+'*_Meta_Save.dat')
+    if len(fnames)==0:
+        # There were no metadata files in that folder, so let's see if there are in children folders
+        fnames = glob.glob(rootdir+'**/S2_'+meta.eventlabel+'*_Meta_Save.dat', recursive=True)
+        fnames = sn.sort_nicely(fnames)
+
+    if len(fnames)>=1:
+        # get the folder with the latest modified time
+        fname = max(fnames, key=os.path.getmtime)
+
+    if len(fnames)==0:
+        # There may be no metafiles in the inputdir - raise an error and give a helpful message
+        print('WARNING: Unable to find an output metadata file from Eureka!\'s S2 step '
+                +'in the inputdir: \n"{}"!\n'.format(meta.inputdir)
+                +'Assuming this S2 data was produced by the JWST pipeline instead.')
+        return None
+    elif len(fnames)>1:
+        # There may be multiple runs - use the most recent but warn the user
+        print('WARNING: There are multiple metadata save files in your inputdir: \n"{}"\n'.format(rootdir)
+                +'Using the metadata file: \n{}\n'.format(fname)
+                +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
+                +'of the run you intended, please provide a more precise folder for the metadata file.')
+    
+    fname = fname[:-4] # Strip off the .dat ending
+
+    s2_meta = me.loadevent(fname)
+
+    return s2_meta
+
+def load_general_s2_meta_info(meta, ecf_path, s2_meta):
+    # Need to remove the topdir from the outputdir
+    s2_outputdir = s2_meta.outputdir[len(s2_meta.topdir):]
+    if s2_outputdir[0]=='/':
+        s2_outputdir = s2_outputdir[1:]
+    if s2_outputdir[-1]!='/':
+        s2_outputdir += '/'
+
+    meta = s2_meta
+
+    # Load S3 Eureka! control file and store values in the S2 metadata object
+    ecffile = 'S3_' + meta.eventlabel + '.ecf'
+    ecf     = rd.read_ecf(ecf_path, ecffile)
+    rd.store_ecf(meta, ecf)
+
+    # Overwrite the inputdir with the exact output directory from S2
+    meta.inputdir = os.path.join(s2_meta.topdir, s2_outputdir)
+    meta.old_datetime = meta.datetime # Capture the date that the
+    meta.datetime = None # Reset the datetime in case we're running this on a different day
+    meta.inputdir_raw = s2_outputdir
+    meta.outputdir_raw = meta.outputdir
 
     return meta

--- a/eureka/S5_lightcurve_fitting/likelihood.py
+++ b/eureka/S5_lightcurve_fitting/likelihood.py
@@ -177,7 +177,7 @@ def ptform(theta, prior1, prior2, priortype):
             raise ValueError("PriorType must be 'U', 'LU', or 'N'")
     return p
 
-def computeRedChiSq(lc, model, meta, freenames):
+def computeRedChiSq(lc, model, meta, freenames, log):
     """Compute the reduced chi-squared value.
 
     Parameters
@@ -190,6 +190,8 @@ def computeRedChiSq(lc, model, meta, freenames):
         The metadata object.
     freenames: iterable
         The names of the fitted parameters.
+    log: logedit.Logedit
+        The open log in which notes from this step can be added.
 
     Returns
     -------
@@ -209,7 +211,7 @@ def computeRedChiSq(lc, model, meta, freenames):
     chi2red = chi2 / (len(lc.flux) - len(freenames))
 
     if meta.run_verbose:
-        print('Reduced Chi-squared: ', chi2red)
+        log.writelog('Reduced Chi-squared: ', chi2red)
 
     return chi2red
 

--- a/eureka/S5_lightcurve_fitting/likelihood.py
+++ b/eureka/S5_lightcurve_fitting/likelihood.py
@@ -206,12 +206,12 @@ def computeRedChiSq(lc, model, meta, freenames, log):
         Moved code to separate file, added documentation.
     """
     model_lc = model.eval()
-    residuals = (lc.flux - model_lc) #/ lc.unc
+    residuals = (lc.flux - model_lc)
     chi2 = np.sum((residuals / lc.unc_fit) ** 2)
     chi2red = chi2 / (len(lc.flux) - len(freenames))
 
     if meta.run_verbose:
-        log.writelog('Reduced Chi-squared: ', chi2red)
+        log.writelog(f'Reduced Chi-squared: {chi2red}')
 
     return chi2red
 

--- a/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -230,7 +230,7 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', full=True, nburn=0)
     """
     if len(freenames) > 20:
         # Break the plot into many plots to avoid an enormous figure
-        ndims = 20*np.ones(int(len(freenames//20)), dtype=int)
+        ndims = 20*np.ones(int(len(freenames)//20), dtype=int)
         if len(freenames)-np.sum(ndims) > 0:
             ndims = np.append(ndims, int(len(freenames)-np.sum(ndims)))
     else:
@@ -239,10 +239,6 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', full=True, nburn=0)
     for plot_number, ndim in enumerate(ndims):
         fig, axes = plt.subplots(ndim, 1, num=int('55{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))), sharex=True, figsize=(6, ndim))
         
-        print(plot_number)
-        print(ndims)
-        print(type(ndims[0]), type(ndim), type(plot_number), type(np.sum(ndims[:plot_number])), type(np.sum(ndims[:plot_number])+ndim))
-
         for i, j in enumerate(range(np.sum(ndims[:plot_number]), np.sum(ndims[:plot_number])+ndim)):
             axes[i].plot(samples[:, :, j], alpha=0.4)
             axes[i].set_ylabel(freenames[j])

--- a/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -199,7 +199,7 @@ def plot_corner(samples, lc, meta, freenames, fitter):
 
     return
 
-def plot_chain(samples, lc, meta, freenames, fitter='emcee', full=True, nburn=0):
+def plot_chain(samples, lc, meta, freenames, fitter='emcee', full=True, nburn=0, nrows=3, ncols=4, nthin=1):
     """Plot the evolution of the chain to look for temporal trends
 
     Parameters
@@ -216,6 +216,14 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', full=True, nburn=0)
         The name of the fitter (for plot filename)
     full:   bool
         Whether or not the samples passed in include any burn-in steps
+    nburn:  int
+        The number of burn-in steps that are discarded later
+    nrows:  int
+        The number of rows to make per figure
+    ncols:  int
+        The number of columns to make per figure
+    nthin:  int
+        If >1, the plot will use every nthin point to help speed up computation and reduce clutter on the plot.
 
     Returns
     -------
@@ -228,22 +236,35 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', full=True, nburn=0)
     - December 29, 2021 Taylor Bell
         Moved plotting code to a separate function.
     """
-    if len(freenames) > 20:
-        # Break the plot into many plots to avoid an enormous figure
-        ndims = 20*np.ones(int(len(freenames)//20), dtype=int)
-        if len(freenames)-np.sum(ndims) > 0:
-            ndims = np.append(ndims, int(len(freenames)-np.sum(ndims)))
-    else:
-        ndims = np.array([len(freenames),])
+    nsubplots = nrows*ncols
+    nplots = int(np.ceil(len(freenames)/nsubplots))
 
-    for plot_number, ndim in enumerate(ndims):
-        fig, axes = plt.subplots(ndim, 1, num=int('55{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))), sharex=True, figsize=(6, ndim))
+    k = 0
+    for plot_number in range(nplots):
+        fig, axes = plt.subplots(nrows, ncols, num=int('55{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))), sharex=True, figsize=(6*ncols, 4*nrows))
         
-        for i, j in enumerate(range(np.sum(ndims[:plot_number]), np.sum(ndims[:plot_number])+ndim)):
-            axes[i].plot(samples[:, :, j], alpha=0.4)
-            axes[i].set_ylabel(freenames[j])
-            if full and nburn>0:
-                axes[i].axvline(nburn)
+        for j in range(ncols):
+            for i in range(nrows):
+                if k >= samples.shape[2]:
+                    axes[i][j].set_axis_off()
+                    continue
+                vals = samples[::nthin, :, k]
+                xvals = np.arange(samples.shape[0])[::nthin]
+                n3sig, n2sig, n1sig, med, p1sig, p2sig, p3sig = np.percentile(vals, [0.15,2.5,16,50,84,97.5,99.85], axis=1)
+                axes[i][j].fill_between(xvals, n3sig, p3sig, alpha=0.2, label=r'3$\sigma$')
+                axes[i][j].fill_between(xvals, n2sig, p2sig, alpha=0.2, label=r'2$\sigma$')
+                axes[i][j].fill_between(xvals, n1sig, p1sig, alpha=0.2, label=r'1$\sigma$')
+                axes[i][j].plot(xvals, med, label='Median')
+                axes[i][j].set_ylabel(freenames[k])
+                axes[i][j].set_xlim(0, samples.shape[0]-1)
+                for arr in [n3sig, n2sig, n1sig, med, p1sig, p2sig, p3sig]:
+                    # Add some horizontal lines to make movement in walker population more obvious
+                    axes[i][j].axhline(arr[0], ls='dotted', c='k', lw=1)
+                if full and nburn>0:
+                    axes[i][j].axvline(nburn, ls='--', c='k', label='End of Burn-In')
+                if (j==(ncols-1) and i==(nrows//2)) or (k == samples.shape[2]-1):
+                    axes[i][j].legend(loc=6, bbox_to_anchor=(1.01,0.5))
+                k += 1
         fig.tight_layout(h_pad=0.0)
         
         fname = 'figs/fig55{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))
@@ -252,8 +273,8 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', full=True, nburn=0)
         else:
             fname += '_chain'
         fname += '_{}'.format(fitter)
-        if len(ndims)>1:
-            fname += '_plot{}'.format(plot_number)
+        if nplots>1:
+            fname += '_plot{}of{}'.format(plot_number+1,nplots)
         fname += '.png'
         fig.savefig(meta.outputdir+fname, bbox_inches='tight', pad_inches=0.05, dpi=250)
         if meta.hide_plots:

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -99,6 +99,8 @@ def plot_spectra(eventlabel, ecf_path='./', s5_meta=None):
             rd.copy_ecf(meta, ecf_path, ecffile)
 
             # Get the wavelength values
+            meta.wave_low = np.array(meta.wave_low)
+            meta.wave_hi = np.array(meta.wave_hi)
             wavelengths = np.mean(np.append(meta.wave_low.reshape(1,-1), meta.wave_hi.reshape(1,-1), axis=0), axis=0)
             wave_errs = (meta.wave_hi-meta.wave_low)/2
 

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from astropy import units, constants
-import os, glob
+import os, glob, h5py
 import time as time_pkg
 from ..lib import manageevent as me
 from ..lib import readECF as rd
@@ -230,16 +230,34 @@ def plot_spectra(eventlabel, ecf_path='./', s5_meta=None):
 def parse_s5_saves(meta, fit_methods, y_param, channel_key='shared'):
     for fitter in fit_methods:
         if fitter in ['dynesty', 'emcee']:
-            fname = f'S5_{fitter}_samples_{channel_key}.csv'
-            samples = pd.read_csv(meta.inputdir+fname, escapechar='#', skipinitialspace=True)
-            if y_param=='fp':
-                keys = [key for key in samples.keys() if 'fp' in key]
+            fname = f'S5_{fitter}_fitparams_{channel_key}.csv'
+            fitted_values = pd.read_csv(meta.inputdir+fname, escapechar='#', skipinitialspace=True)
+            full_keys = fitted_values.keys()
+            
+            fname = f'S5_{fitter}_samples_{channel_key}'
+            if os.path.isfile(meta.inputdir+fname+'.h5'):
+                # New code to load HDF5 files
+                with h5py.File(meta.inputdir+fname+'.h5', 'r') as hf:
+                    samples = hf['samples'][:]
             else:
-                keys = [key for key in samples.keys() if 'rp' in key]
+                # Keep this old code for the time being to allow backwards compatibility
+                samples = pd.read_csv(meta.inputdir+fname+'.csv', escapechar='#', skipinitialspace=True)
+
+            if y_param=='fp':
+                keys = [key for key in full_keys if 'fp' in key]
+            else:
+                keys = [key for key in full_keys if 'rp' in key]
+
             if len(keys)==0:
                 raise AssertionError(f'Parameter {y_param} was not in the list of fitted parameters which includes:'
-                                    +', '.join(samples.keys()))
-            spectra_samples = np.array([samples[key] for key in keys])
+                                    +', '.join(full_keys))
+    
+            if os.path.isfile(meta.inputdir+fname+'.h5'):
+                # New code to load HDF5 files
+                spectra_samples = np.array([samples[:,full_keys==key] for key in keys]).reshape((len(keys),-1))
+            else:
+                # Keep this old code for the time being to allow backwards compatibility
+                spectra_samples = np.array([samples[key] for key in keys])
             lowers, medians, uppers = np.percentile(spectra_samples, [16,50,84], axis=1)
             lowers = np.abs(medians-lowers)
             uppers = np.abs(uppers-medians)

--- a/eureka/tests/NIRCam_ecfs/S3_NIRCam.ecf
+++ b/eureka/tests/NIRCam_ecfs/S3_NIRCam.ecf
@@ -34,5 +34,4 @@ topdir     ../tests
 
 # Directories relative to project dir
 inputdir     /data/JWST-Sim/NIRCam/Stage2/
-ancildir    /data/JWST-Sim/NIRCam/ancil/
 outputdir	/data/JWST-Sim/NIRCam/Stage3/

--- a/eureka/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
+++ b/eureka/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
@@ -33,5 +33,4 @@ topdir     ../tests
 
 # Directories relative to project dir
 inputdir     /data/JWST-Sim/NIRSpec/Stage2/
-ancildir     /data/JWST-Sim/NIRSpec/ancil
 outputdir	 /data/JWST-Sim/NIRSpec/Stage3/


### PR DESCRIPTION
This PR builds upon #166, so that one should be merged first.

I maintained backwards compatibility with old saved csv chains, but I
now save chains as HDF5 files which are far more compressed and still
independent of programming language.

I also made a much better chain plot to show the evolution of the emcee
walkers with several visual aids. See below for a super-short emcee fit I
just did to the MIRI/LRS phase curve that is obviously nowhere near
burned in, but gives you the general idea of what the plot looks like.
There will be multiple figures if there are more than 12 parameters to
keep the figure size manageable. I'll try to do a longer run to show you
what the chain looks like when it's at least near converged, but those
horizontal dotted lines can be used as rulers to see if the median or 1-3
sigma level of the ensemble of walkers has changed.

![fig550_fullchain_emcee_plot1of2](https://user-images.githubusercontent.com/24514122/157147312-a7e57982-3612-4f27-941e-947b451fd566.png)