### PR TITLE
Some tweaks for the newest NGTS-10b simulation with a companion star

### DIFF
--- a/eureka/S3_data_reduction/miri.py
+++ b/eureka/S3_data_reduction/miri.py
@@ -63,7 +63,10 @@ def read(filename, data, meta):
     if meta.firstFile:
         print('  WARNING: The timestamps for the simulated MIRI data are currently hardcoded '
               'because they are not in the .fits files themselves')
-    if data.mhdr['EFFINTTM']==10.3376:
+    if 'new_drift' in data.filename:
+        # Time array for the newest MIRISIM observations
+        data.time = np.linspace(0, 47.712*(1849)/3600/24, 1849, endpoint=True)[data.intstart - 1:data.intend-1]
+    elif data.mhdr['EFFINTTM']==10.3376:
         # There is no time information in the old simulated MIRI data
         # As a placeholder, I am creating timestamps indentical to the ones in STSci-SimDataJWST/MIRI/Ancillary_files/times.dat.txt converted to days
         data.time = np.linspace(0, 17356.28742796742/3600/24, 1680, endpoint=True)[data.intstart - 1:data.intend]

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -151,13 +151,16 @@ def lcJWST(eventlabel, ecf_path='./', s3_meta=None):
             meta.wave_hi = np.array(meta.wave_hi)
             meta.wave_low = np.array(meta.wave_low)
 
+            if not hasattr(meta, 'boundary'):
+                meta.boundary = 'extend' # The default value before this was added as an option
+
             # Do 1D sigma clipping (along time axis) on unbinned spectra
             optspec = np.ma.masked_array(optspec)
             if meta.sigma_clip:
                 log.writelog('Sigma clipping unbinned spectral time series', mute=(not meta.verbose))
                 outliers = 0
                 for l in range(meta.subnx):
-                    optspec[:,l], nout = clipping.clip_outliers(optspec[:,l], log, wave_1d[l], meta.sigma, meta.box_width, meta.maxiters, meta.fill_value, verbose=meta.verbose)
+                    optspec[:,l], nout = clipping.clip_outliers(optspec[:,l], log, wave_1d[l], meta.sigma, meta.box_width, meta.maxiters, meta.boundary, meta.fill_value, verbose=meta.verbose)
                     outliers += nout
                 log.writelog('Identified a total of {} outliers in time series, or an average of {} outliers per wavelength'.format(outliers, np.round(outliers/meta.subnx, 1)), mute=meta.verbose)
 
@@ -197,7 +200,7 @@ def lcJWST(eventlabel, ecf_path='./', s3_meta=None):
 
                 # Do 1D sigma clipping (along time axis) on binned spectra
                 if meta.sigma_clip:
-                    meta.lcdata[i], outliers = clipping.clip_outliers(meta.lcdata[i], log, wave_1d[l], meta.sigma, meta.box_width, meta.maxiters, meta.fill_value, verbose=False)
+                    meta.lcdata[i], outliers = clipping.clip_outliers(meta.lcdata[i], log, wave_1d[l], meta.sigma, meta.box_width, meta.maxiters, meta.boundary, meta.fill_value, verbose=False)
                     log.writelog('  Sigma clipped {} outliers in time series'.format(outliers))
 
                 # Plot each spectroscopic light curve

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -70,7 +70,7 @@ def fitJWST(eventlabel, ecf_path='./', s4_meta=None):
         meta.bg_hw_range = [meta.bg_hw,]
 
     if meta.testing_S5:
-        # Only fit a single channel while testing
+        # Only fit a single channel while testing unless doing a shared fit then do two
         chanrng = 1
     else:
         chanrng = meta.nspecchan
@@ -115,6 +115,9 @@ def fitJWST(eventlabel, ecf_path='./', s4_meta=None):
                 if 'shared' in val:
                     sharedp = True
             meta.sharedp = sharedp
+
+            if meta.sharedp and meta.testing_S5:
+                chanrng = 2
 
             # Subtract off the user provided time value to avoid floating point precision problems when fitting for values like t0
             offset = params.time_offset.value

--- a/eureka/lib/clipping.py
+++ b/eureka/lib/clipping.py
@@ -7,7 +7,7 @@ from astropy.stats import sigma_clip
 
 __all__ = ['clip_outliers', 'gauss_removal']
  
-def clip_outliers(data, log, wavelength, sigma=10, box_width=5, maxiters=5, fill_value='mask', verbose=False):
+def clip_outliers(data, log, wavelength, sigma=10, box_width=5, maxiters=5, boundary='extend', fill_value='mask', verbose=False):
     '''Find outliers in 1D time series.
   
     Be careful when using this function on a time-series with known astrophysical variations. The variable
@@ -45,7 +45,8 @@ def clip_outliers(data, log, wavelength, sigma=10, box_width=5, maxiters=5, fill
     '''
     kernel = Box1DKernel(box_width)
     # Compute the moving mean
-    smoothed_data = convolve(data, kernel, boundary='extend')
+    bound_val = np.ma.median(data) # Only used if boundary=='fill'
+    smoothed_data = convolve(data, kernel, boundary=boundary, fill_value=bound_val)
     # Compare data to the moving mean (to remove astrophysical signals)
     residuals = data-smoothed_data
     # Sigma clip residuals to find bad points in data


### PR DESCRIPTION
I needed to add a new time array for the newest MIRI simulations. I also needed more flexibility in the sigma clipping due to the strong ramp in MIRISIM_TSO simulations. Finally, S5 now simultaneously fits 2 wavelengths if testing_S5==True and any of the fit_par ecf values are 'shared'