### PR TITLE
Only one plt.figure per type, overwrite if need

### DIFF
--- a/eureka/S2_calibrations/s2_calibrate.py
+++ b/eureka/S2_calibrations/s2_calibrate.py
@@ -244,11 +244,11 @@ class EurekaSpec2Pipeline(Spec2Pipeline):
             log.writelog('\nGenerating x1dints figure')
             m = np.where(meta.segment_list==filename)[0][0]+1
             max_m = meta.num_data_files
-            fig_number = '11'+str(m).zfill(np.max([int(np.floor(np.log10(max_m))+1),2]))
+            fig_number = '11'+str(m).zfill(int(np.floor(np.log10(max_m))+1))
             fname = 'fig{}_'.format(fig_number)+'_'.join(filename.split('/')[-1].split('_')[:-1])+'_x1dints'
             x1d_fname = '_'.join(filename.split('/')[-1].split('_')[:-1])+'_x1dints'
             with datamodels.open(meta.outputdir+x1d_fname+'.fits') as sp1d:
-                plt.figure(int(fig_number), figsize=[15,5])
+                plt.figure(int('11{}'.format(str(0).zfill(int(np.floor(np.log10(max_m))+1)))), figsize=[15,5])
                 plt.clf()
                 
                 for i in range(len(sp1d.spec)):

--- a/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/eureka/S4_generate_lightcurves/plots_s4.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 
 
 def binned_lightcurve(meta, time, i):
-    '''Plot each spectroscopic light curve.
+    '''Plot each spectroscopic light curve. (Fig 4300)
 
     Parameters
     ----------
@@ -18,7 +18,7 @@ def binned_lightcurve(meta, time, i):
     -------
     None
     '''
-    plt.figure(4300 + i, figsize=(8, 6))
+    plt.figure(int('43{}'.format(str(0).zfill(int(np.floor(np.log10(meta.nspecchan))+1)))), figsize=(8, 6))
     plt.clf()
     plt.suptitle(f"Bandpass {i}: %.3f - %.3f" % (meta.wave_low[i], meta.wave_hi[i]))
     ax = plt.subplot(111)
@@ -33,12 +33,12 @@ def binned_lightcurve(meta, time, i):
     plt.xlabel(f'Time [{meta.time_units} - {time_modifier}]')
 
     plt.subplots_adjust(left=0.10, right=0.95, bottom=0.10, top=0.90, hspace=0.20, wspace=0.3)
-    plt.savefig(meta.outputdir + 'figs/Fig' + str(4300 + i) + '-' + meta.eventlabel + '-1D_LC.png')
+    plt.savefig(meta.outputdir + 'figs/Fig43{}-1D_LC.png'.format(str(i).zfill(int(np.floor(np.log10(meta.nspecchan))+1))))
     if not meta.hide_plots:
         plt.pause(0.2)
 
 def drift1d(meta):
-    '''Plot the 1D drift/jitter results.
+    '''Plot the 1D drift/jitter results. (Fig 4100)
 
     Parameters
     ----------
@@ -49,25 +49,18 @@ def drift1d(meta):
     -------
     None
     '''
-    plt.figure(4101, figsize=(8,4))
+    plt.figure(int('41{}'.format(str(0).zfill(int(np.floor(np.log10(meta.nspecchan))+1)))), figsize=(8, 4))
     plt.clf()
     plt.plot(np.arange(meta.n_int)[np.where(meta.driftmask)], meta.drift1d[np.where(meta.driftmask)], '.')
-    # plt.subplot(211)
-    # for j in range(istart,ev.n_reads-1):
-    #     plt.plot(ev.drift2D[:,j,1],'.')
-    # plt.ylabel('Spectrum Drift Along y')
-    # plt.subplot(212)
-    # for j in range(istart,ev.n_reads-1):
-    #     plt.plot(ev.drift2D[:,j,0]+ev.drift[:,j],'.')
     plt.ylabel('Spectrum Drift Along x')
     plt.xlabel('Frame Number')
     plt.tight_layout()
-    plt.savefig(meta.outputdir + 'figs/Fig4101-Drift.png')
+    plt.savefig(meta.outputdir + 'figs/Fig41{}-Drift.png'.format(str(0).zfill(int(np.floor(np.log10(meta.nspecchan))+1))))
     if not meta.hide_plots:
         plt.pause(0.2)
 
 def lc_driftcorr(meta, wave_1d, optspec):
