### PR TITLE
Cleaning up ecf templates

### DIFF
--- a/demos/JWST/S1_miri_template.ecf
+++ b/demos/JWST/S1_miri_template.ecf
@@ -1,40 +1,40 @@
 # Eureka! Control File for Stage 1: Detector Processing
 
-suffix 						uncal
+suffix              uncal
 
 # Control ramp fitting method
-ramp_fit_algorithm				'default' 	#Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores 				'none'  		#Options are 'none', quarter', 'half','all'
+ramp_fit_algorithm  'default'   #Options are 'default', 'mean', or 'differenced'
+ramp_fit_max_cores  'none'  #Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
-skip_group_scale			False
-skip_dq_init				False
-skip_saturation				False
-skip_ipc					True	#Skipped by default for all instruments
-skip_firstframe				True    #Skipped by default for MIRI TSO
-skip_lastframe				True
-skip_refpix					False
-skip_linearity				False
-skip_rscd					True	#Skipped by default for MIRI TSO
-skip_dark_current			False
-skip_jump					False
-skip_ramp_fitting			False
-skip_gain_scale				False
+skip_group_scale    False
+skip_dq_init        False
+skip_saturation     False
+skip_ipc            True    #Skipped by default for all instruments
+skip_firstframe     True    #Skipped by default for MIRI TSO
+skip_lastframe      True
+skip_refpix         False
+skip_linearity      False
+skip_rscd           True    #Skipped by default for MIRI TSO
+skip_dark_current   False
+skip_jump           False
+skip_ramp_fitting   False
+skip_gain_scale     False
 
 # Project directory
-topdir						/home/User
+topdir              /home/User
 
 # Directories relative to project directory
-inputdir					/Data/JWST-Sim/MIRI/Uncalibrated
-outputdir					/Data/JWST-Sim/MIRI/Stage1
+inputdir            /Data/JWST-Sim/NIRCam/Uncalibrated
+outputdir           /Data/JWST-Sim/NIRCam/Stage1
 
 # Diagnostics
-testing_S1					False
+testing_S1          False
 
 #####
 
 # "Default" ramp fitting settings
-default_ramp_fit_weighting  			default		#Options are "default", "fixed", "interpolated", "flat", or "custom"
-default_ramp_fit_fixed_exponent 		10			#Only used for "fixed" weighting
-default_ramp_fit_custom_snr_bounds		[5,10,20,50,100]	# Only used for "custom" weighting, array no spaces
-default_ramp_fit_custom_exponents		[0.4,1,3,6,10]		# Only used for "custom" weighting, array no spaces
+default_ramp_fit_weighting          default             #Options are "default", "fixed", "interpolated", "flat", or "custom"
+default_ramp_fit_fixed_exponent     10                  #Only used for "fixed" weighting
+default_ramp_fit_custom_snr_bounds  [5,10,20,50,100]    # Only used for "custom" weighting, array no spaces
+default_ramp_fit_custom_exponents   [0.4,1,3,6,10]      # Only used for "custom" weighting, array no spaces

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -1,39 +1,39 @@
 # Eureka! Control File for Stage 1: Detector Processing
 
-suffix 							uncal
+suffix              uncal
 
 # Control ramp fitting method
-ramp_fit_algorithm				'default' 	#Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores 				'none'  		#Options are 'none', quarter', 'half','all'
+ramp_fit_algorithm  'default'   #Options are 'default', 'mean', or 'differenced'
+ramp_fit_max_cores  'none'  #Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
-skip_group_scale				False
-skip_dq_init					False
-skip_saturation					False
-skip_ipc						True			#Skipped by default for all instruments
-skip_superbias					False
-skip_refpix						False
-skip_linearity					False
-skip_persistence				True			#Skipped by default for Near-IR TSO
-skip_dark_current				False
-skip_jump						False
-skip_ramp_fitting				False
-skip_gain_scale					False
+skip_group_scale    False
+skip_dq_init        False
+skip_saturation     False
+skip_ipc            True    #Skipped by default for all instruments
+skip_superbias      False
+skip_refpix         False
+skip_linearity      False
+skip_persistence    True    #Skipped by default for Near-IR TSO
+skip_dark_current   False
+skip_jump           False
+skip_ramp_fitting   False
+skip_gain_scale     False
 
 # Project directory
-topdir							/home/User
+topdir              /home/User
 
 # Directories relative to project directory
-inputdir					/Data/JWST-Sim/NIRCam/Uncalibrated
-outputdir					/Data/JWST-Sim/NIRCam/Stage1
+inputdir            /Data/JWST-Sim/NIRCam/Uncalibrated
+outputdir           /Data/JWST-Sim/NIRCam/Stage1
 
 # Diagnostics
-testing_S1						False
+testing_S1          False
 
 #####
 
 # "Default" ramp fitting settings
-default_ramp_fit_weighting  			default		#Options are "default", "fixed", "interpolated", "flat", or "custom"
-default_ramp_fit_fixed_exponent 		10			#Only used for "fixed" weighting
-default_ramp_fit_custom_snr_bounds		[5,10,20,50,100]	# Only used for "custom" weighting, array no spaces
-default_ramp_fit_custom_exponents		[0.4,1,3,6,10]		# Only used for "custom" weighting, array no spaces
+default_ramp_fit_weighting          default             #Options are "default", "fixed", "interpolated", "flat", or "custom"
+default_ramp_fit_fixed_exponent     10                  #Only used for "fixed" weighting
+default_ramp_fit_custom_snr_bounds  [5,10,20,50,100]    # Only used for "custom" weighting, array no spaces
+default_ramp_fit_custom_exponents   [0.4,1,3,6,10]      # Only used for "custom" weighting, array no spaces

--- a/demos/JWST/S2_imaging_template.ecf
+++ b/demos/JWST/S2_imaging_template.ecf
@@ -1,20 +1,20 @@
 # Eureka! Control File for Stage 2: Data Reduction
 
-suffix      rateints     # Data file suffix
+suffix              rateints     # Data file suffix
 
 # Note: different instruments and modes will use different steps by default
-skip_bkg_subtract		True	# Not run for TSO observations
-skip_flat_field			False
-skip_photom				True
-skip_resample			True	# Not run for TSO observations
+skip_bkg_subtract   True    # Not run for TSO observations
+skip_flat_field     False
+skip_photom         True
+skip_resample       True    # Not run for TSO observations
 
 # Diagnostics
-testing_S2	False
-hide_plots	False	# If True, plots will automatically be closed rather than popping up
+testing_S2          False
+hide_plots          False   # If True, plots will automatically be closed rather than popping up
 
 # Project directory
-topdir      /home/User/
+topdir              /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRCam/Stage1
-outputdir	/Data/JWST-Sim/NIRCam/Stage2
+inputdir            /Data/JWST-Sim/NIRCam/Stage1
+outputdir           /Data/JWST-Sim/NIRCam/Stage2

--- a/demos/JWST/S2_miri_lrs_template.ecf
+++ b/demos/JWST/S2_miri_lrs_template.ecf
@@ -1,40 +1,40 @@
 # Eureka! Control File for Stage 2: Data Reduction
 
-suffix      rateints     # Data file suffix
+suffix                  rateints    # Data file suffix
 
 # Controls the cross-dispersion extraction
-slit_y_low			None	# Use None to rely on the default parameters
-slit_y_high			None	# Use None to rely on the default parameters
+slit_y_low              None    # Use None to rely on the default parameters
+slit_y_high             None    # Use None to rely on the default parameters
 
 # Modify the existing file to change the dispersion extraction - FIX: DOES NOT WORK CURRENTLY
