### PR TITLE
Add celerite as a gp package and abillity for shared parameters

### DIFF
--- a/demos/JWST/S5_fit_par_template.epf
+++ b/demos/JWST/S5_fit_par_template.epf
@@ -40,13 +40,17 @@ u2           0.5           	'free'         0            1            U
 # ** Systematic variables **
 # polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
 # expramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
-# GP model parameters (A, WN, m_1, m_2)
+# GP model parameters (A, WN, m_1, m_2) in log scale
 # --------------------
 c0           1             	'free'         0.95         1.05         U
-c1           0           	'free'          -0.1         0.1         U
+c1           0           	'free'         -0.1         0.1          U
+#A            -5           	'free'         -20.         -5.          U
+#WN           -15          	'free'         -20.         -10.         U
+#m1           -5          	'free'         -10.         0.           U
 # -----------
 # ** White noise **
 # Use scatter_mult to fit a multiplier to the expected noise level from Stage 3 (recommended)
 # Use scatter_ppm to fit the noise level in ppm
+# Use WN parameter in GP model parameters to account for white noise in the GP model
 # -----------
 scatter_mult 1             	'free'         1            0.1          N

--- a/demos/JWST/S5_fit_par_template.epf
+++ b/demos/JWST/S5_fit_par_template.epf
@@ -40,7 +40,7 @@ u2           0.5           	'free'         0            1            U
 # ** Systematic variables **
 # polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
 # expramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
-# GP model parameters (A, WN, m_1, m_2) in log scale
+# GP model parameters (A, WN, m1, m2) in log scale
 # --------------------
 c0           1             	'free'         0.95         1.05         U
 c1           0           	'free'         -0.1         0.1          U

--- a/demos/JWST/S5_template.ecf
+++ b/demos/JWST/S5_template.ecf
@@ -37,8 +37,9 @@ run_sample      'auto'
 run_tol         0.1
 
 #GP inputs
-kernel_inputs   ['time','time'] #options: time
-kernel_class    ['ExpSquared','Exp'] #options: ExpSquared, Matern32, Exp, RationalQuadratic
+kernel_inputs   ['time'] #options: time
+kernel_class    ['Matern32'] #options: ExpSquared, Matern32, Exp, RationalQuadratic for george, Matern32 for celerite (sums of kernels possible for george separated by commas)
+GP_package      'celerite' #options: george, celerite
 
 # Plotting controls
 interp          False   # Should astrophysical model be interpolated (useful for uneven sampling like that from HST)

--- a/eureka/S5_lightcurve_fitting/likelihood.py
+++ b/eureka/S5_lightcurve_fitting/likelihood.py
@@ -48,7 +48,7 @@ def ln_like(theta, lc, model, freenames):
     else:
         lc.unc_fit = deepcopy(lc.unc)
     if model.GP:
-        ln_like_val = GP_loglikelihood(model, model_lc)
+        ln_like_val = GP_loglikelihood(model, model_lc, lc.unc_fit)
     else:
         residuals = (lc.flux - model_lc) 
         ln_like_val = (-0.5 * (np.ma.sum((residuals / lc.unc_fit) ** 2+ np.ma.log(2.0 * np.pi * (lc.unc_fit) ** 2))))
@@ -286,7 +286,7 @@ def computeRMS(data, maxnbins=None, binstep=1, isrmserr=False):
     else:
         return rms, stderr, binsz
 
-def GP_loglikelihood(model, fit):
+def GP_loglikelihood(model, fit, unc_fit):
     """Compute likelihood, when model fit includes GP
 
     Parameters
@@ -309,5 +309,5 @@ def GP_loglikelihood(model, fit):
     """
     for m in model.components:
         if m.modeltype == 'GP':
-            return m.loglikelihood( fit)
+            return m.loglikelihood( fit, unc_fit)
     return 0

--- a/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -111,7 +111,7 @@ class GPModel(Model):
             if self.gp_code_name == 'celerite':
                 gp.compute(self.kernel_input_arrays[0], self.lc.unc)
                 mu, cov = gp.predict(self.lc.flux-fit, self.kernel_input_arrays[0], return_var=True)
