### PR TITLE
Update fitters.py

### DIFF
--- a/eureka/S5_lightcurve_fitting/fitters.py
+++ b/eureka/S5_lightcurve_fitting/fitters.py
@@ -661,7 +661,7 @@ def save_fit(meta, lc, fitter, fit_params, freenames, samples=[]):
         if lc.share:
             fname = f'S5_{fitter}_samples_shared.csv'
         else:
-            fname = f'S5_{fitter}_samples_ch{lc.channel}.csv'
+            fname = f'S5_{fitter}_samples_ch%03i.csv' % lc.channel
         np.savetxt(meta.outputdir+fname, samples, header=','.join(freenames), delimiter=',')
     
     return


### PR DESCRIPTION
lightcurve channels should be enumerated as 001, 002, 003,.... etc.  This way, directory sorting (e.g. via `ls`) returns the LC outputs in the proper channel order.