-waverange_start		None	# Use None to rely on the default parameters
-waverange_end		None	# Use None to rely on the default parameters
+waverange_start         None    # Use None to rely on the default parameters
+waverange_end           None    # Use None to rely on the default parameters
 
 # Note: different instruments and modes will use different steps by default
-skip_bkg_subtract		True	# Not run for MIRI LRS Slitless
-skip_imprint_subtract	True	# Not run for MIRI LRS Slitless
-skip_msa_flagging		True	# Not run for MIRI LRS Slitless
-skip_extract_2d			True	# Not run for MIRI LRS Slitless
-skip_srctype			False
-skip_master_background	True	# Not run for MIRI LRS Slitless
-skip_wavecorr			True	# Not run for MIRI LRS Slitless
-skip_flat_field			False
-skip_straylight			True	# Not run for MIRI LRS Slitless
-skip_fringe				True	# Not run for MIRI LRS Slitless
-skip_pathloss			True	# Not run for MIRI LRS Slitless
-skip_barshadow			True	# Not run for MIRI LRS Slitless
-skip_photom				False
-skip_resample			True	# Not run for MIRI LRS Slitless
-skip_cube_build			True	# Not run for MIRI LRS Slitless
-skip_extract_1d			False
+skip_bkg_subtract       True    # Not run for MIRI LRS Slitless
+skip_imprint_subtract   True    # Not run for MIRI LRS Slitless
+skip_msa_flagging       True    # Not run for MIRI LRS Slitless
+skip_extract_2d         True    # Not run for MIRI LRS Slitless
+skip_srctype            False
+skip_master_background  True    # Not run for MIRI LRS Slitless
+skip_wavecorr           True    # Not run for MIRI LRS Slitless
+skip_flat_field         False
+skip_straylight         True    # Not run for MIRI LRS Slitless
+skip_fringe             True    # Not run for MIRI LRS Slitless
+skip_pathloss           True    # Not run for MIRI LRS Slitless
+skip_barshadow          True    # Not run for MIRI LRS Slitless
+skip_photom             True
+skip_resample           True    # Not run for MIRI LRS Slitless
+skip_cube_build         True    # Not run for MIRI LRS Slitless
+skip_extract_1d         False
 
 # Diagnostics
-testing_S2	False
-hide_plots	False	# If True, plots will automatically be closed rather than popping up
+testing_S2              False
+hide_plots              False   # If True, plots will automatically be closed rather than popping up
 
 # Project directory
-topdir      /home/User/
+topdir                  /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/MIRI/Stage1
-outputdir	/Data/JWST-Sim/MIRI/Stage2
+inputdir                /Data/JWST-Sim/MIRI/Stage1
+outputdir               /Data/JWST-Sim/MIRI/Stage2

--- a/demos/JWST/S2_nircam_wfss_template.ecf
+++ b/demos/JWST/S2_nircam_wfss_template.ecf
@@ -1,40 +1,40 @@
 # Eureka! Control File for Stage 2: Data Reduction
 
-suffix      rateints     # Data file suffix
+suffix                  rateints     # Data file suffix
 
 # Controls the cross-dispersion extraction
-slit_y_low			None	# Use None to rely on the default parameters
-slit_y_high			None	# Use None to rely on the default parameters
+slit_y_low              None    # Use None to rely on the default parameters
+slit_y_high             None    # Use None to rely on the default parameters
 
 # Modify the existing file to change the dispersion extraction - FIX: DOES NOT WORK CURRENTLY
-waverange_start		None	# Use None to rely on the default parameters
-waverange_end		None	# Use None to rely on the default parameters
+waverange_start         None    # Use None to rely on the default parameters
+waverange_end           None    # Use None to rely on the default parameters
 
 # Note: different instruments and modes will use different steps by default
-skip_bkg_subtract		False	# Not run for TSO observations
-skip_imprint_subtract	True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_msa_flagging		True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_extract_2d			False
-skip_srctype			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_master_background	True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_wavecorr			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_flat_field			False
-skip_straylight			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_fringe				True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_pathloss			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_barshadow			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_photom				False
-skip_resample			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_cube_build			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_extract_1d			False
+skip_bkg_subtract       False   # Not run for TSO observations
+skip_imprint_subtract   True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_msa_flagging       True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_extract_2d         False
+skip_srctype            True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_master_background  True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_wavecorr           True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_flat_field         False
+skip_straylight         True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_fringe             True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_pathloss           True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_barshadow          True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_photom             True
+skip_resample_spec      True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_cube_build         True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_extract_1d         False
 
 # Diagnostics
-testing_S2 	False
-hide_plots	False	# If True, plots will automatically be closed rather than popping up
+testing_S2              False
+hide_plots              False   # If True, plots will automatically be closed rather than popping up
 
 # Project directory
-topdir      /home/User/
+topdir                  /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRCam/Stage1
-outputdir	/Data/JWST-Sim/NIRCam/Stage2
+inputdir                /Data/JWST-Sim/NIRCam/Stage1
+outputdir               /Data/JWST-Sim/NIRCam/Stage2

--- a/demos/JWST/S2_nirspec_fs_template.ecf
+++ b/demos/JWST/S2_nirspec_fs_template.ecf
@@ -1,40 +1,40 @@
 # Eureka! Control File for Stage 2: Data Reduction
 
-suffix      rateints     # Data file suffix
+suffix                  rateints    # Data file suffix
 
 # Controls the cross-dispersion extraction
-slit_y_low			-1	# Use None to rely on the default parameters
-slit_y_high			50	# Use None to rely on the default parameters
+slit_y_low              -1      # Use None to rely on the default parameters
+slit_y_high             50      # Use None to rely on the default parameters
 
 # Modify the existing file to change the dispersion extraction - FIX: DOES NOT WORK CURRENTLY
-waverange_start		6e-08	# Use None to rely on the default parameters
-waverange_end		6e-06	# Use None to rely on the default parameters
+waverange_start         6e-08   # Use None to rely on the default parameters
+waverange_end           6e-06   # Use None to rely on the default parameters
 
 # Note: different instruments and modes will use different steps by default
-skip_bkg_subtract		False	# Not run for TSO observations
-skip_imprint_subtract	True	# Not run for NIRSpec Fixed Slit
-skip_msa_flagging		True	# Not run for NIRSpec Fixed Slit
-skip_extract_2d			False
-skip_srctype			False
-skip_master_background	True	# Not run for NIRSpec Fixed Slit
-skip_wavecorr			False
-skip_flat_field			True	# ***NOTE*** At the time the NIRSpec ERS Hackathon simulated data was created, this step did not work correctly and is by default turned off.
-skip_straylight			True	# Not run for NIRSpec Fixed Slit
-skip_fringe				True	# Not run for NIRSpec Fixed Slit
-skip_pathloss			False	# Not run for TSO observations
-skip_barshadow			True	# Not run for NIRSpec Fixed Slit
-skip_photom				False
-skip_resample			False	# Not run for TSO observations
-skip_cube_build			True	# Not run for NIRSpec Fixed Slit
-skip_extract_1d			False
+skip_bkg_subtract       False   # Not run for TSO observations
+skip_imprint_subtract   True    # Not run for NIRSpec Fixed Slit
+skip_msa_flagging       True    # Not run for NIRSpec Fixed Slit
+skip_extract_2d         False
+skip_srctype            False
+skip_master_background  True    # Not run for NIRSpec Fixed Slit
+skip_wavecorr           False
+skip_flat_field         True    # ***NOTE*** At the time the NIRSpec ERS Hackathon simulated data was created, this step did not work correctly and is by default turned off.
+skip_straylight         True    # Not run for NIRSpec Fixed Slit
+skip_fringe             True    # Not run for NIRSpec Fixed Slit
+skip_pathloss           False   # Not run for TSO observations
+skip_barshadow          True    # Not run for NIRSpec Fixed Slit
+skip_photom             True
+skip_resample           False   # Not run for TSO observations
+skip_cube_build         True    # Not run for NIRSpec Fixed Slit
+skip_extract_1d         False
 
 # Diagnostics