-
+                mu += gp.kernel.jitter*np.ones(len(self.lc.flux))
         #lcfinal = np.append(lcfinal, mu)
            
         return mu#, std
@@ -169,6 +169,7 @@ class GPModel(Model):
         
         if self.gp_code_name == 'celerite':
             kernel = celerite.terms.RealTerm(log_a = self.coeffs['A'], log_c = 0)*kernel
+            kernel += celerite.terms.JitterTerm(log_sigma = self.coeffs['WN'])
             gp = celerite.GP(kernel, mean=0, fit_mean=False)
         
         if self.gp_code_name == 'george':

--- a/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -6,13 +6,9 @@ from copy import deepcopy
 from .Model import Model
 from ...lib.readEPF import Parameters
 
-###########for future tinygp version - tinygp needs python >= 3.7
-###########!! careful when activating - did not test the tinygp code yet (didn't have python >= 3.7)
-#import jax.numpy as jnp
+#tinygp is not supported yet
 #import tinygp
-#from tinygp import kernels, GaussianProcess
-#from jax.config import config
-#config.update("jax_enable_x64", True)
+
 
 class GPModel(Model):
     """Model for Gaussian Process (GP)"""
@@ -113,33 +109,39 @@ class GPModel(Model):
         lcfinal=np.array([])
         
         for c in np.arange(self.nchan):
+            
             #get flux and uncertainties for current channel
             c_flux = self.flux[len(self.time)*c:len(self.time)*(c+1)]
             c_fit = fit[len(self.time)*c:len(self.time)*(c+1)]
             c_unc_fit = self.unc_fit[len(self.time)*c:len(self.time)*(c+1)]
+            
             # Create the GP object with current parameters
             if gp==None:
-                gp = self.setup_GP(c)       
+                gp = self.setup_GP(c)  
+                
             if self.nkernels > 1:
                 if self.gp_code_name == 'george':
                     gp.compute(self.kernel_input_arrays.T,c_unc_fit)
                     mu,cov = gp.predict(c_flux- c_fit,self.kernel_input_arrays.T)
+                    
                 if self.gp_code_name == 'tinygp':
-                    cond_gp = gp.condition(self.kernel_input_arrays.T,c_unc_fit).gp
+                    cond_gp = gp.condition(c_flux- c_fit, noise=c_unc_fit).gp
                     mu, cov = cond_gp.loc, cond_gp.variance
+                    
                 if self.gp_code_name == 'celerite':
                     raise AssertionError('Celerite cannot compute multi-dimensional GPs, please choose a different GP code')
             else:
                 if self.gp_code_name == 'george':
                     gp.compute(self.kernel_input_arrays[0],c_unc_fit)
                     mu,cov = gp.predict(c_flux- c_fit,self.kernel_input_arrays[0])
+                    
                 if self.gp_code_name == 'tinygp':
-                    cond_gp = gp.condition(self.kernel_inputs[0],c_unc_fit).gp
+                    cond_gp = gp.condition(c_flux- c_fit, noise=c_unc_fit).gp
                     mu, cov = cond_gp.loc, cond_gp.variance
+                    
                 if self.gp_code_name == 'celerite':
                     gp.compute(self.kernel_input_arrays[0], c_unc_fit)
                     mu, cov = gp.predict(c_flux- c_fit, self.kernel_input_arrays[0], return_var=True)
-                    mu += gp.kernel.jitter*np.ones(len(c_flux))
             lcfinal = np.append(lcfinal, mu)
 
         return lcfinal#, cov
@@ -159,13 +161,10 @@ class GPModel(Model):
         for i in self.kernel_input_names:
             if i == 'time':
                 x = self.time
-                #x = np.linspace(0.10, 0.22, num=1287)
                 kernel_inputs.append(x)
-                #kernel_inputs.append(self.time)
             ##add more input options here 
 
         if normalise: 
-            #print(kernel_inputs)
             norm_kernel_inputs = [(i-i.mean())/i.std() for i in kernel_inputs]
             self.kernel_input_arrays =  np.array(norm_kernel_inputs)
             return
