### PR TITLE
Closes #292 by fixing syntax for extras_require in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt') as f:
 
 extras_require = {
    'jwst': ["jwst==1.3.3", "stcal", "asdf>=2.7.1,<2.11.0"],
-   'hst': ["git+https://github.com/keflavich/image_registration.git"] # Need the GitHub version as 0.2.6 is required for python>=3.10, but 0.2.6 is not yet on PyPI
+   'hst': ["image_registration @ git+https://github.com/keflavich/image_registration.git"] # Need the GitHub version as 0.2.6 is required for python>=3.10, but 0.2.6 is not yet on PyPI
 }
 
 FILES = []


### PR DESCRIPTION
Installing Eureka! is currently failing due to a small error in `setup.py`. According to [PEP 508](https://peps.python.org/pep-0508/) syntax, the line 

`'hst': ["git+https://github.com/keflavich/image_registration.git"]`

should be changed to:

`'hst': ["image_registration @ git+https://github.com/keflavich/image_registration.git"]`