### PR TITLE
Undoing bug introduced by GP PR

### DIFF
--- a/eureka/S5_lightcurve_fitting/fitters.py
+++ b/eureka/S5_lightcurve_fitting/fitters.py
@@ -519,7 +519,7 @@ def initialize_emcee_walkers(meta, log, ndim, lsq_sol, freepars, prior1, prior2,
                          'Using {} walkers instead of the initially requested {} walkers is not permitted as there are {} fitted parameters'.format(nwalkers, old_nwalkers, ndim), mute=True)
             raise AssertionError('Error: Failed to initialize all walkers within the set bounds for all parameters!\n'+
                                  'Using {} walkers instead of the initially requested {} walkers is not permitted as there are {} fitted parameters'.format(nwalkers, old_nwalkers, ndim))
-	return pos, nwalkers
+    return pos, nwalkers
 
 
 def dynestyfitter(lc, model, meta, log, **kwargs):


### PR DESCRIPTION
The most recent PR for the GP code included a tab instead of four spaces in one place of the fitters.py file which breaks even importing eureka (or at least importing Stage 5 code).