### PR TITLE
Allow background subtracted FITS files to be saved

### DIFF
--- a/demos/HST/S3_wfc3_template.ecf
+++ b/demos/HST/S3_wfc3_template.ecf
@@ -33,6 +33,7 @@ bg_hw       	40          # Half-width of exclusion region for BG subtraction (re
 bg_thresh   	[5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg     	 	0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    	5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub    False       # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     	8           # Half-width of aperture region for spectral extraction (relative to source position)

--- a/demos/JWST/S3_miri_lrs_template.ecf
+++ b/demos/JWST/S3_miri_lrs_template.ecf
@@ -13,6 +13,7 @@ bg_hw       17          # Half-width of exclusion region for BG subtraction (rel
 bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub  False      # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     4           # Half-width of aperture region for spectral extraction (relative to source position)

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -13,6 +13,7 @@ bg_hw       8			# Half-width of exclusion region for BG subtraction (relative to
 bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub  False      # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     8			# Half-width of aperture region for spectral extraction (relative to source position)

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -13,6 +13,7 @@ bg_hw       7          # Half-width of exclusion region for BG subtraction (rela
 bg_thresh   [10,10]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    10           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub  False      # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     6          # Half-width of aperture region for spectral extraction (relative to source position)

--- a/docs/media/S3_template.ecf
+++ b/docs/media/S3_template.ecf
@@ -13,6 +13,7 @@ bg_hw       8          # Half-width of exclusion region for BG subtraction (rela
 bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub  False       # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     8          # Half-width of aperture region for spectral extraction (relative to source position)

--- a/eureka/S3_data_reduction/background.py
+++ b/eureka/S3_data_reduction/background.py
@@ -92,7 +92,10 @@ def BGsubtraction(data, meta, log, isplots):
     if hasattr(meta, 'save_bgsub') and meta.save_bgsub:
         log.writelog('  Saving background subtracted FITS files', mute=(not meta.verbose))
         new_filename = data.filename.split(os.sep)[-1]
-        new_filename = os.path.join(meta.outputdir, 'bgsub_FITS', new_filename)
+        new_folder = os.path.join(meta.outputdir, 'bgsub_FITS')
+        if not os.path.isdir(new_folder):
+            os.mkdir(new_folder)
+        new_filename = os.path.join(new_folder, new_filename)
         with datamodels.open(data.filename) as file:
             file.data = data.subdata
             file.save(new_filename)

--- a/eureka/S3_data_reduction/background.py
+++ b/eureka/S3_data_reduction/background.py
@@ -11,6 +11,8 @@ from astropy.stats import SigmaClip, sigma_clip
 from astropy.modeling.models import custom_model
 from astropy.modeling.fitting import LevMarLSQFitter
 from photutils import MMMBackground, MedianBackground, Background2D
+from jwst import datamodels
+import os
 
 from ..lib import clipping
 
@@ -86,6 +88,14 @@ def BGsubtraction(data, meta, log, isplots):
     # 9.  Background subtraction
     # Perform background subtraction
     data.subdata -= data.subbg
+    
+    if hasattr(meta, 'save_bgsub') and meta.save_bgsub:
+        log.writelog('  Saving background subtracted FITS files', mute=(not meta.verbose))
+        new_filename = data.filename.split(os.sep)[-1]
+        new_filename = os.path.join(meta.outputdir, 'bgsub_FITS', new_filename)
+        with datamodels.open(data.filename) as file:
+            file.data = data.subdata
+            file.save(new_filename)
 
     return data
 

--- a/eureka/tests/NIRCam_ecfs/S3_NIRCam.ecf
+++ b/eureka/tests/NIRCam_ecfs/S3_NIRCam.ecf
@@ -14,6 +14,7 @@ bg_hw       20			# Half-width of exclusion region for BG subtraction (relative t
 bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub  False      # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     20			# Half-width of aperture region for spectral extraction (relative to source position)

--- a/eureka/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
+++ b/eureka/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
@@ -13,6 +13,7 @@ bg_hw       10          # Half-width of exclusion region for BG subtraction (rel
 bg_thresh   [15,15]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      0          # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    2           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub  False      # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     8         # Half-width of aperture region for spectral extraction (relative to source position)


### PR DESCRIPTION
This PR allows background subtracted FITS files to be saved in Stage 3. The FITS files have different shapes since the background subtraction happens after util.trim happens, but at least we'll have something to submit to the ERS data challenge Background-Subtracted Countrate Images folder.