-testing_S2 	False
-hide_plots	False	# If True, plots will automatically be closed rather than popping up
+testing_S2              False
+hide_plots              False   # If True, plots will automatically be closed rather than popping up
 
 # Project directory
-topdir      /home/User/
+topdir                  /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRSpec/Stage1
-outputdir	/Data/JWST-Sim/NIRSpec/Stage2
+inputdir                /Data/JWST-Sim/NIRSpec/Stage1
+outputdir               /Data/JWST-Sim/NIRSpec/Stage2

--- a/demos/JWST/S3_miri_lrs_template.ecf
+++ b/demos/JWST/S3_miri_lrs_template.ecf
@@ -1,38 +1,38 @@
 # Eureka! Control File for Stage 3: Data Reduction
 
-ncpu		1          # Number of CPUs
-suffix		calints     # Data file suffix
+ncpu            1           # Number of CPUs
+suffix          calints     # Data file suffix
 
 # Subarray region of interest
-ywindow     [150,380]	# Vertical axis as seen in DS9
-xwindow     [7,70]		# Horizontal axis as seen in DS9
-src_pos_type gaussian   # Determine source position when not given in header (Options: gaussian, weighted, or max)
+ywindow         [150,380]   # Vertical axis as seen in DS9
+xwindow         [7,70]      # Horizontal axis as seen in DS9
+src_pos_type    gaussian    # Determine source position when not given in header (Options: gaussian, weighted, or max)
 
 # Background parameters
-bg_hw       17          # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
-bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
-p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
-save_bgsub  False      # Whether or not to save background subtracted FITS files
+bg_hw           8           # Half-width of exclusion region for BG subtraction (relative to source position)
+bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
+bg_deg          1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
+p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub      False       # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
-spec_hw     4           # Half-width of aperture region for spectral extraction (relative to source position)
-fittype     meddata     # Method for constructing spatial profile (Options: smooth, meddata, poly, gauss, wavelet, or wavelet2D)
-window_len  31          # Smoothing window length, when fittype = smooth
-prof_deg    3           # Polynomial degree, when fittype = poly
-p5thresh    10          # X-sigma threshold for outlier rejection while constructing spatial profile
-p7thresh    10          # X-sigma threshold for outlier rejection during optimal spectral extraction
+spec_hw         4           # Half-width of aperture region for spectral extraction (relative to source position)
+fittype         meddata     # Method for constructing spatial profile (Options: smooth, meddata, poly, gauss, wavelet, or wavelet2D)
+window_len      31          # Smoothing window length, when fittype = smooth
+prof_deg        3           # Polynomial degree, when fittype = poly
+p5thresh        10          # X-sigma threshold for outlier rejection while constructing spatial profile
+p7thresh        10          # X-sigma threshold for outlier rejection during optimal spectral extraction
 
 # Diagnostics
-isplots_S3  3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-testing_S3  False       # Boolean, set True to only use last file and generate select figures
-hide_plots	False       # If True, plots will automatically be closed rather than popping up
-save_output True        # Save outputs for use in S4
-verbose     False       # If True, more details will be printed about steps
+isplots_S3      3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+testing_S3      False       # Boolean, set True to only use last file and generate select figures
+hide_plots      False       # If True, plots will automatically be closed rather than popping up
+save_output     True        # Save outputs for use in S4
+verbose         False       # If True, more details will be printed about steps
 
 # Project directory
-topdir      /home/User
+topdir          /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/MIRI/Stage2	# The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
-outputdir	/Data/JWST-Sim/MIRI/Stage3
+inputdir        /Data/JWST-Sim/MIRI/Stage2/   # The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
+outputdir       /Data/JWST-Sim/MIRI/Stage3/

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -1,38 +1,38 @@
 # Eureka! Control File for Stage 3: Data Reduction
 
-ncpu        1           # Number of CPUs
-suffix      calints     # Data file suffix
+ncpu            1           # Number of CPUs
+suffix          calints     # Data file suffix
 
 # Subarray region of interest
-ywindow     [5,64]      # Vertical axis as seen in DS9
-xwindow     [100,1700]  # Horizontal axis as seen in DS9
-src_pos_type gaussian   # Determine source position when not given in header (Options: gaussian, weighted, or max)
+ywindow         [5,64]      # Vertical axis as seen in DS9
+xwindow         [100,1700]  # Horizontal axis as seen in DS9
+src_pos_type    gaussian    # Determine source position when not given in header (Options: gaussian, weighted, or max)
 
 # Background parameters
-bg_hw       8			# Half-width of exclusion region for BG subtraction (relative to source position).	To test multiple apertures, use the format [min_value,max_value,step_size]
-bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
-bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
-p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
-save_bgsub  False      # Whether or not to save background subtracted FITS files
+bg_hw           8           # Half-width of exclusion region for BG subtraction (relative to source position)
+bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
+bg_deg          1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
+p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub      False       # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
-spec_hw     8			# Half-width of aperture region for spectral extraction (relative to source position). To test multiple apertures, use the format [min_value,max_value,step_size]
-fittype     meddata     # Method for constructing spatial profile (Options: smooth, meddata, poly, gauss, wavelet, or wavelet2D)
-window_len  31          # Smoothing window length, when fittype = smooth
-prof_deg    3           # Polynomial degree, when fittype = poly
-p5thresh    10          # X-sigma threshold for outlier rejection while constructing spatial profile
-p7thresh    10          # X-sigma threshold for outlier rejection during optimal spectral extraction
+spec_hw         8           # Half-width of aperture region for spectral extraction (relative to source position)
+fittype         meddata     # Method for constructing spatial profile (Options: smooth, meddata, poly, gauss, wavelet, or wavelet2D)
+window_len      31          # Smoothing window length, when fittype = smooth
+prof_deg        3           # Polynomial degree, when fittype = poly
+p5thresh        10          # X-sigma threshold for outlier rejection while constructing spatial profile
+p7thresh        10          # X-sigma threshold for outlier rejection during optimal spectral extraction
 
 # Diagnostics
-isplots_S3  3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-testing_S3  False       # Boolean, set True to only use last file and generate select figures
-hide_plots	False		# If True, plots will automatically be closed rather than popping up
-save_output True        # Save outputs for use in S4
-verbose     False       # If True, more details will be printed about steps
+isplots_S3      3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+testing_S3      False       # Boolean, set True to only use last file and generate select figures
+hide_plots      False       # If True, plots will automatically be closed rather than popping up
+save_output     True        # Save outputs for use in S4
+verbose         False       # If True, more details will be printed about steps
 
 # Project directory
-topdir      /home/User
+topdir          /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRCam/Stage2	# The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
-outputdir	/Data/JWST-Sim/NIRCam/Stage3
+inputdir        /Data/JWST-Sim/NIRCam/Stage2/   # The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
+outputdir       /Data/JWST-Sim/NIRCam/Stage3/

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -1,38 +1,38 @@
 # Eureka! Control File for Stage 3: Data Reduction
 
-ncpu        1           # Number of CPUs
-suffix      calints     # Data file suffix
+ncpu            1           # Number of CPUs
+suffix          calints     # Data file suffix
 
 # Subarray region of interest