-    '''Plot a 2D light curve with drift correction.
+    '''Plot a 2D light curve with drift correction. (Fig 4200)
 
     Parameters
     ----------
@@ -82,7 +75,7 @@ def lc_driftcorr(meta, wave_1d, optspec):
     -------
     None
     '''
-    plt.figure(4102, figsize=(8, 8))  # ev.n_files/20.+0.8))
+    plt.figure(int('42{}'.format(str(0).zfill(int(np.floor(np.log10(meta.nspecchan))+1)))), figsize=(8, 8))
     plt.clf()
     wmin = wave_1d.min()
     wmax = wave_1d.max()
@@ -106,14 +99,14 @@ def lc_driftcorr(meta, wave_1d, optspec):
     plt.xlabel(r'Wavelength ($\mu m$)')
     plt.colorbar(label='Normalized Flux')
     plt.tight_layout()
-    plt.savefig(meta.outputdir + 'figs/fig4102-2D_LC.png')
+    plt.savefig(meta.outputdir + 'figs/Fig42{}-2D_LC.png'.format(str(0).zfill(int(np.floor(np.log10(meta.nspecchan))+1))))
     if meta.hide_plots:
         plt.close()
     else:
         plt.pause(0.2)
 
 def cc_spec(meta, ref_spec, fit_spec, n):
-    '''Compare the spectrum used for cross-correlation with the current spectrum.
+    '''Compare the spectrum used for cross-correlation with the current spectrum (Fig 4400).
 
     Parameters
     ----------
@@ -130,7 +123,7 @@ def cc_spec(meta, ref_spec, fit_spec, n):
     -------
     None
     '''
-    plt.figure(4500)
+    plt.figure(int('44{}'.format(str(0).zfill(int(np.floor(np.log10(meta.nspecchan))+1)))), figsize=(8, 8))
     plt.clf()
     plt.title(f'Cross Correlation - Spectrum {n}')
     nx = len(ref_spec)
@@ -138,12 +131,12 @@ def cc_spec(meta, ref_spec, fit_spec, n):
     plt.plot(range(meta.drift_range,nx-meta.drift_range), fit_spec, '-', label='Current Spectrum')
     plt.legend(loc='best')
     plt.tight_layout()
-    plt.savefig(meta.outputdir + f'figs/Fig4500-{n}-CC_Spec')
+    plt.savefig(meta.outputdir + 'figs/Fig44{}-CC_Spec.png'.format(str(n).zfill(int(np.floor(np.log10(meta.nspecchan))+1))))
     if not meta.hide_plots:
         plt.pause(0.2)
 
 def cc_vals(meta, vals, n):
-    '''Make the cross-correlation strength plot.
+    '''Make the cross-correlation strength plot (Fig 4500).
 
     Parameters
     ----------
