### PR TITLE
Fixing reduced chi-squared calculation

### DIFF
--- a/eureka/S5_lightcurve_fitting/models/Model.py
+++ b/eureka/S5_lightcurve_fitting/models/Model.py
@@ -298,9 +298,10 @@ class CompositeModel(Model):
         # Get the time
         if self.time is None:
             self.time = kwargs.get('time')
-            
-        flux = np.ones(len(self.time)*self.nchan)
-        
+
+        # Set the default value
+        flux = np.zeros(len(self.time)*self.nchan)
+
         # Evaluate flux
         for model in self.components:
             if model.modeltype == 'GP':


### PR DESCRIPTION
Previously the GPeval function would return all ones if a GP was not being used. Because the GP model is additive rather than multiplicative, this messed up the reduced chi-squared calculation but other parts of the code did not end up using the GPeval function so they were fine.

Resolves #253.