-ywindow     [2,28]      # Vertical axis as seen in DS9
-xwindow     [60,410]  # Horizontal axis as seen in DS9
-src_pos_type gaussian   # Determine source position when not given in header (Options: gaussian, weighted, or max)
+ywindow         [2,28]      # Vertical axis as seen in DS9
+xwindow         [60,410]    # Horizontal axis as seen in DS9
+src_pos_type    gaussian    # Determine source position when not given in header (Options: gaussian, weighted, or max)
 
 # Background parameters
-bg_hw       7          # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh   [10,10]       # Double-iteration X-sigma threshold for outlier rejection along time axis
-bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
-p3thresh    10           # X-sigma threshold for outlier rejection during background subtraction
-save_bgsub  False      # Whether or not to save background subtracted FITS files
+bg_hw           7           # Half-width of exclusion region for BG subtraction (relative to source position)
+bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
+bg_deg          1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
+p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub      False       # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
-spec_hw     6          # Half-width of aperture region for spectral extraction (relative to source position)
-fittype     smooth     # Method for constructing spatial profile (Options: smooth, meddata, poly, gauss, wavelet, or wavelet2D)
-window_len  11          # Smoothing window length, when fittype = smooth
-prof_deg    3           # Polynomial degree, when fittype = poly
-p5thresh    10          # X-sigma threshold for outlier rejection while constructing spatial profile
-p7thresh    60          # X-sigma threshold for outlier rejection during optimal spectral extraction
+spec_hw         6           # Half-width of aperture region for spectral extraction (relative to source position)
+fittype         smooth      # Method for constructing spatial profile (Options: smooth, meddata, poly, gauss, wavelet, or wavelet2D)
+window_len      11          # Smoothing window length, when fittype = smooth
+prof_deg        3           # Polynomial degree, when fittype = poly
+p5thresh        10          # X-sigma threshold for outlier rejection while constructing spatial profile
+p7thresh        60          # X-sigma threshold for outlier rejection during optimal spectral extraction
 
 # Diagnostics
-isplots_S3  3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-testing_S3  False       # Boolean, set True to only use last file and generate select figures
-hide_plots  True        # If True, plots will automatically be closed rather than popping up
-save_output True        # Save outputs for use in S4
-verbose     False       # If True, more details will be printed about steps
+isplots_S3      3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+testing_S3      False       # Boolean, set True to only use last file and generate select figures
+hide_plots      False       # If True, plots will automatically be closed rather than popping up
+save_output     True        # Save outputs for use in S4
+verbose         False       # If True, more details will be printed about steps
 
 # Project directory
-topdir      /home/User
+topdir          /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRSpec/Stage2	# The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
-outputdir	/Data/JWST-Sim/NIRSpec/Stage3
+inputdir        /Data/JWST-Sim/NIRSpec/Stage2/   # The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
+outputdir       /Data/JWST-Sim/NIRSpec/Stage3/

--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -1,10 +1,10 @@
 # Eureka! Control File for Stage 4: Generate Lightcurves 
 
 # Number of spectroscopic channels spread evenly over given wavelength range
-nspecchan   20          # Number of spectroscopic channels
-wave_min    2.4         # Minimum wavelength. Set to None to use the shortest extracted wavelength from Stage 3.
-wave_max    4.0         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
-allapers	True		# Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
+nspecchan       20          # Number of spectroscopic channels
+wave_min        2.4         # Minimum wavelength. Set to None to use the shortest extracted wavelength from Stage 3.
+wave_max        4.0         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
+allapers        True        # Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
 # Parameters for drift correction of 1D spectra
 correctDrift    False   # Set True to correct drift/jitter in 1D spectra (not recommended for simulated data)
@@ -14,24 +14,24 @@ drift_range     11      # Trim spectra by +/-X pixels to compute valid region of
 drift_hw        5       # Half-width in pixels used when fitting Gaussian, must be smaller than drift_range
 drift_iref      -1      # Index of reference spectrum used for cross correlation, -1 = last spectrum
 sub_mean        True    # Set True to subtract spectrum mean during cross correlation
-sub_continuum	True	# Set True to subtract the continuum from the spectra using a highpass filter
-highpassWidth	10		# The integer width of the highpass filter when subtracting the continuum
+sub_continuum   True    # Set True to subtract the continuum from the spectra using a highpass filter
+highpassWidth   10      # The integer width of the highpass filter when subtracting the continuum
 
 # Parameters for sigma clipping
-sigma_clip		False	# Whether or not sigma clipping should be performed on the 1D time series
-sigma			10		# The number of sigmas a point must be from the rolling median to be considered an outlier
-box_width		10		# The width of the box-car filter (used to calculated the rolling median) in units of number of data points
-maxiters		5		# The number of iterations of sigma clipping that should be performed.
-fill_value		mask	# Either the string 'mask' to mask the outlier values (recommended), 'boxcar' to replace data with the mean from the box-car filter, or a constant float-type fill value.
+sigma_clip      False   # Whether or not sigma clipping should be performed on the 1D time series
+sigma           10      # The number of sigmas a point must be from the rolling median to be considered an outlier
+box_width       10      # The width of the box-car filter (used to calculated the rolling median) in units of number of data points
+maxiters        5       # The number of iterations of sigma clipping that should be performed.
+fill_value      mask    # Either the string 'mask' to mask the outlier values (recommended), 'boxcar' to replace data with the mean from the box-car filter, or a constant float-type fill value.
 
 # Diagnostics
-isplots_S4  3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-hide_plots	False		# If True, plots will automatically be closed rather than popping up
-verbose     False       # If True, more details will be printed about steps
+isplots_S4      3       # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+hide_plots      False   # If True, plots will automatically be closed rather than popping up
+verbose         False   # If True, more details will be printed about steps
 
 # Project directory
-topdir      /home/User
+topdir          /home/User
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRCam/Stage3	# The folder containing the outputs from Eureka!'s S3 or JWST's S3 pipeline (will be overwritten if calling S3 and S4 sequentially)
-outputdir	/Data/JWST-Sim/NIRCam/Stage4
+inputdir        /Data/JWST-Sim/NIRCam/Stage3    # The folder containing the outputs from Eureka!'s S3 or JWST's S3 pipeline (will be overwritten if calling S3 and S4 sequentially)
+outputdir       /Data/JWST-Sim/NIRCam/Stage4

--- a/demos/JWST/S5_fit_par_template.ecf
+++ b/demos/JWST/S5_fit_par_template.ecf
@@ -1,15 +1,14 @@
-#Name	 	Value	 		Free?			PriorPar1		PriorPar2		PriorType
+#Name        Value         Free?          PriorPar1    PriorPar2    PriorType
 #PriorType can be U (Uniform), LU (Log Uniform), or N (Normal). If U/LU, PriorPar1 and PriorPar2 represent upper and lower limits of the parameter/log(the parameter). If N, PriorPar1 is the mean and PriorPar2 is the standard deviation of a Gaussian prior.
-rp			0.16			'free'			0.05			0.3				U
-per			0.813473978		'free'			0.813473978		0.000000035		N
-t0   		55528.353027	'free'			55528.34		55528.36		U
-time_offset	0				'independent'
-inc  		82.109	 		'free'			82.109			0.088			N
-a    		4.97			'free'			4.97			0.14			N
-ecc  		0.0	 			'fixed' 		0 				1				U
-w    		90.				'fixed' 		0 				180				U
-limb_dark	'quadratic' 	'independent'
-u1			0.3				'free'			-1				1				U
-u2			0.1				'free'			-1				1				U
-transittype	'primary'	 	'independent'
-c0			1.009			'free'			0.95			1.05			U
+rp           0.16          'free'         0.05         0.3          U
+per          0.813473978   'free'         0.813473978  0.000000035  N
+t0           55528.353027  'free'         55528.34     55528.36     U
+time_offset  0             'independent'
+inc          82.109        'free'         82.109       0.088        N
+a            4.97          'free'         4.97         0.14         N
+ecc          0.0           'fixed'        0            1            U
+w            90.           'fixed'        0            180          U
+limb_dark    'kipping2013'   'independent'
+u1           0.3           'free'         0            1            U
+u2           0.1           'free'         0            1            U
+c0           1             'free'         0.95         1.05         U

