### PR TITLE
Updating CRDS instructions for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ GitHub following the method described below.
 	pip install .
 	```
 
-3. Set JWST CRDS environment variables. Eureka! installs the JWST Calibration Pipeline, and these variables need to be set for the calibration steps to properly run. The best practice for doing this is to add these two lines to your .bashrc (or equivalent shell startup script).
+3. Set JWST CRDS environment variables. Eureka! installs the JWST Calibration Pipeline, and these variables need to be set for the calibration steps to properly run. The best practice for doing this is to add these two lines to your .zshrc (for Mac users) or .bashrc (for bash users), or equivalent shell startup script.
 
 	```bash
 	export CRDS_PATH=/PATH/TO/FOLDER/crds_cache	

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -50,7 +50,7 @@ CRDS Environment Variables
 --------------------------
 
 Eureka! installs the JWST Calibration Pipeline as part of its requirements, and this also requires users to set the proper environment variables so that it can download the proper reference files needed to run the pipeline. 
-For users not on the internal STScI network, two environment variables need to be set to enable this functionality. In your .bashrc file, or other shell initialization file, add these two lines:
+For users not on the internal STScI network, two environment variables need to be set to enable this functionality. In your .zshrc (for Mac users) or .bashrc file (for bash users), or other shell initialization file, add these two lines:
 
 	.. code-block:: bash
 


### PR DESCRIPTION
Updated instructions for setting CRDS environment variables to make things more explicit for Mac users on the Z shell.