### PR TITLE
Added CRDS vars to README, added sphinx-rtd-theme to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ GitHub following the method described below.
 	pip install .
 	```
 
+3. Set JWST CRDS environment variables. Eureka! installs the JWST Calibration Pipeline, and these variables need to be set for the calibration steps to properly run. The best practice for doing this is to add these two lines to your .bashrc (or equivalent shell startup script).
+
+	```bash
+	export CRDS_PATH=/PATH/TO/FOLDER/crds_cache	
+	export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+	```
+
 ## Documentation
 
 Check out the docs at [https://eurekadocs.readthedocs.io](https://eurekadocs.readthedocs.io).

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,6 @@ pytest
 recommonmark
 requests
 scipy
+sphinx-rtd-theme
 svo_filters
 tqdm


### PR DESCRIPTION
The process for setting the CRDS environment variables also should be outlined in the GitHub readme, otherwise people will probably miss doing this if they don't read the documentation. 

In addition, people like to build local documentation sometimes (either for development or personal reasons), so if they want to do this, they need sphinx-rtd-theme to be installed.