--- a/demos/JWST/S5_template.ecf
+++ b/demos/JWST/S5_template.ecf
@@ -2,12 +2,12 @@
 
 ncpu            1 # The number of CPU threads to use when running emcee or dynesty in parallel
 
-allapers        True # Run S5 on all of the apertures considered in S4? Otherwise will use newest output in the inputdir
-rescale_err     False    # Rescale uncertainties to have reduced chi-squared of unity
-fit_par         ./S5_fit_par_template.ecf # What fitting ecf do you want to use?
-verbose         True # If True, more details will be printed about steps
-fit_method      [dynesty] #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
-run_myfuncs     [batman_tr,polynomial] #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, and polynomial (can list multiple types separated by commas)
+allapers        True                    # Run S5 on all of the apertures considered in S4? Otherwise will use newest output in the inputdir
+rescale_err     False                   # Rescale uncertainties to have reduced chi-squared of unity
+fit_par         ./S5_fit_par_template.ecf   # What fitting ecf do you want to use?
+verbose         True                    # If True, more details will be printed about steps
+fit_method      [dynesty]               #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
+run_myfuncs     [batman_tr,polynomial]  #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, and polynomial (can list multiple types separated by commas)
 
 # Limb darkening controls (not yet implemented)
 #fix_ld          False #use limb darkening file?
@@ -15,33 +15,33 @@ run_myfuncs     [batman_tr,polynomial] #options are: batman_tr, batman_ecl, sinu
 
 #lsq
 lsq_method      'Nelder-Mead' # The scipy.optimize.minimize optimization method to use
-lsq_tol         1e-6 # The tolerance for the scipy.optimize.minimize optimization method
+lsq_tol         1e-6    # The tolerance for the scipy.optimize.minimize optimization method
 
 #mcmc
-old_chain       None # Output folder relative to topdir that contains an old emcee chain to resume where you left off (set to None to start from scratch)
+old_chain       None    # Output folder relative to topdir that contains an old emcee chain to resume where you left off (set to None to start from scratch)
 lsq_first       True    # Initialize with an initial lsq call (can help shorten burn-in, but turn off if lsq fails). Only used if old_chain is None
 run_nsteps      4000
 run_nwalkers    50
 run_nburn       2000
 
 #dynesty
-run_nlive       1024 # Must be > ndim * (ndim + 1) // 2
+run_nlive       1024    # Must be > ndim * (ndim + 1) // 2
 run_bound       'multi'
 run_sample      'unif'
 run_tol         0.1
 
 # Plotting controls
-interp          False    # Should astrophysical model be interpolated (useful for uneven sampling like that from HST)
+interp          False   # Should astrophysical model be interpolated (useful for uneven sampling like that from HST)
 
 # Diagnostics
-isplots_S5      5 # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-testing_S5      False # Boolean, set True to only use the first spectral channel
-testing_model   False # Boolean, set True to only inject a model source of systematics
-hide_plots      False # If True, plots will automatically be closed rather than popping up
+isplots_S5      5       # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+testing_S5      False   # Boolean, set True to only use the first spectral channel
+testing_model   False   # Boolean, set True to only inject a model source of systematics
+hide_plots      False   # If True, plots will automatically be closed rather than popping up
 
 # Project directory
 topdir          /home/User/
 
 # Directories relative to project dir
-inputdir        /Data/JWST-Sim/NIRCam/Stage4/    # The folder containing the outputs from Eureka!'s S4 pipeline (will be overwritten if calling S4 and S5 sequentially)
+inputdir        /Data/JWST-Sim/NIRCam/Stage4/   # The folder containing the outputs from Eureka!'s S4 pipeline (will be overwritten if calling S4 and S5 sequentially)
 outputdir       /Data/JWST-Sim/NIRCam/Stage5/

--- a/demos/JWST/S6_template.ecf
+++ b/demos/JWST/S6_template.ecf
@@ -3,34 +3,34 @@
 allapers        True # Run S6 on all of the apertures considered in S5? Otherwise will use newest output in the inputdir
 
 # Plotting parameters
-y_unit			(Rp/Rs)^2 # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
-y_scalar		100 # Can be used to convert to percent (100), ppm (1e6), etc.
-x_unit			um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
+y_unit          (Rp/Rs)^2 # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
+y_scalar        100 # Can be used to convert to percent (100), ppm (1e6), etc.
+x_unit          um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
 
 # This section is relevant if isplots_S6>=3
 # Scale height parameters (if you want a second copy of the plot with a second y-axis with units of scale height)
-star_Rad		0.6506 # The radius of the star in units of solar radii
-planet_Teq		1400 # The equilibrium temperature of the planet in units of Kelvin
-planet_Mass		2 # The planet's mass in units of Jupiter radii (used to calculate surface gravity)
-planet_Rad		None # The planet's radius in units of Jupiter radii (used to calculate surface gravity); Set to None to use the average fitted radius
-planet_mu		2.3 # The mean molecular mass of the atmosphere (in atomic mass units)
-planet_R0		None # The reference radius (in Jupiter radii) for the scale height measurement; Set to None to use the mean fitted radius
+star_Rad        0.6506 # The radius of the star in units of solar radii
+planet_Teq      1400 # The equilibrium temperature of the planet in units of Kelvin
+planet_Mass     2 # The planet's mass in units of Jupiter radii (used to calculate surface gravity)
+planet_Rad      None # The planet's radius in units of Jupiter radii (used to calculate surface gravity); Set to None to use the average fitted radius
+planet_mu       2.3 # The mean molecular mass of the atmosphere (in atomic mass units)
+planet_R0       None # The reference radius (in Jupiter radii) for the scale height measurement; Set to None to use the mean fitted radius
 
 # Diagnostics
 isplots_S6      5 # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-testing_S6		False
+testing_S6      False
 hide_plots      False # If True, plots will automatically be closed rather than popping up
 
 # Project directory
 topdir          /home/User/
 
 # Model to plot as well (path relative to project dir of a csv with col 1 as wavelength in microns, col 2 in the same units as the plotted spectrum, any headers preceded by a #)
-model_spectrum	None # Set to None if no model should be plotted
-model_x_unit	um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
-model_y_unit	Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
-model_y_scalar	1 # Indicate whether model y-values have already been scaled (e.g. write 1e-6 if model_spectrum is in ppm)
+model_spectrum  None # Set to None if no model should be plotted
+model_x_unit    um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
+model_y_unit    Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
+model_y_scalar  1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
 model_delimiter None #Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to project dir
-inputdir        /Data/JWST-Sim/NIRCam/Stage5/	# The folder containing the outputs from Eureka!'s S5 pipeline (will be overwritten if calling S5 and S6 sequentially)
+inputdir        /Data/JWST-Sim/NIRCam/Stage5/   # The folder containing the outputs from Eureka!'s S5 pipeline (will be overwritten if calling S5 and S6 sequentially)
 outputdir       /Data/JWST-Sim/NIRCam/Stage6/

--- a/docs/media/S1_template.ecf
+++ b/docs/media/S1_template.ecf
@@ -1,39 +1,39 @@
 # Eureka! Control File for Stage 1: Detector Processing
 
