### PR TITLE
Removing requirement for astropy<5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asdf==2.8.1
-astropy<5.0.0
+astropy
 astroquery>=0.4.2
 batman-package
 bokeh


### PR DESCRIPTION
This was added by Adina for an older jwst version and is no longer
needed.

This resolves #197