### PR TITLE
image_registration is now truly optional

### DIFF
--- a/eureka/S3_data_reduction/hst_scan.py
+++ b/eureka/S3_data_reduction/hst_scan.py
@@ -5,7 +5,10 @@ import scipy.signal as sps
 import matplotlib.pyplot as plt
 from astropy.io import fits
 import sys
-import image_registration as imr
+try:
+    import image_registration as imr
+except ModuleNotFoundError as e:
+    pass
 from ..lib import gaussian as g
 from ..lib import smooth, centroid, smoothing
 
@@ -538,6 +541,9 @@ def correct_slitshift2(data, slitshift, mask=None, isreverse=False):
 
 # Calulate drift2D
 def calcDrift2D(im1, im2, m, n, n_files):
+    if imr not in sys.modules:
+        raise ModuleNotFoundError("The image-registration package was not installed with Eureka and is required for HST analyses.\n"+
+                                  "You can install all HST-related dependencies with `pip install .[hst]`")
     drift2D = imr.chi2_shift(im1, im2, boundary='constant', nthreads=1,
                              zeromean=False, return_error=False)
     return (drift2D, m, n)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as f:
 
 extras_require = {
    'jwst': ["jwst==1.3.3", "stcal", "asdf>=2.7.1,<2.11.0"],
-   'hst': ["image_registration"]
+   'hst': ["git+https://github.com/keflavich/image_registration.git"] # Need the GitHub version as 0.2.6 is required for python>=3.10, but 0.2.6 is not yet on PyPI
 }
 
 FILES = []


### PR DESCRIPTION
Previously I'd forgotten to not throw an error about missing
image_registration if WFC3 analyses were not being performed.