-suffix 							uncal
+suffix              uncal
 
 # Control ramp fitting method
-ramp_fit_algorithm				'default' 	#Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores 				'none'  		#Options are 'none', quarter', 'half','all'
+ramp_fit_algorithm  'default'   #Options are 'default', 'mean', or 'differenced'
+ramp_fit_max_cores  'none'  #Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
-skip_group_scale				False
-skip_dq_init					False
-skip_saturation					False
-skip_ipc						True			#Skipped by default for all instruments
-skip_superbias					False
-skip_refpix						False
-skip_linearity					False
-skip_persistence				True			#Skipped by default for Near-IR TSO
-skip_dark_current				False
-skip_jump						False
-skip_ramp_fitting				False
-skip_gain_scale					False
+skip_group_scale    False
+skip_dq_init        False
+skip_saturation     False
+skip_ipc            True    #Skipped by default for all instruments
+skip_superbias      False
+skip_refpix         False
+skip_linearity      False
+skip_persistence    True    #Skipped by default for Near-IR TSO
+skip_dark_current   False
+skip_jump           False
+skip_ramp_fitting   False
+skip_gain_scale     False
 
 # Project directory
-topdir							/home/User
+topdir              /home/User
 
 # Directories relative to project directory
-inputdir					/Data/JWST-Sim/NIRCam/Uncalibrated
-outputdir					/Data/JWST-Sim/NIRCam/Stage1
+inputdir            /Data/JWST-Sim/NIRCam/Uncalibrated
+outputdir           /Data/JWST-Sim/NIRCam/Stage1
 
 # Diagnostics
-testing_S1						False
+testing_S1          False
 
 #####
 
 # "Default" ramp fitting settings
-default_ramp_fit_weighting  			default		#Options are "default", "fixed", "interpolated", "flat", or "custom"
-default_ramp_fit_fixed_exponent 		10			#Only used for "fixed" weighting
-default_ramp_fit_custom_snr_bounds		[5,10,20,50,100]	# Only used for "custom" weighting, array no spaces
-default_ramp_fit_custom_exponents		[0.4,1,3,6,10]		# Only used for "custom" weighting, array no spaces
+default_ramp_fit_weighting          default             #Options are "default", "fixed", "interpolated", "flat", or "custom"
+default_ramp_fit_fixed_exponent     10                  #Only used for "fixed" weighting
+default_ramp_fit_custom_snr_bounds  [5,10,20,50,100]    # Only used for "custom" weighting, array no spaces
+default_ramp_fit_custom_exponents   [0.4,1,3,6,10]      # Only used for "custom" weighting, array no spaces

--- a/docs/media/S2_template.ecf
+++ b/docs/media/S2_template.ecf
@@ -1,40 +1,40 @@
 # Eureka! Control File for Stage 2: Data Reduction
 
-suffix      rateints     # Data file suffix
+suffix                  rateints     # Data file suffix
 
 # Controls the cross-dispersion extraction
-slit_y_low			None	# Use None to rely on the default parameters
-slit_y_high			None	# Use None to rely on the default parameters
+slit_y_low              None    # Use None to rely on the default parameters
+slit_y_high             None    # Use None to rely on the default parameters
 
 # Modify the existing file to change the dispersion extraction - FIX: DOES NOT WORK CURRENTLY
-waverange_start		None	# Use None to rely on the default parameters
-waverange_end		None	# Use None to rely on the default parameters
+waverange_start         None    # Use None to rely on the default parameters
+waverange_end           None    # Use None to rely on the default parameters
 
 # Note: different instruments and modes will use different steps by default
-skip_bkg_subtract		False	# Not run for TSO observations
-skip_imprint_subtract	True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_msa_flagging		True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_extract_2d			False
-skip_srctype			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_master_background	True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_wavecorr			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_flat_field			False
-skip_straylight			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_fringe				True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_pathloss			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_barshadow			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_photom				True
-skip_resample_spec		True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_cube_build			True	# Not run for NIRCam Wide-Field Slitless Spectroscopy
-skip_extract_1d			False
+skip_bkg_subtract       False   # Not run for TSO observations
+skip_imprint_subtract   True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_msa_flagging       True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_extract_2d         False
+skip_srctype            True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_master_background  True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_wavecorr           True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_flat_field         False
+skip_straylight         True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_fringe             True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_pathloss           True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_barshadow          True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_photom             True
+skip_resample_spec      True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_cube_build         True    # Not run for NIRCam Wide-Field Slitless Spectroscopy
+skip_extract_1d         False
 
 # Diagnostics
-testing_S2 	False
-hide_plots	False	# If True, plots will automatically be closed rather than popping up
+testing_S2              False
+hide_plots              False   # If True, plots will automatically be closed rather than popping up
 
 # Project directory
-topdir      /home/User/
+topdir                  /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRCam/Stage1
-outputdir	/Data/JWST-Sim/NIRCam/Stage2
+inputdir                /Data/JWST-Sim/NIRCam/Stage1
+outputdir               /Data/JWST-Sim/NIRCam/Stage2

--- a/docs/media/S3_template.ecf
+++ b/docs/media/S3_template.ecf
@@ -1,38 +1,38 @@
 # Eureka! Control File for Stage 3: Data Reduction
 
-ncpu        1           # Number of CPUs
-suffix      calints     # Data file suffix
+ncpu            1           # Number of CPUs
+suffix          calints     # Data file suffix
 
 # Subarray region of interest
-ywindow     [5,64]      # Vertical axis as seen in DS9
-xwindow     [100,1700]  # Horizontal axis as seen in DS9
-src_pos_type gaussian   # Determine source position when not given in header (Options: gaussian, weighted, or max)
+ywindow         [5,64]      # Vertical axis as seen in DS9
+xwindow         [100,1700]  # Horizontal axis as seen in DS9
+src_pos_type    gaussian    # Determine source position when not given in header (Options: gaussian, weighted, or max)
 
 # Background parameters
-bg_hw       8          # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
-bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
-p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
-save_bgsub  False       # Whether or not to save background subtracted FITS files
+bg_hw           8           # Half-width of exclusion region for BG subtraction (relative to source position)
+bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
+bg_deg          1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
+p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
+save_bgsub      False       # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
-spec_hw     8          # Half-width of aperture region for spectral extraction (relative to source position)
-fittype     meddata     # Method for constructing spatial profile (Options: smooth, meddata, poly, gauss, wavelet, or wavelet2D)
-window_len  31          # Smoothing window length, when fittype = smooth
-prof_deg    3           # Polynomial degree, when fittype = poly
-p5thresh    10          # X-sigma threshold for outlier rejection while constructing spatial profile
-p7thresh    10          # X-sigma threshold for outlier rejection during optimal spectral extraction
+spec_hw         8           # Half-width of aperture region for spectral extraction (relative to source position)
+fittype         meddata     # Method for constructing spatial profile (Options: smooth, meddata, poly, gauss, wavelet, or wavelet2D)
+window_len      31          # Smoothing window length, when fittype = smooth
+prof_deg        3           # Polynomial degree, when fittype = poly
+p5thresh        10          # X-sigma threshold for outlier rejection while constructing spatial profile
+p7thresh        10          # X-sigma threshold for outlier rejection during optimal spectral extraction
 
 # Diagnostics
-isplots_S3  3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-testing_S3  False       # Boolean, set True to only use last file and generate select figures
-hide_plots	False		# If True, plots will automatically be closed rather than popping up
-save_output True        # Save outputs for use in S4
-verbose     False       # If True, more details will be printed about steps
+isplots_S3      3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+testing_S3      False       # Boolean, set True to only use last file and generate select figures
+hide_plots      False       # If True, plots will automatically be closed rather than popping up
+save_output     True        # Save outputs for use in S4
+verbose         False       # If True, more details will be printed about steps
 
 # Project directory