@@ -158,11 +151,11 @@ def cc_vals(meta, vals, n):
     -------
     None
     '''
-    plt.figure(4501)
+    plt.figure(int('45{}'.format(str(0).zfill(int(np.floor(np.log10(meta.nspecchan))+1)))), figsize=(8, 8))
     plt.clf()
     plt.title(f'Cross Correlation - Values {n}')
     plt.plot(range(-meta.drift_range,meta.drift_range+1), vals, '.')
     plt.tight_layout()
-    plt.savefig(meta.outputdir + f'figs/Fig4501-{n}-CC_Vals')
+    plt.savefig(meta.outputdir + 'figs/Fig45{}-CC_Vals.png'.format(str(n).zfill(int(np.floor(np.log10(meta.nspecchan))+1))))
     if not meta.hide_plots:
         plt.pause(0.2)

--- a/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -8,7 +8,7 @@ from .likelihood import computeRMS
 from .utils import COLORS
 
 def plot_fit(lc, model, meta, fitter, isTitle=True):
-    """Plot the fitted model over the data.
+    """Plot the fitted model over the data. (Fig 5100)
 
     Parameters
     ----------
@@ -63,7 +63,7 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
             model_phys = model_phys[channel*len(new_time):(channel+1)*len(new_time)]
 
         residuals = flux - model
-        fig = plt.figure(int('51{}'.format(str(channel).zfill(len(str(lc.nchannel))))), figsize=(8, 6))
+        fig = plt.figure(int('51{}'.format(str(0).zfill(len(str(lc.nchannel))))), figsize=(8, 6))
         plt.clf()
         ax = fig.subplots(3,1)
         ax[0].errorbar(lc.time, flux, yerr=unc, fmt='.', color='w', ecolor=color, mec=color)
@@ -91,7 +91,7 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
     return
 
 def plot_rms(lc, model, meta, fitter):
-    """Plot an Allan plot to look for red noise.
+    """Plot an Allan plot to look for red noise. (Fig 5200)
 
     Parameters
     ----------
@@ -136,7 +136,7 @@ def plot_rms(lc, model, meta, fitter):
         rms, stderr, binsz = computeRMS(residuals, binstep=1)
         normfactor = 1e-6
         plt.rcParams.update({'legend.fontsize': 11}) # FINDME: this should not be done here but where the rcparams are defined for Eureka
-        plt.figure(int('52{}'.format(str(channel).zfill(len(str(lc.nchannel))))), figsize=(8, 6))
+        plt.figure(int('52{}'.format(str(0).zfill(len(str(lc.nchannel))))), figsize=(8, 6))
         plt.clf()
         plt.suptitle(' Correlated Noise', size=16)
         plt.loglog(binsz, rms / normfactor, color='black', lw=1.5, label='Fit RMS', zorder=3)  # our noise
@@ -158,7 +158,7 @@ def plot_rms(lc, model, meta, fitter):
     return
 
 def plot_corner(samples, lc, meta, freenames, fitter):
-    """Plot a corner plot.
+    """Plot a corner plot. (Fig 5300)
 
     Parameters
     ----------
@@ -184,7 +184,7 @@ def plot_corner(samples, lc, meta, freenames, fitter):
     - December 29, 2021 Taylor Bell
         Moved plotting code to a separate function.
     """
-    fig = plt.figure(int('53{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))), figsize=(8, 6))
+    fig = plt.figure(int('53{}'.format(str(0).zfill(len(str(lc.nchannel))))), figsize=(8, 6))
     fig = corner.corner(samples, fig=fig, show_titles=True,quantiles=[0.16, 0.5, 0.84],title_fmt='.4', labels=freenames)
     fname = 'figs/fig53{}_corner_{}.png'.format(str(lc.channel).zfill(len(str(lc.nchannel))), fitter)
     fig.savefig(meta.outputdir+fname, bbox_inches='tight', pad_inches=0.05, dpi=250)
@@ -196,7 +196,7 @@ def plot_corner(samples, lc, meta, freenames, fitter):
     return
 
 def plot_chain(samples, lc, meta, freenames, fitter='emcee', burnin=False, nburn=0, nrows=3, ncols=4, nthin=1):
-    """Plot the evolution of the chain to look for temporal trends
+    """Plot the evolution of the chain to look for temporal trends (Fig 5400)
 
     Parameters
     ----------
@@ -237,7 +237,7 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', burnin=False, nburn
 
     k = 0
     for plot_number in range(nplots):
-        fig, axes = plt.subplots(nrows, ncols, num=int('55{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))), sharex=True, figsize=(6*ncols, 4*nrows))
+        fig, axes = plt.subplots(nrows, ncols, num=int('54{}'.format(str(0).zfill(len(str(lc.nchannel))))), sharex=True, figsize=(6*ncols, 4*nrows))
 
         for j in range(ncols):
             for i in range(nrows):
@@ -263,7 +263,7 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', burnin=False, nburn
                 k += 1
         fig.tight_layout(h_pad=0.0)
 
-        fname = 'figs/fig55{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))
+        fname = 'figs/fig54{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))
         if burnin:
             fname += '_burninchain'
         else:
@@ -281,7 +281,7 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', burnin=False, nburn
     return
 
 def plot_res_distr(lc, model, meta, fitter):
-    """Plot the normalized distribution of residuals + a Gaussian
+    """Plot the normalized distribution of residuals + a Gaussian. (Fig 5500)
 
     Parameters
     ----------
@@ -311,7 +311,7 @@ def plot_res_distr(lc, model, meta, fitter):
     time = lc.time
     model_lc = model.eval()
 
-    plt.figure(int('55{}'.format(str(lc.channel).zfill(len(str(lc.nchannel))))), figsize=(8, 6))
+    plt.figure(int('55{}'.format(str(0).zfill(len(str(lc.nchannel))))), figsize=(8, 6))
 
 
     for channel in lc.fitted_channels:


### PR DESCRIPTION
Rather than opening Fig4300, Fig4301, Fig4302, etc., just open a Fig4300
with plt.figure and then overwrite that figure as needed to avoid
excessive RAM usage. This does not change the output filename, just
reduces the number of plots we open.