### PR TITLE
Resolve #182 by auto setting wave_min/max if None

### DIFF
--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -2,8 +2,8 @@
 
 # Number of spectroscopic channels spread evenly over given wavelength range
 nspecchan   20          # Number of spectroscopic channels
-wave_min    2.4         # Minimum wavelength
-wave_max    4.0         # Maximum wavelength
+wave_min    2.4         # Minimum wavelength. Set to None to use the shortest extracted wavelength from Stage 3.
+wave_max    4.0         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
 allapers	True		# Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
 # Parameters for drift correction of 1D spectra

--- a/docs/media/S4_template.ecf
+++ b/docs/media/S4_template.ecf
@@ -2,8 +2,8 @@
 
 # Number of spectroscopic channels spread evenly over given wavelength range
 nspecchan   20          # Number of spectroscopic channels
-wave_min    2.4         # Minimum wavelength
-wave_max    4.0         # Maximum wavelength
+wave_min    2.4         # Minimum wavelength. Set to None to use the shortest extracted wavelength from Stage 3.
+wave_max    4.0         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
 allapers	True		# Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
 # Parameters for drift correction of 1D spectra

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -340,7 +340,7 @@ Number of spectroscopic channels spread evenly over given wavelength range
 
 wave_min & wave_max
 ''''''''''''''''''''
-Start and End of the wavelength range being considered
+Start and End of the wavelength range being considered. Set to None to use the shortest/longest extracted wavelength from Stage 3.
 
 
 allapers

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -123,9 +123,16 @@ def lcJWST(eventlabel, ecf_path='./', s3_meta=None):
             opterr = np.reshape(table['opterr'].data, (-1, meta.subnx))
             wave_1d = table['wave_1d'].data[0:meta.subnx]
             meta.time = table['time'].data[::meta.subnx]
-            if meta.wave_min<np.min(wave_1d):
+
+            if meta.wave_min is None:
+                meta.wave_min = np.min(wave_1d)
+                log.writelog(f'No value was provided for meta.wave_min, so defaulting to {meta.wave_min}.', mute=(not meta.verbose))
+            elif meta.wave_min<np.min(wave_1d):
                 log.writelog(f'WARNING: The selected meta.wave_min ({meta.wave_min}) is smaller than the shortest wavelength ({np.min(wave_1d)})')
-            if meta.wave_max>np.max(wave_1d):
+            if meta.wave_max is None:
+                meta.wave_max = np.max(wave_1d)
+                log.writelog(f'No value was provided for meta.wave_max, so defaulting to {meta.wave_max}.', mute=(not meta.verbose))
+            elif meta.wave_max>np.max(wave_1d):
                 log.writelog(f'WARNING: The selected meta.wave_max ({meta.wave_max}) is larger than the longest wavelength ({np.max(wave_1d)})')
 
             #Replace NaNs with zero

--- a/eureka/tests/NIRCam_ecfs/S4_NIRCam.ecf
+++ b/eureka/tests/NIRCam_ecfs/S4_NIRCam.ecf
@@ -2,8 +2,8 @@
 
 # Number of spectroscopic channels spread evenly over given wavelength range
 nspecchan   10          # Number of spectroscopic channels
-wave_min    2.5         # Minimum wavelength
-wave_max    4.0         # Maximum wavelength
+wave_min    2.5         # Minimum wavelength. Set to None to use the shortest extracted wavelength from Stage 3.
+wave_max    4.0         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
 allapers	True		# Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
 # Parameters for drift correction of 1D spectra

--- a/eureka/tests/NIRSpec_ecfs/S4_NIRSpec.ecf
+++ b/eureka/tests/NIRSpec_ecfs/S4_NIRSpec.ecf
@@ -2,8 +2,8 @@
 
 # Number of spectroscopic channels spread evenly over given wavelength range
 nspecchan   1          # Number of spectroscopic channels
-wave_min    2.5         # Minimum wavelength
-wave_max    4.0         # Maximum wavelength
+wave_min    2.5         # Minimum wavelength. Set to None to use the shortest extracted wavelength from Stage 3.
+wave_max    4.0         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
 allapers	True		# Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
 # Parameters for drift correction of 1D spectra


### PR DESCRIPTION
Automatically sets the wave_min and wave_max values to the min and max
of the extracted spectra if the values are None in the S4 ecf.

I've confirmed that this still passes the pytest tests.