@@ -191,46 +190,78 @@ class GPModel(Model):
             self.set_inputs()
         
         if self.nchan > 1:
+            #get the kernel which is the sum of the individual kernel fucntions
             for i in range(self.nkernels):
                 if i == 0:
                     kernel = self.get_kernel(self.kernel_types[i],i, channel)
                 else:
                     kernel += self.get_kernel(self.kernel_types[i],i, channel)
 
+                    
             if self.gp_code_name == 'celerite':
+                #adding the amplitude
                 kernel = celerite.terms.RealTerm(log_a = self.coeffs['A_%i'%channel], log_c = 0)*kernel
+                
+                #adding the jitter/white noise term
                 kernel += celerite.terms.JitterTerm(log_sigma = self.coeffs['WN_%i'%channel])
+                
+                #make gp object
                 gp = celerite.GP(kernel, mean=0, fit_mean=False)
 
+                
             if self.gp_code_name == 'george':
+                #adding the amplitude
                 kernel = kernels.ConstantKernel(self.coeffs['A_%i'%channel],ndim=self.nkernels,axes=np.arange(self.nkernels))*kernel
+                
+                #make gp object
                 gp = george.GP(kernel, white_noise=self.coeffs['WN_%i'%channel],fit_white_noise=self.fit_white_noise, mean=0, fit_mean=False)#, solver=george.solvers.HODLRSolver)
 
+                
             if self.gp_code_name == 'tinygp':
-                kernel = kernels.ConstantKernel(self.coeffs['A_%i'%channel],ndim=self.nkernels,axes=np.arange(self.nkernels))*kernel
-                gp = tinygp.GaussianProcess(kernel, diag=self.coeffs['WN_%i'%channel]**2, mean=0)
+                #adding the amplitude
+                kernel = tinygp.kernels.Constant(self.coeffs['A_%i'%channel])*kernel
+                
+                #make gp object
+                gp = tinygp.GaussianProcess(kernel, self.kernel_input_arrays.T, diag=self.coeffs['WN_%i'%channel]**2, mean=0)
                 
         else:
+            #get the kernel which is the sum of the individual kernel fucntions
             for i in range(self.nkernels):
                 if i == 0:
                     kernel = self.get_kernel(self.kernel_types[i],i)
                 else:
                     kernel += self.get_kernel(self.kernel_types[i],i)
+                    
 
             if self.gp_code_name == 'celerite':
+                #adding the amplitude
                 kernel = celerite.terms.RealTerm(log_a = self.coeffs['A'], log_c = 0)*kernel
+                
+                #adding the jitter/white noise term
                 kernel += celerite.terms.JitterTerm(log_sigma = self.coeffs['WN'])
+                
+                #make gp object
                 gp = celerite.GP(kernel, mean=0, fit_mean=False)
+                
 
             if self.gp_code_name == 'george':
+                #adding the amplitude
                 kernel = kernels.ConstantKernel(self.coeffs['A'],ndim=self.nkernels,axes=np.arange(self.nkernels))*kernel
+                
+                #make gp object
                 gp = george.GP(kernel, white_noise=self.coeffs['WN'],fit_white_noise=self.fit_white_noise, mean=0, fit_mean=False)#, solver=george.solvers.HODLRSolver)
+                
 
             if self.gp_code_name == 'tinygp':
-                kernel = kernels.ConstantKernel(self.coeffs['A'],ndim=self.nkernels,axes=np.arange(self.nkernels))*kernel
-                gp = tinygp.GaussianProcess(kernel, diag=self.coeffs['WN']**2, mean=0)
-
+                #adding the amplitude
+                kernel = tinygp.kernels.Constant(self.coeffs['A'])*kernel
+                
+                #make gp object
+                gp = tinygp.GaussianProcess(kernel, self.kernel_input_arrays.T, diag=self.coeffs['WN']**2, mean=0)
+                
         return gp
+    
+    
 
     def loglikelihood(self, fit, unc_fit):
         """Compute log likelihood of GP
@@ -240,7 +271,7 @@ class GPModel(Model):
 
         Returns
         -------
-        log likelihood of the GP evaluated by george/tinygp
+        log likelihood of the GP evaluated by george/tinygp/celerite
         """
         #update uncertainty
         self.unc_fit = unc_fit
