### PR TITLE
Removing niriss_cython import

### DIFF
--- a/eureka/S3_data_reduction/__init__.py
+++ b/eureka/S3_data_reduction/__init__.py
@@ -4,7 +4,6 @@ from . import bright2flux
 from . import hst_scan
 from . import miri
 from . import nircam
-from . import niriss_cython
 from . import niriss_profiles
 from . import niriss
 from . import nirspec


### PR DESCRIPTION
I accidentally added niriss_cython even though it shouldn't be imported
directly