### PR TITLE
Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -40,9 +40,8 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Relevant log output
-      description: Please copy and paste any relevant log output.
-      render: shell
+      label: Error traceback output
+      description: Please copy and paste the full traceback of the error you encountered.
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-template.yml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yml
@@ -3,7 +3,6 @@ description: File a bug report
 title: "[Bug]: "
 labels: ["bug"]
 body:
-body:
   - type: markdown
     attributes:
       value: |
@@ -38,3 +37,17 @@ body:
       value: "A bug happened!"
     validations:
       required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://example.com)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/first-template.yml
+++ b/.github/ISSUE_TEMPLATE/first-template.yml
@@ -2,7 +2,6 @@ name: Bug Report
 description: File a bug report
 title: "[Bug]: "
 labels: ["bug"]
-assignees:
 body:
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/first-template.yml
+++ b/.github/ISSUE_TEMPLATE/first-template.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+assignees:
+body:
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: dropdown
+    id: instrument
+    attributes:
+      label: Instrument
+      description: Which instrument or piece of code were you running?
+      multiple: true
+      options:
+        - NIRISS (Stages 1-3)
+        - NIRSpec (Stages 1-3)
+        - NIRCam (Stages 1-3)
+        - MIRI (Stages 1-3)
+        - Light curve fitting (Stages 4-6)
+        - Other
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true

--- a/.github/workflow/assign-issue.yml
+++ b/.github/workflow/assign-issue.yml
@@ -1,0 +1,14 @@
+name: assign-issue
+on:
+  issues:
+    types:
+      - created
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Naturalclar/issue-action@v2.0.2
+        with:
+          title-or-body: "both"
+          parameters: '[ {"keywords": ["light curve fitting"], "assignees": ["meganmansfield"]}]'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Hey, @kevin218, this is my first attempt at making an issue template. What I'm trying to set up now is a workflow script that will automatically assign an issue to different people based on whether the issue is submitted for one of the four instruments or for general lightcurve fitting. However, after setting this up I realized I can only view the template and test it out if it's merged into the main branch. Would you be ok with going ahead and merging this? I promise I won't make changes to any of the other files. :)