-topdir      /home/User/
+topdir          /home/User/
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRCam/Stage2/	# The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
-outputdir	/Data/JWST-Sim/NIRCam/Stage3/
+inputdir        /Data/JWST-Sim/NIRCam/Stage2/   # The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
+outputdir       /Data/JWST-Sim/NIRCam/Stage3/

--- a/docs/media/S4_template.ecf
+++ b/docs/media/S4_template.ecf
@@ -1,10 +1,10 @@
 # Eureka! Control File for Stage 4: Generate Lightcurves 
 
 # Number of spectroscopic channels spread evenly over given wavelength range
-nspecchan   20          # Number of spectroscopic channels
-wave_min    2.4         # Minimum wavelength. Set to None to use the shortest extracted wavelength from Stage 3.
-wave_max    4.0         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
-allapers	True		# Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
+nspecchan       20          # Number of spectroscopic channels
+wave_min        2.4         # Minimum wavelength. Set to None to use the shortest extracted wavelength from Stage 3.
+wave_max        4.0         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
+allapers        True        # Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
 # Parameters for drift correction of 1D spectra
 correctDrift    False   # Set True to correct drift/jitter in 1D spectra (not recommended for simulated data)
@@ -14,24 +14,24 @@ drift_range     11      # Trim spectra by +/-X pixels to compute valid region of
 drift_hw        5       # Half-width in pixels used when fitting Gaussian, must be smaller than drift_range
 drift_iref      -1      # Index of reference spectrum used for cross correlation, -1 = last spectrum
 sub_mean        True    # Set True to subtract spectrum mean during cross correlation
-sub_continuum	True	# Set True to subtract the continuum from the spectra using a highpass filter
-highpassWidth	10		# The integer width of the highpass filter when subtracting the continuum
+sub_continuum   True    # Set True to subtract the continuum from the spectra using a highpass filter
+highpassWidth   10      # The integer width of the highpass filter when subtracting the continuum
 
 # Parameters for sigma clipping
-sigma_clip		False	# Whether or not sigma clipping should be performed on the 1D time series
-sigma			10		# The number of sigmas a point must be from the rolling median to be considered an outlier
-box_width		10		# The width of the box-car filter (used to calculated the rolling median) in units of number of data points
-maxiters		5		# The number of iterations of sigma clipping that should be performed.
-fill_value		mask	# Either the string 'mask' to mask the outlier values (recommended), 'boxcar' to replace data with the mean from the box-car filter, or a constant float-type fill value.
+sigma_clip      False   # Whether or not sigma clipping should be performed on the 1D time series
+sigma           10      # The number of sigmas a point must be from the rolling median to be considered an outlier
+box_width       10      # The width of the box-car filter (used to calculated the rolling median) in units of number of data points
+maxiters        5       # The number of iterations of sigma clipping that should be performed.
+fill_value      mask    # Either the string 'mask' to mask the outlier values (recommended), 'boxcar' to replace data with the mean from the box-car filter, or a constant float-type fill value.
 
 # Diagnostics
-isplots_S4  3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-hide_plots	False		# If True, plots will automatically be closed rather than popping up
-verbose     False       # If True, more details will be printed about steps
+isplots_S4      3       # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+hide_plots      False   # If True, plots will automatically be closed rather than popping up
+verbose         False   # If True, more details will be printed about steps
 
 # Project directory
-topdir      /home/User
+topdir          /home/User
 
 # Directories relative to project dir
-inputdir    /Data/JWST-Sim/NIRCam/Stage3	# The folder containing the outputs from Eureka!'s S3 or JWST's S3 pipeline (will be overwritten if calling S3 and S4 sequentially)
-outputdir	/Data/JWST-Sim/NIRCam/Stage4
+inputdir        /Data/JWST-Sim/NIRCam/Stage3    # The folder containing the outputs from Eureka!'s S3 or JWST's S3 pipeline (will be overwritten if calling S3 and S4 sequentially)
+outputdir       /Data/JWST-Sim/NIRCam/Stage4

--- a/docs/media/S5_fit_par_template.ecf
+++ b/docs/media/S5_fit_par_template.ecf
@@ -1,14 +1,14 @@
-#Name	 	Value	 		Free?			PriorPar1		PriorPar2		PriorType
-#PriorType can be U (Uniform), LU (Log Uniform), or N (Normal). If U/LU, PriorPar1 and PriorPar2 represent lower and upper limits of the parameter/log(the parameter). If N, PriorPar1 is the mean and PriorPar2 is the standard deviation of a Gaussian prior.
-rp			0.16			'free'			0.05			0.3				U
-per			0.813473978		'free'			0.813473978		0.000000035		N
-t0   		55528.353027	'free'			55528.34		55528.36		U
-time_offset	0				'independent'
-inc  		82.109	 		'free'			82.109			0.088			N
-a    		4.97			'free'			4.97			0.14			N
-ecc  		0.0	 			'fixed' 		0 				1				U
-w    		90.				'fixed' 		0 				180				U
-limb_dark	'quadratic' 	'independent'
-u1			0.3				'free'			-1				1				U
-u2			0.1				'free'			-1				1				U
-c0			1.009			'free'			0.95			1.05			U
+#Name        Value         Free?          PriorPar1    PriorPar2    PriorType
+#PriorType can be U (Uniform), LU (Log Uniform), or N (Normal). If U/LU, PriorPar1 and PriorPar2 represent upper and lower limits of the parameter/log(the parameter). If N, PriorPar1 is the mean and PriorPar2 is the standard deviation of a Gaussian prior.
+rp           0.16          'free'         0.05         0.3          U
+per          0.813473978   'free'         0.813473978  0.000000035  N
+t0           55528.353027  'free'         55528.34     55528.36     U
+time_offset  0             'independent'
+inc          82.109        'free'         82.109       0.088        N
+a            4.97          'free'         4.97         0.14         N
+ecc          0.0           'fixed'        0            1            U
+w            90.           'fixed'        0            180          U
+limb_dark    'kipping2013'   'independent'
+u1           0.3           'free'         0            1            U
+u2           0.1           'free'         0            1            U
+c0           1             'free'         0.95         1.05         U

--- a/docs/media/S5_template.ecf
+++ b/docs/media/S5_template.ecf
@@ -1,47 +1,47 @@
 # Eureka! Control File for Stage 5: Lightcurve Fitting
 
-ncpu			1 # The number of CPU threads to use when running emcee or dynesty in parallel
+ncpu            1 # The number of CPU threads to use when running emcee or dynesty in parallel
 
-allapers        True # Run S5 on all of the apertures considered in S4? Otherwise will use newest output in the inputdir
-rescale_err     False    # Rescale uncertainties to have reduced chi-squared of unity
-fit_par         ./S5_fit_par_template.ecf # What fitting ecf do you want to use?
-verbose         True # If True, more details will be printed about steps
-fit_method      [dynesty] #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
-run_myfuncs     [batman_tr,polynomial] #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, and polynomial (can list multiple types separated by commas)
+allapers        True                    # Run S5 on all of the apertures considered in S4? Otherwise will use newest output in the inputdir
+rescale_err     False                   # Rescale uncertainties to have reduced chi-squared of unity
+fit_par         ./S5_fit_par_template.ecf   # What fitting ecf do you want to use?
+verbose         True                    # If True, more details will be printed about steps
+fit_method      [dynesty]               #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
+run_myfuncs     [batman_tr,polynomial]  #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, and polynomial (can list multiple types separated by commas)
 
 # Limb darkening controls (not yet implemented)
 #fix_ld          False #use limb darkening file?
 #ld_file         /path/to/limbdarkening/ld_outputfile.txt  #location of limb darkening file
 
 #lsq