@@ -248,10 +279,14 @@ class GPModel(Model):
         logL = []
         
         for c in np.arange(self.nchan):
+            #set up GP with current parameters
             gp = self.setup_GP(c)
+            
+            #get fluxes, current fit and uncertainties for channel
             c_flux = self.flux[len(self.time)*c:len(self.time)*(c+1)]
             c_fit = fit[len(self.time)*c:len(self.time)*(c+1)]
             c_unc_fit = self.unc_fit[len(self.time)*c:len(self.time)*(c+1)]
+        
         
             if self.gp_code_name == 'celerite':
                 if self.nkernels > 1:
@@ -260,6 +295,7 @@ class GPModel(Model):
                     gp.compute(self.kernel_input_arrays[0], c_unc_fit)
                 logL.append(gp.log_likelihood(c_flux - c_fit))
 
+                
             if self.gp_code_name == 'george':
                 if self.nkernels > 1:
                     gp.compute(self.kernel_input_arrays.T,c_unc_fit)
@@ -267,17 +303,21 @@ class GPModel(Model):
                     gp.compute(self.kernel_input_arrays[0],c_unc_fit)
                 logL.append(gp.lnlikelihood(c_flux - c_fit,quiet=True))
 
+                
             if self.gp_code_name == 'tinygp':
-                if self.nkernels > 1:
-                    logL.append(gp.condition(c_flux - c_fit, X_test = self.kernel_input_arrays.T).log_probability)
-                else:
-                    logL.append(gp.condition(c_flux - c_fit, X_test = self.kernel_input_arrays[0]).log_probability) 
+                cond = gp.condition(c_flux - c_fit)
+                logL.append(cond.log_probability)
+
                     
         return sum(logL)
 
+    
     def get_kernel(self, kernel_name, i, channel=0):
         """get individual kernels"""
+        #get metric for the individual kernel for the current channel
         metric = ( 1./np.exp(self.coeffs[kernel_name][channel]) )**2
+        
+        
         if self.gp_code_name == 'george':
             if kernel_name == 'Matern32':
                 kernel = kernels.Matern32Kernel(metric,ndim=self.nkernels,axes=i)
@@ -288,15 +328,17 @@ class GPModel(Model):
             if kernel_name == 'Exp':
                 kernel = kernels.ExpKernel(metric,ndim=self.nkernels,axes=i)   
 
+                
         if self.gp_code_name == 'tinygp':
             if kernel_name == 'Matern32':
-                kernel = tinygp.kernels.Matern32(metric,ndim=self.nkernels,axes=i)
+                kernel = tinygp.kernels.Matern32(metric)
             if kernel_name == 'ExpSquared':
-                kernel = tinygp.kernels.ExpSquared(metric,ndim=self.nkernels,axes=i)
+                kernel = tinygp.kernels.ExpSquared(metric)
             if kernel_name == 'RationalQuadratic':
-                kernel = tinygp.kernels.RationalQuadratic(alpha=1,scale=metric,ndim=self.nkernels,axes=i)
+                kernel = tinygp.kernels.RationalQuadratic(alpha=1,scale=metric)
             if kernel_name == 'Exp':
-                kernel = tinygp.kernels.Exp(metric,ndim=self.nkernels,axes=i) 
+                kernel = tinygp.kernels.Exp(metric) 
+                
                 
         if self.gp_code_name == 'celerite':
             if kernel_name == 'Matern32':

--- a/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -84,7 +84,7 @@ class GPModel(Model):
                         raise AssertionError('Please start your metric enumeration with m1.')
                     self.coeffs[self.kernel_types[no]].append(v[0])
                 else:
-                    no = int(remvisnum[1])-1
+                    no = int(remvisnum[0][1])-1
                     self.coeffs[self.kernel_types[no]].append(v[0])
             if k.startswith('WN'):
                 remvisnum = k.split('_')
