### PR TITLE
Only rotating xwindow ywindow once

### DIFF
--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -239,7 +239,7 @@ def reduceJWST(eventlabel, ecf_path='./', s2_meta=None):
                 istart = 0
             for m in range(istart, meta.num_data_files):
                 # Keep track if this is the first file - otherwise MIRI will keep swapping x and y windows
-                if m==istart:
+                if m==istart and meta.spec_hw==meta.spec_hw_range[0] and meta.bg_hw==meta.bg_hw_range[0]:
                     meta.firstFile = True
                 else:
                     meta.firstFile = False

--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -158,7 +158,7 @@ def reduceJWST(eventlabel, ecf_path='./', s2_meta=None):
 
     #check for range of background apertures
     if isinstance(meta.bg_hw, list):
-        meta.bg_hw_range = range(meta.bg_hw[0], meta.bg_hw[1]+meta.spec_hw[2], meta.bg_hw[2])
+        meta.bg_hw_range = range(meta.bg_hw[0], meta.bg_hw[1]+meta.bg_hw[2], meta.bg_hw[2])
     else:
         meta.bg_hw_range = [meta.bg_hw]
 


### PR DESCRIPTION
Before, using multiple aperture pairs for MIRI would result in xwindow
and ywindow being rotated for every aperture pair which would cause the
code to crash and give many error messages (e.g. Issue #184). This edit
closes #184