-lsq_method		'Nelder-Mead' # The scipy.optimize.minimize optimization method to use
-lsq_tol			1e-6 # The tolerance for the scipy.optimize.minimize optimization method
+lsq_method      'Nelder-Mead' # The scipy.optimize.minimize optimization method to use
+lsq_tol         1e-6    # The tolerance for the scipy.optimize.minimize optimization method
 
 #mcmc
-old_chain       None # Output folder relative to topdir that contains an old emcee chain to resume where you left off (set to None to start from scratch)
+old_chain       None    # Output folder relative to topdir that contains an old emcee chain to resume where you left off (set to None to start from scratch)
 lsq_first       True    # Initialize with an initial lsq call (can help shorten burn-in, but turn off if lsq fails). Only used if old_chain is None
 run_nsteps      4000
 run_nwalkers    50
 run_nburn       2000
 
 #dynesty
-run_nlive       1024 # Must be > ndim * (ndim + 1) // 2
+run_nlive       1024    # Must be > ndim * (ndim + 1) // 2
 run_bound       'multi'
 run_sample      'unif'
 run_tol         0.1
 
 # Plotting controls
-interp			False	# Should astrophysical model be interpolated (useful for uneven sampling like that from HST)
+interp          False   # Should astrophysical model be interpolated (useful for uneven sampling like that from HST)
 
 # Diagnostics
-isplots_S5      5 # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-testing_S5      False # Boolean, set True to only use the first spectral channel
-testing_model   False # Boolean, set True to only inject a model source of systematics
-hide_plots      False # If True, plots will automatically be closed rather than popping up
+isplots_S5      5       # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+testing_S5      False   # Boolean, set True to only use the first spectral channel
+testing_model   False   # Boolean, set True to only inject a model source of systematics
+hide_plots      False   # If True, plots will automatically be closed rather than popping up
 
 # Project directory
 topdir          /home/User/
 
 # Directories relative to project dir
-inputdir        /Data/JWST-Sim/NIRCam/Stage4/	# The folder containing the outputs from Eureka!'s S4 pipeline (will be overwritten if calling S4 and S5 sequentially)
+inputdir        /Data/JWST-Sim/NIRCam/Stage4/   # The folder containing the outputs from Eureka!'s S4 pipeline (will be overwritten if calling S4 and S5 sequentially)
 outputdir       /Data/JWST-Sim/NIRCam/Stage5/

--- a/docs/media/S6_template.ecf
+++ b/docs/media/S6_template.ecf
@@ -3,33 +3,34 @@
 allapers        True # Run S6 on all of the apertures considered in S5? Otherwise will use newest output in the inputdir
 
 # Plotting parameters
-y_unit			(Rp/Rs)^2 # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
-y_scalar		100 # Can be used to convert to percent (100), ppm (1e6), etc.
-x_unit			um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
+y_unit          (Rp/Rs)^2 # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
+y_scalar        100 # Can be used to convert to percent (100), ppm (1e6), etc.
+x_unit          um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
 
 # This section is relevant if isplots_S6>=3
 # Scale height parameters (if you want a second copy of the plot with a second y-axis with units of scale height)
-star_Rad		0.6506 # The radius of the star in units of solar radii
-planet_Teq		1400 # The equilibrium temperature of the planet in units of Kelvin
-planet_Mass		2 # The planet's mass in units of Jupiter radii (used to calculate surface gravity)
-planet_Rad		None # The planet's radius in units of Jupiter radii (used to calculate surface gravity); Set to None to use the average fitted radius
-planet_mu		2.3 # The mean molecular mass of the atmosphere (in atomic mass units)
-planet_R0		None # The reference radius (in Jupiter radii) for the scale height measurement; Set to None to use the mean fitted radius
+star_Rad        0.6506 # The radius of the star in units of solar radii
+planet_Teq      1400 # The equilibrium temperature of the planet in units of Kelvin
+planet_Mass     2 # The planet's mass in units of Jupiter radii (used to calculate surface gravity)
+planet_Rad      None # The planet's radius in units of Jupiter radii (used to calculate surface gravity); Set to None to use the average fitted radius
+planet_mu       2.3 # The mean molecular mass of the atmosphere (in atomic mass units)
+planet_R0       None # The reference radius (in Jupiter radii) for the scale height measurement; Set to None to use the mean fitted radius
 
 # Diagnostics
 isplots_S6      5 # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-testing_S6		False
+testing_S6      False
 hide_plots      False # If True, plots will automatically be closed rather than popping up
 
 # Project directory
 topdir          /home/User/
 
 # Model to plot as well (path relative to project dir of a csv with col 1 as wavelength in microns, col 2 in the same units as the plotted spectrum, any headers preceded by a #)
-model_spectrum	None # Set to None if no model should be plotted
-model_x_unit	um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
-model_y_unit	Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
-model_y_scalar	1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
+model_spectrum  None # Set to None if no model should be plotted
+model_x_unit    um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
+model_y_unit    Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
+model_y_scalar  1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
+model_delimiter None #Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to project dir
-inputdir        /Data/JWST-Sim/NIRCam/Stage5/	# The folder containing the outputs from Eureka!'s S5 pipeline (will be overwritten if calling S5 and S6 sequentially)
+inputdir        /Data/JWST-Sim/NIRCam/Stage5/   # The folder containing the outputs from Eureka!'s S5 pipeline (will be overwritten if calling S5 and S6 sequentially)
 outputdir       /Data/JWST-Sim/NIRCam/Stage6/

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -21,6 +21,13 @@ If you are following the installation instructions and still encounter an error,
 `GitHub <https://github.com/kevin218/Eureka/issues>`_ and paste the full error message you are getting along
 with details about which python version and operating system you are using.
 
+Issues installing or importing batman
+'''''''''''''''''''''''''''''''''''''
+
+Be sure that you are installing (or have installed) batman-package (not batman) from pip. If you have accidentally
+installed the wrong package you can try pip uninstalling it, but you may just need to make a whole new environment.
+In general, we strongly recommend you closely follow the instructions on the :ref:`installation` page.
+
 
 Matplotlib RuntimeError() whenever Eureka is imported and plt.show() is called
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -59,6 +66,14 @@ Some more permanent solutions would be to:
   An example of this is to change ``export PATH="~/anaconda3/bin:$PATH"`` in your **~/.bashrc** file to ``export PATH="~/anaconda3/bin:~/Library/TeX/texbin:$PATH"``.
   For anyone using Ubuntu or an older version of Mac this might be found in /usr/bin instead. Make sure you run source ~/.bash_profile or source ~/.bashrc to apply the changes.
 
+My question isn't listed here!
+''''''''''''''''''''''''''''''
+
+First check to see if your question/concern is already addressed in an open or closed issue on the Eureka! 
+`GitHub <https://github.com/kevin218/Eureka/issues>`_ page. If not, please open a new issue and paste the
+full error message you are getting along with details about which python version and operating system you
+are using, and ideally the ecf you used to get your error (ideally copy-paste it into the issue in a
+quote block).
 
 FAQ
 --------------------------


### PR DESCRIPTION
Removing all the tabs from ecf templates and replacing them with spaces to make sure the templates look nicely formatted for everyone regardless of the text file viewer. Also made some minor tweaks to ecf defaults and added a bit of documentation to the FAQ page to answer some frequently asked issues on Slack.