@@ -139,7 +139,7 @@ class GPModel(Model):
                 if self.gp_code_name == 'celerite':
                     gp.compute(self.kernel_input_arrays[0], c_unc_fit)
                     mu, cov = gp.predict(c_flux- c_fit, self.kernel_input_arrays[0], return_var=True)
-                    mu += gp.kernel.jitter*np.ones(len(self.flux[c]))
+                    mu += gp.kernel.jitter*np.ones(len(c_flux))
             lcfinal = np.append(lcfinal, mu)
 
         return lcfinal#, cov
@@ -300,7 +300,7 @@ class GPModel(Model):
                 
         if self.gp_code_name == 'celerite':
             if kernel_name == 'Matern32':
-                kernel = celerite.terms.Matern32Term(log_sigma = 1, log_rho = metric, eps=1e-12)
+                kernel = celerite.terms.Matern32Term(log_sigma = 1, log_rho = metric)
             else:
                 raise AssertionError('Celerite currently only supports a Matern32 kernel')
 

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -217,7 +217,7 @@ def fit_channel(meta,time,flux,chan,flux_err,eventlabel,sharedp,params,log,longp
                                 longparamlist=lc_model.longparamlist, nchan=lc_model.nchannel_fitted, paramtitles=paramtitles)
         modellist.append(t_ramp)
     if 'GP' in meta.run_myfuncs:
-        t_GP = m.GPModel(meta.kernel_class, meta.kernel_inputs, lc_model, parameters=params, name='GP', fmt='r--', log=log)
+        t_GP = m.GPModel(meta.kernel_class, meta.kernel_inputs, lc_model, parameters=params, name='GP', fmt='r--', log=log, gp_code=meta.GP_package, longparamlist=lc_model.longparamlist, nchan=lc_model.nchannel_fitted, paramtitles=paramtitles)
         modellist.append(t_GP)
     model = m.CompositeModel(modellist, nchan=lc_model.nchannel_fitted)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astropy
 batman-package
 bokeh
 ccdproc
+celerite
 corner
 crds
 cython

--- a/tests/NIRCam_ecfs/S5_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S5_NIRCam.ecf
@@ -31,8 +31,9 @@ run_sample      'auto'
 run_tol         10 # For testing, set to something dynesty can get to quickly
 
 #GP inputs
-kernel_inputs   ['time','time'] #options: time
-kernel_class    ['ExpSquared','Exp'] #options: ExpSquared, Matern32, Exp, RationalQuadratic
+kernel_inputs   ['time'] #options: time
+kernel_class    ['Matern32'] #options: ExpSquared, Matern32, Exp, RationalQuadratic for george, Matern32 for celerite (sums of kernels possible for george separated by commas)
+GP_package      'celerite' #options: george, celerite
 
 # Plotting controls
 interp          True    # Should astrophysical model be interpolated (useful for uneven sampling like that from HST)

--- a/tests/NIRSpec_ecfs/S5_NIRSpec.ecf
+++ b/tests/NIRSpec_ecfs/S5_NIRSpec.ecf
@@ -31,8 +31,9 @@ run_sample      'unif'
 run_tol         0.1
 
 #GP inputs
-kernel_inputs   ['time','time'] #options: time
-kernel_class    ['ExpSquared','Exp'] #options: ExpSquared, Matern32, Exp, RationalQuadratic
+kernel_inputs   ['time'] #options: time
+kernel_class    ['Matern32'] #options: ExpSquared, Matern32, Exp, RationalQuadratic for george, Matern32 for celerite (sums of kernels possible for george separated by commas)
+GP_package      'celerite' #options: george, celerite
 
 # Plotting controls
 interp          False    # Should astrophysical model be interpolated (useful for uneven sampling like that from HST)


### PR DESCRIPTION
- Some changes to parameters and how they are read in to be able to support shared parameters within the GP. 
- Added the gp package celerite and runs fine on individual channels, but I wasn't able to fully run with shared fits so it might be buggy still. 
- Also fixed that the lc.unc_fit is used within the GP model as the noise instead of lc.unc. 
- (There have also been some changes to the tinygp code but it doesn't work just yet so I need to do this for the next release.)