### PR TITLE
Changing the way inputdir is auto completed

### DIFF
--- a/demos/HST/run_eureka_wfc3.py
+++ b/demos/HST/run_eureka_wfc3.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.append('../../')
+import sys, os
+sys.path.append(f'..{os.sep}..{os.sep}')
 import eureka.lib.plots
 import eureka.S3_data_reduction.s3_reduce as s3
 import eureka.S4_generate_lightcurves.s4_genLC as s4
@@ -10,7 +10,7 @@ import eureka.S6_planet_spectra.s6_spectra as s6
 eureka.lib.plots.set_rc(style='eureka', usetex=False, filetype='.png')
 
 eventlabel = 'wfc3'
-ecf_path = './'
+ecf_path = '.'+os.sep
 
 if __name__ == '__main__':
 	s3_meta = s3.reduce(eventlabel, ecf_path=ecf_path)

--- a/demos/JWST/run_eureka.py
+++ b/demos/JWST/run_eureka.py
@@ -1,5 +1,5 @@
-import sys
-sys.path.insert(0, '../../')
+import sys, os
+sys.path.append(f'..{os.sep}..{os.sep}')
 import eureka.lib.plots
 import eureka.S1_detector_processing.s1_process as s1
 import eureka.S2_calibrations.s2_calibrate as s2
@@ -15,7 +15,7 @@ eureka.lib.plots.set_rc(style='eureka', usetex=False, filetype='.png')
 # eventlabel = 'miri_lrs_template'
 # eventlabel = 'nirspec_fs_template'
 eventlabel = 'nircam_wfss_template'
-ecf_path = './'
+ecf_path = '.'+os.sep
 
 if __name__ == '__main__':
 	#s1_meta = s1.rampfitJWST(eventlabel, ecf_path=ecf_path)

--- a/eureka/S1_detector_processing/s1_process.py
+++ b/eureka/S1_detector_processing/s1_process.py
@@ -18,17 +18,17 @@ class MetaClass:
     def __init__(self):
         return
 
-def rampfitJWST(eventlabel, ecf_path='./'):
+def rampfitJWST(eventlabel, ecf_path=None):
     '''Process a Stage 0, *_uncal.fits file to Stage 1 *_rate.fits and *_rateints.fits files.
 
     Steps taken to perform this processing can follow the default JWST pipeline, or alternative methods.  
 
     Parameters
     ----------
-    eventlabel: str
+    eventlabel : str
         The unique identifier for these data.
-    ecf_path:   str
-        The absolute or relative path to where ecfs are stored
+    ecf_path : str, optional
+        The absolute or relative path to where ecfs are stored. Defaults to None which resolves to './'.
 
     Returns
     -------
@@ -61,12 +61,12 @@ def rampfitJWST(eventlabel, ecf_path='./'):
     # Create directories for Stage 1 processing outputs
     # This code allows the input and output files to be stored outside of the Eureka! folder
     outputdir = os.path.join(meta.topdir, *meta.outputdir.split(os.sep))
-    if outputdir[-1]!='/':
-        outputdir += '/'
+    if outputdir[-1] != os.sep:
+        outputdir += os.sep
     run = util.makedirectory(meta, 'S1')
     meta.workdir = util.pathdirectory(meta, 'S1', run)
     # Add a trailing slash so we don't need to add it everywhere below
-    meta.workdir += '/'
+    meta.workdir += os.sep
     # Make a separate folder for plot outputs
     if not os.path.exists(meta.workdir+'figs'):
         os.makedirs(meta.workdir+'figs')
@@ -95,7 +95,7 @@ def rampfitJWST(eventlabel, ecf_path='./'):
     for m in range(istart, meta.num_data_files):
         # Report progress
         filename = meta.segment_list[m]
-        log.writelog(f'Starting file {m + 1} of {meta.num_data_files}: '+filename.split('/')[-1])
+        log.writelog(f'Starting file {m + 1} of {meta.num_data_files}: '+filename.split(os.sep)[-1])
 
         with fits.open(filename, mode='update') as hdulist:
             # jwst 1.3.3 breaks unless NDITHPTS/NRIMDTPT are integers rather than the strings that they are in the old simulated NIRCam data

--- a/eureka/S2_calibrations/s2_calibrate.py
+++ b/eureka/S2_calibrations/s2_calibrate.py
@@ -32,7 +32,7 @@ class MetaClass:
     def __init__(self):
         return
 
-def calibrateJWST(eventlabel, ecf_path='./', s1_meta=None):
+def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None):
     '''Reduces rateints spectrum or image files ouput from Stage 1 of the JWST pipeline into calints and x1dints.
 
     This function does the preparation for running the STScI's JWST pipeline and decides whether to run the
@@ -40,12 +40,12 @@ def calibrateJWST(eventlabel, ecf_path='./', s1_meta=None):
 
     Parameters
     ----------
-    eventlabel: str
+    eventlabel : str
         Unique label for this dataset
-    ecf_path:   str
-        The absolute or relative path to where ecfs are stored
-    s1_meta:    MetaClass
-        The metadata object from Eureka!'s S1 step (if running S1 and S2 sequentially).
+    ecf_path : str, optional
+        The absolute or relative path to where ecfs are stored. Defaults to None which resolves to './'.
+    s1_meta : MetaClass, optional
+        The metadata object from Eureka!'s S1 step (if running S1 and S2 sequentially). Defaults to None.
 
     Returns
     -------
@@ -67,28 +67,26 @@ def calibrateJWST(eventlabel, ecf_path='./', s1_meta=None):
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
 
-    if s1_meta == None:
-        #load savefile
-        s1_meta = read_s1_meta(meta)
-
-    if s1_meta != None:
-        meta = load_general_s1_meta_info(meta, ecf_path, s1_meta)
+    if s1_meta is None:
+        # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
+        s1_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S2', allowFail=True)
     else:
+        # Running these stages sequentially, so can safely assume the path hasn't changed
+        meta.inputdir = s1_meta.outputdir
+        meta.inputdir_raw = meta.inputdir[len(meta.topdir):]
+    
+    if s1_meta is None:
         # Attempt to find subdirectory containing S1 FITS files
-        meta = find_s1_files(meta)
-
-        # Create directories for Stage 2 processing outputs
-        meta.inputdir_raw = meta.inputdir
-        meta.outputdir_raw = meta.outputdir
-        meta.inputdir = os.path.join(meta.topdir, *meta.inputdir_raw.split(os.sep))
-        meta.outputdir = os.path.join(meta.topdir, *meta.outputdir_raw.split(os.sep))
+        meta = util.find_fits(meta)    
+    else:
+        meta = me.mergeevents(meta, s1_meta)
     
     run = util.makedirectory(meta, 'S2')
     meta.outputdir = util.pathdirectory(meta, 'S2', run)
 
     # Output S2 log file
     meta.s2_logname = meta.outputdir + 'S2_' + meta.eventlabel + ".log"
-    if s1_meta != None:
+    if s1_meta is not None:
         log = logedit.Logedit(meta.s2_logname, read=s1_meta.s1_logname)
     else:
         log = logedit.Logedit(meta.s2_logname)
@@ -160,160 +158,6 @@ def calibrateJWST(eventlabel, ecf_path='./', s1_meta=None):
 
     log.closelog()
     
-    return meta
-
-
-def read_s1_meta(meta):
-    '''Loads in an S1 meta file.
-
-    Parameters
-    ----------
-    meta:    MetaClass
-        The new meta object for the current S2 processing.
-
-    Returns
-    -------
-    s1_meta:   MetaClass
-        The S1 metadata object.
-
-    Notes
-    -------
-    History:
-
-    - April 15, 2022 Taylor Bell
-        Initial version.
-    '''
-    # Search for the S1 output metadata in the inputdir provided in
-    # First just check the specific inputdir folder
-    rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-    if rootdir[-1]!='/':
-        rootdir += '/'
-    fnames = glob.glob(rootdir+'S1_'+meta.eventlabel+'*_Meta_Save.dat')
-    if len(fnames)==0:
-        # There were no metadata files in that folder, so let's see if there are in children folders
-        fnames = glob.glob(rootdir+'**/S1_'+meta.eventlabel+'*_Meta_Save.dat', recursive=True)
-
-    if len(fnames)>=1:
-        # get the folder with the latest modified time
-        fname = max(fnames, key=os.path.getmtime)
-    
-    if len(fnames)==0:
-        # There may be no rateints files in the inputdir or any of its children directories - raise an error and give a helpful message
-        print('WARNING: Unable to find an output metadata file from Eureka!\'s S1 step '
-             +'in the inputdir: \n"{}"!\n'.format(meta.inputdir)
-             +'Assuming this S1 data was produced by the JWST pipeline instead.')
-        return None
-    elif len(fnames)>1:
-        # There may be multiple runs - use the most recent but warn the user
-        print('WARNING: There are multiple metadata save files in your inputdir: \n"{}"\n'.format(rootdir)
-                +'Using the metadata file: \n{}\n'.format(fname)
-                +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
-                +'of the run you intended, please provide a more precise folder for the metadata file.')
-
-    fname = fname[:-4] # Strip off the .dat ending
-
-    s1_meta = me.loadevent(fname)
-
-    # Code to not break backwards compatibility with old MetaClass save files but also use the new MetaClass going forwards
-    s1_meta = readECF.MetaClass(**s1_meta.__dict__)
-
-    return s1_meta
-
-def find_s1_files(meta):
-    '''Locates S1 output FITS files if not running S1 and S2 sequentially.
-
-    Parameters
-    ----------
-    meta:    MetaClass
-        The new meta object for the current S2 processing.
-
-    Returns
-    -------
-    meta:   MetaClass
-        The meta object with the updated inputdir pointing to the location of
-        the input files to use.
-
-    Notes
-    -------
-    History:
-
-    - April 15, 2022 Taylor Bell
-        Initial version.
-    '''
-    rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-    if rootdir[-1]!='/':
-        rootdir += '/'
-    fnames = glob.glob(rootdir+'*'+meta.suffix + '.fits')
-    if len(fnames)==0:
-        # There were no rateints files in that folder, so let's see if there are in children folders
-        fnames = glob.glob(rootdir+'**/*'+meta.suffix + '.fits', recursive=True)
-        fnames = sn.sort_nicely(fnames)
-
-    if len(fnames)==0:
-        # If the code can't find any of the reqested files, raise an error and give a helpful message
-        raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files in the inputdir: \n"{meta.inputdir}"!\n'+
-                             f'You likely need to change the inputdir in {meta.filename} to point to the folder containing the "{meta.suffix}.fits" files.')
-    
-    folders = np.unique([os.sep.join(fname.split(os.sep)[:-1]) for fname in fnames])
-    if len(folders)>=1:
-        # get the file with the latest modified time
-        folder = max(folders, key=os.path.getmtime)
-    
-    if len(folders)>1:
-        # There may be multiple runs - use the most recent but warn the user
-        print(f'WARNING: There are multiple folders containing "{meta.suffix}.fits" files in your inputdir: \n"{meta.inputdir}"\n'
-             +f'Using the files in: \n{folder}\n'
-              +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
-              +'of the run you intended, please provide a more precise folder for the metadata file.')
-
-    meta.inputdir = folder[len(meta.topdir):]
-    if meta.inputdir[-1] != '/':
-        meta.inputdir += '/'
-
-    return meta
-
-def load_general_s1_meta_info(meta, ecf_path, s1_meta):
-    '''Loads in the S1 meta save file and adds in attributes from the S2 ECF.
-
-    Parameters
-    ----------
-    meta:    MetaClass
-        The new meta object for the current S2 processing.
-    ecf_path:
-        The absolute path to where the S2 ECF is stored.
-
-    Returns
-    -------
-    meta:   MetaClass
-        The S1 metadata object with attributes added by S2.
-
-    Notes
-    -------
-    History:
-
-    - April 15, 2022 Taylor Bell
-        Initial version.
-    '''
-    # Need to remove the topdir from the outputdir
-    s1_outputdir = s1_meta.outputdir[len(meta.topdir):]
-    if s1_outputdir[0]=='/':
-        s1_outputdir = s1_outputdir[1:]
-    if s1_outputdir[-1]!='/':
-        s1_outputdir += '/'
-    s1_topdir = s1_meta.topdir
-    
-    # Load S2 Eureka! control file and store values in the S1 metadata object
-    ecffile = 'S2_' + meta.eventlabel + '.ecf'
-    meta = s1_meta
-    meta.read(ecf_path, ecffile)
-
-    # Overwrite the inputdir with the exact output directory from S1
-    meta.inputdir = os.path.join(s1_topdir, s1_outputdir)
-    meta.old_datetime = meta.datetime # Capture the date that the S1 data was made (to figure out it's foldername)
-    meta.datetime = None # Reset the datetime in case we're running this on a different day
-    meta.inputdir_raw = s1_outputdir
-    meta.outputdir_raw = meta.outputdir
-
     return meta
 
 class EurekaSpec2Pipeline(Spec2Pipeline):
@@ -415,7 +259,7 @@ class EurekaSpec2Pipeline(Spec2Pipeline):
             max_m = meta.num_data_files
             fig_number = str(m).zfill(int(np.floor(np.log10(max_m))+1))
             fname = f'fig2101_file{fig_number}_x1dints'
-            x1d_fname = '_'.join(filename.split('/')[-1].split('_')[:-1])+'_x1dints'
+            x1d_fname = '_'.join(filename.split(os.sep)[-1].split('_')[:-1])+'_x1dints'
             with datamodels.open(meta.outputdir+x1d_fname+'.fits') as sp1d:
                 plt.figure(2101, figsize=[15,5])
                 plt.clf()
@@ -426,7 +270,7 @@ class EurekaSpec2Pipeline(Spec2Pipeline):
                 plt.title('Time Series Observation: Extracted spectra')
                 plt.xlabel('Wavelength (micron)')
                 plt.ylabel('Flux')
-                plt.savefig(meta.outputdir+'figs/'+fname+figure_filetype, bbox_inches='tight', dpi=300)
+                plt.savefig(meta.outputdir+'figs'+os.sep+fname+figure_filetype, bbox_inches='tight', dpi=300)
                 if meta.hide_plots:
                     plt.close()
                 else:

--- a/eureka/S3_data_reduction/background.py
+++ b/eureka/S3_data_reduction/background.py
@@ -248,7 +248,7 @@ def fitbg(dataim, meta, mask, x1, x2, deg=1, threshold=5, isrotate=False, isplot
                     plt.title(str(j))
                     plt.plot(goodxvals, dataslice, 'bo')
                     plt.plot(range(nx), bg[j], 'g-')
-                    plt.savefig(meta.outputdir + 'figs/Fig6_BG_'+str(j)+figure_filetype, dpi=300)
+                    plt.savefig(meta.outputdir + 'figs'+os.sep+'Fig6_BG_'+str(j)+figure_filetype, dpi=300)
                     plt.pause(0.01)
 
     if isrotate == 1:
@@ -356,7 +356,7 @@ def fitbg2(dataim, meta, mask, bgmask, deg=1, threshold=5, isrotate=False, isplo
                         plt.title(str(j))
                         plt.plot(goodxvals, dataslice, 'bo')
                         plt.plot(goodxvals, model, 'g-')
-                        plt.savefig(meta.outputdir + 'figs/Fig6_BG_'+str(j)+figure_filetype, dpi=300)
+                        plt.savefig(meta.outputdir + 'figs'+os.sep+'Fig6_BG_'+str(j)+figure_filetype, dpi=300)
                         plt.pause(0.01)
 
                     # Calculate residuals

--- a/eureka/S3_data_reduction/plots_s3.py
+++ b/eureka/S3_data_reduction/plots_s3.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 import matplotlib.pyplot as plt
 from .source_pos import gauss
 from ..lib.plots import figure_filetype
@@ -35,7 +36,7 @@ def lc_nodriftcorr(meta, wave_1d, optspec):
     plt.xlabel(r'Wavelength ($\mu m$)')
     plt.colorbar(label='Normalized Flux')
     plt.tight_layout()
-    plt.savefig(meta.outputdir + 'figs/fig3101-2D_LC'+figure_filetype, dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+'fig3101-2D_LC'+figure_filetype, dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
 
@@ -79,7 +80,7 @@ def image_and_background(data, meta, n, m):
     plt.tight_layout()
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
     int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
-    plt.savefig(meta.outputdir + f'figs/fig3301_file{file_number}_int{int_number}_ImageAndBackground'+figure_filetype, dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig3301_file{file_number}_int{int_number}_ImageAndBackground'+figure_filetype, dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
 
@@ -115,7 +116,7 @@ def optimal_spectrum(data, meta, n, m):
     plt.tight_layout()
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
     int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
-    plt.savefig(meta.outputdir + f'figs/fig3302_file{file_number}_int{int_number}_Spectrum'+figure_filetype, dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig3302_file{file_number}_int{int_number}_Spectrum'+figure_filetype, dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
 
@@ -178,7 +179,7 @@ def source_position(meta, x_dim, pos_max, m,
     plt.legend()
     plt.tight_layout()
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
-    plt.savefig(meta.outputdir + f'figs/fig3303_file{file_number}_source_pos'+figure_filetype, dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig3303_file{file_number}_source_pos'+figure_filetype, dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
 
@@ -218,7 +219,7 @@ def profile(meta, profile, submask, n, m):
     plt.tight_layout()
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
     int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
-    plt.savefig(meta.outputdir + f'figs/fig3304_file{file_number}_int{int_number}_Profile'+figure_filetype, dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig3304_file{file_number}_int{int_number}_Profile'+figure_filetype, dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
 
@@ -258,6 +259,6 @@ def subdata(meta, i, n, m, subdata, submask, expected, loc):
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
     int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
     col_number = str(i).zfill(int(np.floor(np.log10(nx))+1))
-    plt.savefig(meta.outputdir + f"figs/fig3501_file{file_number}_int{int_number}_col{col_number}_subdata"+figure_filetype, dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig3501_file{file_number}_int{int_number}_col{col_number}_subdata'+figure_filetype, dpi=300)
     if not meta.hide_plots:
         plt.pause(0.1)

--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -116,17 +116,16 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
         meta.bg_hw_range = [meta.bg_hw]
 
     # create directories to store data
-    meta.runs_s3 = [] # Used to make sure we're always looking at the right run for each aperture/annulus pair
+    meta.run_s3 = None # Used to make sure we're always looking at the right run for each aperture/annulus pair
     for spec_hw_val in meta.spec_hw_range:
 
         for bg_hw_val in meta.bg_hw_range:
 
             meta.eventlabel = eventlabel
 
-            meta.runs_s3.append(util.makedirectory(meta, 'S3', ap=spec_hw_val, bg=bg_hw_val))
+            meta.run_s3 = util.makedirectory(meta, 'S3', meta.run_s3, ap=spec_hw_val, bg=bg_hw_val)
 
     # begin process
-    run_i = 0
     for spec_hw_val in meta.spec_hw_range:
 
         for bg_hw_val in meta.bg_hw_range:
@@ -136,8 +135,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
             meta.spec_hw = spec_hw_val
             meta.bg_hw = bg_hw_val
 
-            meta.outputdir = util.pathdirectory(meta, 'S3', meta.runs_s3[run_i], ap=spec_hw_val, bg=bg_hw_val)
-            run_i += 1
+            meta.outputdir = util.pathdirectory(meta, 'S3', meta.run_s3, ap=spec_hw_val, bg=bg_hw_val)
 
             event_ap_bg = meta.eventlabel + "_ap" + str(spec_hw_val) + '_bg' + str(bg_hw_val)
 

--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -55,17 +55,17 @@ class DataClass:
         return
 
 
-def reduce(eventlabel, ecf_path='./', s2_meta=None):
+def reduce(eventlabel, ecf_path=None, s2_meta=None):
     '''Reduces data images and calculates optimal spectra.
 
     Parameters
     ----------
-    eventlabel: str
+    eventlabel : str
         The unique identifier for these data.
-    ecf_path:   str
-        The absolute or relative path to where ecfs are stored
-    s2_meta:    MetaClass
-        The metadata object from Eureka!'s S2 step (if running S2 and S3 sequentially).
+    ecf_path : str, optional
+        The absolute or relative path to where ecfs are stored. Defaults to None which resolves to './'.
+    s2_meta : MetaClass, optional
+        The metadata object from Eureka!'s S2 step (if running S2 and S3 sequentially). Defaults to None.
 
     Returns
     -------
@@ -89,17 +89,19 @@ def reduce(eventlabel, ecf_path='./', s2_meta=None):
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
 
-    if s2_meta == None:
-        #load savefile
-        s2_meta = read_s2_meta(meta)
-
-    if s2_meta != None:
-        meta = load_general_s2_meta_info(meta, ecf_path, s2_meta)
+    if s2_meta is None:
+        # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
+        s2_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S2', allowFail=True)
     else:
-        meta.inputdir_raw = meta.inputdir
-        meta.outputdir_raw = meta.outputdir
-        meta.inputdir = os.path.join(meta.topdir, *meta.inputdir_raw.split(os.sep))
-        meta.outputdir = os.path.join(meta.topdir, *meta.outputdir_raw.split(os.sep))
+        # Running these stages sequentially, so can safely assume the path hasn't changed
+        meta.inputdir = s2_meta.outputdir
+        meta.inputdir_raw = meta.inputdir[len(meta.topdir):]
+    
+    if s2_meta is None:
+        # Attempt to find subdirectory containing S2 FITS files
+        meta = util.find_fits(meta)    
+    else:
+        meta = me.mergeevents(meta, s2_meta)
 
     # check for range of spectral apertures
     if isinstance(meta.spec_hw, list):
@@ -114,14 +116,14 @@ def reduce(eventlabel, ecf_path='./', s2_meta=None):
         meta.bg_hw_range = [meta.bg_hw]
 
     # create directories to store data
-    meta.runs = [] # Used to make sure we're always looking at the right run for each aperture/annulus pair
+    meta.runs_s3 = [] # Used to make sure we're always looking at the right run for each aperture/annulus pair
     for spec_hw_val in meta.spec_hw_range:
 
         for bg_hw_val in meta.bg_hw_range:
 
             meta.eventlabel = eventlabel
 
-            meta.runs.append(util.makedirectory(meta, 'S3', ap=spec_hw_val, bg=bg_hw_val))
+            meta.runs_s3.append(util.makedirectory(meta, 'S3', ap=spec_hw_val, bg=bg_hw_val))
 
     # begin process
     run_i = 0
@@ -134,14 +136,14 @@ def reduce(eventlabel, ecf_path='./', s2_meta=None):
             meta.spec_hw = spec_hw_val
             meta.bg_hw = bg_hw_val
 
-            meta.outputdir = util.pathdirectory(meta, 'S3', meta.runs[run_i], ap=spec_hw_val, bg=bg_hw_val)
+            meta.outputdir = util.pathdirectory(meta, 'S3', meta.runs_s3[run_i], ap=spec_hw_val, bg=bg_hw_val)
             run_i += 1
 
             event_ap_bg = meta.eventlabel + "_ap" + str(spec_hw_val) + '_bg' + str(bg_hw_val)
 
             # Open new log file
             meta.s3_logname = meta.outputdir + 'S3_' + event_ap_bg + ".log"
-            if s2_meta != None:
+            if s2_meta is not None:
                 log = logedit.Logedit(meta.s3_logname, read=s2_meta.s2_logname)
             else:
                 log = logedit.Logedit(meta.s3_logname)
@@ -355,106 +357,5 @@ def reduce(eventlabel, ecf_path='./', s2_meta=None):
                 me.saveevent(meta, meta.outputdir + 'S3_' + event_ap_bg + "_Meta_Save", save=[])
 
             log.closelog()
-
-    return meta
-
-def read_s2_meta(meta):
-    '''Loads in an S2 meta file.
-
-    Parameters
-    ----------
-    meta:    MetaClass
-        The new meta object for the current S3 processing.
-
-    Returns
-    -------
-    s2_meta:   MetaClass
-        The S2 metadata object.
-
-    Notes
-    -------
-    History:
-
-    - March 2022 Taylor Bell
-        Initial version.
-    '''
-    # Search for the S2 output metadata in the inputdir provided in
-    # First just check the specific inputdir folder
-    rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-    if rootdir[-1]!='/':
-        rootdir += '/'
-    fnames = glob.glob(rootdir+'S2_'+meta.eventlabel+'*_Meta_Save.dat')
-    if len(fnames)==0:
-        # There were no metadata files in that folder, so let's see if there are in children folders
-        fnames = glob.glob(rootdir+'**/S2_'+meta.eventlabel+'*_Meta_Save.dat', recursive=True)
-        fnames = sn.sort_nicely(fnames)
-
-    if len(fnames)>=1:
-        # get the folder with the latest modified time
-        fname = max(fnames, key=os.path.getmtime)
-
-    if len(fnames)==0:
-        # There may be no metafiles in the inputdir - raise an error and give a helpful message
-        print('WARNING: Unable to find an output metadata file from Eureka!\'s S2 step '
-                +'in the inputdir: \n"{}"!\n'.format(meta.inputdir)
-                +'Assuming this S2 data was produced by the JWST pipeline instead.')
-        return None
-    elif len(fnames)>1:
-        # There may be multiple runs - use the most recent but warn the user
-        print('WARNING: There are multiple metadata save files in your inputdir: \n"{}"\n'.format(rootdir)
-                +'Using the metadata file: \n{}\n'.format(fname)
-                +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
-                +'of the run you intended, please provide a more precise folder for the metadata file.')
-
-    fname = fname[:-4] # Strip off the .dat ending
-
-    s2_meta = me.loadevent(fname)
-
-    # Code to not break backwards compatibility with old MetaClass save files but also use the new MetaClass going forwards
-    s2_meta = readECF.MetaClass(**s2_meta.__dict__)
-
-    return s2_meta
-
-def load_general_s2_meta_info(meta, ecf_path, s2_meta):
-    '''Loads in the S2 meta save file and adds in attributes from the S3 ECF.
-
-    Parameters
-    ----------
-    meta:    MetaClass
-        The new meta object for the current S3 processing.
-    ecf_path:
-        The absolute path to where the S3 ECF is stored.
-
-    Returns
-    -------
-    meta:   MetaClass
-        The S2 metadata object with attributes added by S3.
-
-    Notes
-    -------
-    History:
-
-    - March 2022 Taylor Bell
-        Initial version.
-    '''
-    # Need to remove the topdir from the outputdir
-    s2_outputdir = s2_meta.outputdir[len(meta.topdir):]
-    if s2_outputdir[0]=='/':
-        s2_outputdir = s2_outputdir[1:]
-    if s2_outputdir[-1]!='/':
-        s2_outputdir += '/'
-    s2_topdir = s2_meta.topdir
-    
-    # Load S3 Eureka! control file and store values in the S2 metadata object
-    ecffile = 'S3_' + meta.eventlabel + '.ecf'
-    meta = s2_meta
-    meta.read(ecf_path, ecffile)
-
-    # Overwrite the inputdir with the exact output directory from S2
-    meta.inputdir = os.path.join(s2_topdir, s2_outputdir)
-    meta.old_datetime = meta.datetime # Capture the date that the S2 data was made (to figure out it's foldername)
-    meta.datetime = None # Reset the datetime in case we're running this on a different day
-    meta.inputdir_raw = s2_outputdir
-    meta.outputdir_raw = meta.outputdir
 
     return meta

--- a/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/eureka/S4_generate_lightcurves/plots_s4.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 import matplotlib.pyplot as plt
 from ..lib import util
 from ..lib.plots import figure_filetype
@@ -33,7 +34,7 @@ def binned_lightcurve(meta, i):
 
     plt.subplots_adjust(left=0.10, right=0.95, bottom=0.10, top=0.90, hspace=0.20, wspace=0.3)
     ch_number = str(i).zfill(int(np.floor(np.log10(meta.nspecchan))+1))
-    plt.savefig(meta.outputdir + f'figs/Fig4102_ch{ch_number}_1D_LC'+figure_filetype, bbox_inches='tight', dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig4102_ch{ch_number}_1D_LC'+figure_filetype, bbox_inches='tight', dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
 
@@ -55,7 +56,7 @@ def drift1d(meta):
     plt.ylabel('Spectrum Drift Along x')
     plt.xlabel('Frame Number')
     plt.tight_layout()
-    plt.savefig(meta.outputdir + 'figs/Fig4103_Drift'+figure_filetype, bbox_inches='tight', dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig4103_Drift'+figure_filetype, bbox_inches='tight', dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
 
@@ -96,7 +97,7 @@ def lc_driftcorr(meta, wave_1d, optspec):
     plt.xlabel(r'Wavelength ($\mu m$)')
     plt.colorbar(label='Normalized Flux')
     plt.tight_layout()
-    plt.savefig(meta.outputdir + 'figs/Fig4101_2D_LC'+figure_filetype, bbox_inches='tight', dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig4101_2D_LC'+figure_filetype, bbox_inches='tight', dpi=300)
     if meta.hide_plots:
         plt.close()
     else:
@@ -130,7 +131,7 @@ def cc_spec(meta, ref_spec, fit_spec, n):
     plt.legend(loc='best')
     plt.tight_layout()
     int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
-    plt.savefig(meta.outputdir + f'figs/Fig4301_int{int_number}_CC_Spec'+figure_filetype, bbox_inches='tight', dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig4301_int{int_number}_CC_Spec'+figure_filetype, bbox_inches='tight', dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
 
@@ -156,6 +157,6 @@ def cc_vals(meta, vals, n):
     plt.plot(np.arange(-meta.drift_range,meta.drift_range+1), vals, '.')
     plt.tight_layout()
     int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
-    plt.savefig(meta.outputdir + f'figs/Fig4302_int{int_number}_CC_Vals'+figure_filetype, bbox_inches='tight', dpi=300)
+    plt.savefig(meta.outputdir + 'figs'+os.sep+f'fig4302_int{int_number}_CC_Vals'+figure_filetype, bbox_inches='tight', dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -85,14 +85,11 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None):
         meta.bg_hw_range = [meta.bg_hw,]
 
     # Create directories for Stage 5 outputs
-    meta.runs_s4 = []
+    meta.run_s4 = None
     for spec_hw_val in meta.spec_hw_range:
         for bg_hw_val in meta.bg_hw_range:
-            run = util.makedirectory(meta, 'S4', ap=spec_hw_val, bg=bg_hw_val)
-            meta.runs_s4.append(run)
+            meta.run_s4 = util.makedirectory(meta, 'S4', meta.run_s4, ap=spec_hw_val, bg=bg_hw_val)
 
-    run_i = 0
-    old_meta = meta
     for spec_hw_val in meta.spec_hw_range:
         for bg_hw_val in meta.bg_hw_range:
 
@@ -105,8 +102,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None):
             meta = load_specific_s3_meta_info(meta)
 
             # Get directory for Stage 4 processing outputs
-            meta.outputdir = util.pathdirectory(meta, 'S4', meta.runs_s4[run_i], ap=meta.spec_hw, bg=meta.bg_hw)
-            run_i += 1
+            meta.outputdir = util.pathdirectory(meta, 'S4', meta.run_s4, ap=meta.spec_hw, bg=meta.bg_hw)
 
             # Copy existing S3 log file and resume log
             meta.s4_logname = meta.outputdir + 'S4_' + meta.eventlabel + ".log"

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -115,7 +115,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None):
             log.writelog('Copying S4 control file', mute=(not meta.verbose))
             meta.copy_ecf()
 
-            log.writelog("Loading S3 save file", mute=(not meta.verbose))
+            log.writelog(f"Loading S3 save file:\n{meta.tab_filename}", mute=(not meta.verbose))
             table = astropytable.readtable(meta.tab_filename)
 
             # Reverse the reshaping which has been done when saving the astropy table
@@ -241,7 +241,9 @@ def load_specific_s3_meta_info(meta):
     # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
     meta.inputdir = inputdir
     s3_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S3', allowFail=False)
+    tab_filename = s3_meta.tab_filename
     # Merge S4 meta into old S3 meta
     meta = me.mergeevents(meta, s3_meta)
+    meta.tab_filename = tab_filename
 
     return meta

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -38,17 +38,17 @@ class MetaClass:
         return
 
 
-def genlc(eventlabel, ecf_path='./', s3_meta=None):
+def genlc(eventlabel, ecf_path=None, s3_meta=None):
     '''Compute photometric flux over specified range of wavelengths.
 
     Parameters
     ----------
-    eventlabel: str
+    eventlabel : str
         The unique identifier for these data.
-    ecf_path:   str
-        The absolute or relative path to where ecfs are stored
-    s3_meta:    MetaClass
-        The metadata object from Eureka!'s S3 step (if running S3 and S4 sequentially).
+    ecf_path : str, optional
+        The absolute or relative path to where ecfs are stored. Defaults to None which resolves to './'.
+    s3_meta : MetaClass
+        The metadata object from Eureka!'s S3 step (if running S3 and S4 sequentially). Defaults to None.
 
     Returns
     -------
@@ -69,11 +69,15 @@ def genlc(eventlabel, ecf_path='./', s3_meta=None):
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
 
-    if s3_meta == None:
-        #load savefile
-        s3_meta = read_s3_meta(meta)
-
-    meta = load_general_s3_meta_info(meta, ecf_path, s3_meta)
+    if s3_meta is None:
+        # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
+        s3_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S3', allowFail=False)
+    else:
+        # Running these stages sequentially, so can safely assume the path hasn't changed
+        meta.inputdir = s3_meta.outputdir
+        meta.inputdir_raw = meta.inputdir[len(meta.topdir):]
+    
+    meta = me.mergeevents(meta, s3_meta)
 
     if not meta.allapers:
         # The user indicated in the ecf that they only want to consider one aperture
@@ -94,15 +98,19 @@ def genlc(eventlabel, ecf_path='./', s3_meta=None):
 
             t0 = time_pkg.time()
 
-            meta = load_specific_s3_meta_info(old_meta, ecf_path, run_i, spec_hw_val, bg_hw_val)
+            meta.spec_hw = spec_hw_val
+            meta.bg_hw = bg_hw_val
+
+            # Load in the S3 metadata used for this particular aperture pair
+            meta = load_specific_s3_meta_info(meta)
 
             # Get directory for Stage 4 processing outputs
-            meta.outputdir = util.pathdirectory(meta, 'S4', meta.runs_s4[run_i], ap=spec_hw_val, bg=bg_hw_val)
+            meta.outputdir = util.pathdirectory(meta, 'S4', meta.runs_s4[run_i], ap=meta.spec_hw, bg=meta.bg_hw)
             run_i += 1
 
             # Copy existing S3 log file and resume log
-            meta.s4_logname  = meta.outputdir + 'S4_' + meta.eventlabel + ".log"
-            log         = logedit.Logedit(meta.s4_logname, read=meta.s3_logname)
+            meta.s4_logname = meta.outputdir + 'S4_' + meta.eventlabel + ".log"
+            log = logedit.Logedit(meta.s4_logname, read=meta.s3_logname)
             log.writelog("\nStarting Stage 4: Generate Light Curves\n")
             log.writelog(f"Input directory: {meta.inputdir}")
             log.writelog(f"Output directory: {meta.outputdir}")
@@ -230,93 +238,14 @@ def genlc(eventlabel, ecf_path='./', s3_meta=None):
 
     return meta
 
-def read_s3_meta(meta):
-
-    # Search for the S2 output metadata in the inputdir provided in
-    # First just check the specific inputdir folder
-    rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-    if rootdir[-1]!='/':
-        rootdir += '/'
-    fnames = glob.glob(rootdir+'S3_'+meta.eventlabel+'*_Meta_Save.dat')
-    if len(fnames)==0:
-        # There were no metadata files in that folder, so let's see if there are in children folders
-        fnames = glob.glob(rootdir+'**/S3_'+meta.eventlabel+'*_Meta_Save.dat', recursive=True)
-        fnames = sn.sort_nicely(fnames)
-
-    if len(fnames)>=1:
-        # get the folder with the latest modified time
-        fname = max(fnames, key=os.path.getmtime)
-
-    if len(fnames)==0:
-        # There may be no metafiles in the inputdir - raise an error and give a helpful message
-        raise AssertionError('Unable to find an output metadata file from Eureka!\'s S3 step '
-                            +'in the inputdir: \n"{}"!'.format(rootdir))
-    elif len(fnames)>1:
-        # There may be multiple runs - use the most recent but warn the user
-        print('WARNING: There are multiple metadata save files in your inputdir: \n"{}"\n'.format(rootdir)
-                +'Using the metadata file: \n{}\n'.format(fname)
-                +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
-                +'of the run you intended, please provide a more precise folder for the metadata file.')
-
-    fname = fname[:-4] # Strip off the .dat ending
-
-    s3_meta = me.loadevent(fname)
-
-    # Code to not break backwards compatibility with old MetaClass save files but also use the new MetaClass going forwards
-    s3_meta = readECF.MetaClass(**s3_meta.__dict__)
-
-    return s3_meta
-
-def load_general_s3_meta_info(meta, ecf_path, s3_meta):
-    # Need to remove the topdir from the outputdir
-    s3_outputdir = s3_meta.outputdir[len(meta.topdir):]
-    if s3_outputdir[0]=='/':
-        s3_outputdir = s3_outputdir[1:]
-    if s3_outputdir[-1]!='/':
-        s3_outputdir += '/'
-
-    meta = s3_meta
-
-    # Load S4 Eureka! control file and store values in the S3 metadata object
-    ecffile = 'S4_' + meta.eventlabel + '.ecf'
-    meta.read(ecf_path, ecffile)
-
-    # Overwrite the inputdir with the exact output directory from S3
-    meta.inputdir = s3_outputdir
-    meta.old_datetime = meta.datetime  # Capture the date that the S3 data was made (to figure out it's foldername)
-    meta.datetime = None # Reset the datetime in case we're running this on a different day
-    meta.inputdir_raw = meta.inputdir
-    meta.outputdir_raw = meta.outputdir
+def load_specific_s3_meta_info(meta):
+    # Get directory containing S3 outputs for this aperture pair
+    inputdir = os.sep.join(meta.inputdir.split(os.sep)[:-2]) + os.sep
+    inputdir += f'ap{meta.spec_hw}_bg{meta.bg_hw}'+os.sep
+    # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
+    meta.inputdir = inputdir
+    s3_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S3', allowFail=False)
+    # Merge S4 meta into old S3 meta
+    meta = me.mergeevents(meta, s3_meta)
 
     return meta
-
-def load_specific_s3_meta_info(meta, ecf_path, run_i, spec_hw_val, bg_hw_val):
-    # Do some folder swapping to be able to reuse this function to find the correct S3 outputs
-    tempfolder = meta.outputdir_raw
-    meta.outputdir_raw = '/'.join(meta.inputdir_raw.split('/')[:-2])
-    meta.inputdir = util.pathdirectory(meta, 'S3', meta.runs[run_i], old_datetime=meta.old_datetime, ap=spec_hw_val, bg=bg_hw_val)
-    meta.outputdir_raw = tempfolder
-
-    # Read in the correct S3 metadata for this aperture pair
-    tempfolder = meta.inputdir
-    meta.inputdir = meta.inputdir[len(meta.topdir):]
-    new_meta = read_s3_meta(meta)
-    meta.inputdir = tempfolder
-
-    # Load S4 Eureka! control file and store values in the S3 metadata object
-    ecffile = 'S4_' + meta.eventlabel + '.ecf'
-    new_meta.read(ecf_path, ecffile)
-
-    # Save correctly identified folders from earlier
-    new_meta.inputdir = meta.inputdir
-    new_meta.outputdir = meta.outputdir
-    new_meta.inputdir_raw = meta.inputdir_raw
-    new_meta.outputdir_raw = meta.outputdir_raw
-
-    new_meta.runs_s4 = meta.runs_s4
-    new_meta.datetime = meta.datetime
-
-    new_meta.spec_hw = spec_hw_val
-    new_meta.bg_hw = bg_hw_val
-
-    return new_meta

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -204,7 +204,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None):
 
                 # Do 1D sigma clipping (along time axis) on binned spectra
                 if meta.sigma_clip:
-                    meta.lcdata[i], outliers = clipping.clip_outliers(meta.lcdata[i], log, wave_1d[l], meta.sigma, meta.box_width, meta.maxiters, meta.boundary, meta.fill_value, verbose=False)
+                    meta.lcdata[i], outliers = clipping.clip_outliers(meta.lcdata[i], log, np.mean([meta.wave_low[i], meta.wave_hi[i]]), meta.sigma, meta.box_width, meta.maxiters, meta.boundary, meta.fill_value, verbose=False)
                     log.writelog('  Sigma clipped {} outliers in time series'.format(outliers))
 
                 # Plot each spectroscopic light curve

--- a/eureka/S5_lightcurve_fitting/lightcurve.py
+++ b/eureka/S5_lightcurve_fitting/lightcurve.py
@@ -4,6 +4,7 @@ Author: Joe Filippazzo
 Email: jfilippazzo@stsci.edu
 """
 import numpy as np
+import os
 import pandas as pd
 import matplotlib.pyplot as plt
 
@@ -207,7 +208,7 @@ class LightCurve(m.Model):
             fig.tight_layout()
 
             ch_number = str(channel).zfill(len(str(self.nchannel)))
-            fname = f'figs/fig5103_ch{ch_number}_all_fits'+figure_filetype
+            fname = 'figs'+os.sep+f'fig5103_ch{ch_number}_all_fits'+figure_filetype
             fig.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
             if meta.hide_plots:
                 plt.close()

--- a/eureka/S5_lightcurve_fitting/modelgrid.py
+++ b/eureka/S5_lightcurve_fitting/modelgrid.py
@@ -84,7 +84,7 @@ class ModelGrid(object):
 
         # Check for a precomputed pickle of this ModelGrid
         model_grid = None
-        if model_directory.endswith('/*'):
+        if model_directory.endswith(os.sep+'*'):
             # Location of model_grid pickle
             file = model_directory.replace('*', 'model_grid.p')
 
@@ -108,12 +108,12 @@ class ModelGrid(object):
         else:
 
             # Print update...
-            if model_directory.endswith('/*'):
+            if model_directory.endswith(os.sep+'*'):
 
                 print("Indexing models...")
 
             # Create some attributes
-            self.path = os.path.dirname(model_directory)+'/'
+            self.path = os.path.dirname(model_directory)+os.sep
             self.refs = None
             self.wave_rng = (0*q.um, 40*q.um)
             self.flux_file = os.path.join(self.path, 'model_grid_flux.hdf5')
@@ -149,7 +149,7 @@ class ModelGrid(object):
                         keys = np.array(header.cards).T[0]
                         dtypes = [type(i[1]) for i in header.cards]
                         vals.append([header.get(k) for k in keys])
-                        filenames.append(f.split('/')[-1])
+                        filenames.append(f.split(os.sep)[-1])
                     except:
                         print(f, 'could not be read into the model grid.')
 
@@ -186,7 +186,7 @@ class ModelGrid(object):
             self.FeH_vals = np.asarray(np.unique(table['FeH']))
 
             # Write an inventory file to this directory for future table loads
-            if model_directory.endswith('/*'):
+            if model_directory.endswith(os.sep+'*'):
                 self.file = file
                 try:
                     pickle.dump(self.__dict__, open(self.file, 'wb'))
@@ -229,7 +229,7 @@ class ModelGrid(object):
         model = self.get(**kwargs)
 
         # Get a dummy FITS file
-        ffile = resource_filename('ExoCTK', 'data/core/ModelGrid_tmp.fits')
+        ffile = resource_filename('ExoCTK', f'data{os.sep}core{os.sep}ModelGrid_tmp.fits')
         hdu = fits.open(ffile)
 
         # Replace the data

--- a/eureka/S5_lightcurve_fitting/models/Model.py
+++ b/eureka/S5_lightcurve_fitting/models/Model.py
@@ -135,8 +135,7 @@ class Model:
 
         # Or a Parameters instance
         if (params is not None) and (type(params).__name__ != Parameters.__name__):
-            raise TypeError("'params' argument must be a JSON file, ascii\
-                             file, or parameters.Parameters instance.")
+            raise TypeError("'params' argument must be a JSON file, ascii file, or parameters.Parameters instance.")
 
         # Set the parameters attribute
         self._parameters = params

--- a/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -1,4 +1,4 @@
-import string
+import os
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import rcParams
@@ -89,7 +89,7 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
         fig.align_ylabels(ax)
 
         ch_number = str(channel).zfill(len(str(lc.nchannel)))
-        fname = f'figs/fig5101_ch{ch_number}_lc_{fitter}'+figure_filetype
+        fname = 'figs'+os.sep+f'fig5101_ch{ch_number}_lc_{fitter}'+figure_filetype
         fig.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
         if not meta.hide_plots:
             plt.pause(0.2)
@@ -154,7 +154,7 @@ def plot_rms(lc, model, meta, fitter):
         plt.yticks(size=12)
         plt.legend()
         ch_number = str(channel).zfill(len(str(lc.nchannel)))
-        fname = f'figs/fig5301_ch{ch_number}_allanplot_{fitter}'+figure_filetype
+        fname = 'figs'+os.sep+f'fig5301_ch{ch_number}_allanplot_{fitter}'+figure_filetype
         plt.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
         if not meta.hide_plots:
             plt.pause(0.2)
@@ -204,7 +204,7 @@ def plot_corner(samples, lc, meta, freenames, fitter):
                         labels=freenames, show_titles=True, title_fmt='.3',
                         title_kwargs={"fontsize": 10}, label_kwargs={"fontsize": 10}, fontsize=10, labelpad=0.25)
     ch_number = str(lc.channel).zfill(len(str(lc.nchannel)))
-    fname = f'figs/fig5501_ch{ch_number}_corner_{fitter}'+figure_filetype
+    fname = 'figs'+os.sep+f'fig5501_ch{ch_number}_corner_{fitter}'+figure_filetype
     fig.savefig(meta.outputdir+fname, bbox_inches='tight', pad_inches=0.05, dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
@@ -286,7 +286,7 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', burnin=False, nburn
         fig.tight_layout(h_pad=0.0)
 
         ch_number = str(lc.channel).zfill(len(str(lc.nchannel)))
-        fname = f'figs/fig5303_ch{ch_number}'
+        fname = 'figs'+os.sep+f'fig5303_ch{ch_number}'
         if burnin:
             fname += '_burninchain'
         else:
@@ -356,7 +356,7 @@ def plot_res_distr(lc, model, meta, fitter):
         plt.plot(x,px*(bins[1]-bins[0])*len(residuals),'k-',lw=2)
         plt.xlabel("Residuals/Uncertainty", fontsize=14)
         ch_number = str(channel).zfill(len(str(lc.nchannel)))
-        fname = f'figs/fig5302_ch{ch_number}_res_distri_{fitter}'+figure_filetype
+        fname = 'figs'+os.sep+f'fig5302_ch{ch_number}_res_distri_{fitter}'+figure_filetype
         plt.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
         if not meta.hide_plots:
             plt.pause(0.2)
@@ -436,7 +436,7 @@ def plot_GP_components(lc, model, meta, fitter, isTitle=True):
         ax[2].set_xlabel(str(lc.time_units), size=14)
 
         ch_number = str(channel).zfill(len(str(lc.nchannel)))
-        fname = f'figs/fig5102_ch{ch_number}_lc_GP_{fitter}'+figure_filetype
+        fname = 'figs'+os.sep+f'fig5102_ch{ch_number}_lc_GP_{fitter}'+figure_filetype
         fig.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
         if not meta.hide_plots:
             plt.pause(0.2)

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -103,15 +103,15 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
             log.writelog(f"Input directory: {meta.inputdir}")
             log.writelog(f"Output directory: {meta.outputdir}")
 
-            # Copy ecf
+            # Copy ECF
             log.writelog('Copying S5 control file', mute=(not meta.verbose))
             meta.copy_ecf()
-            # Copy parameter ecf
-            log.writelog('Copying S5 parameter control file', mute=(not meta.verbose))
-            shutil.copy(os.path.join(ecf_path, meta.fit_par), meta.outputdir)
-
+            
             # Set the intial fitting parameters
-            params = Parameters(ecf_path, meta.fit_par)
+            params = Parameters(meta.folder, meta.fit_par)
+            # Copy EPF
+            log.writelog('Copying S5 parameter control file', mute=(not meta.verbose))
+            params.write(meta.outputdir)
             sharedp = False
             for arg, val in params.dict.items():
                 if 'shared' in val:
@@ -291,9 +291,6 @@ def load_specific_s4_meta_info(meta):
     inputdir = os.sep.join(meta.inputdir.split(os.sep)[:-2]) + os.sep
     # Get directory containing S4 outputs for this aperture pair
     inputdir += f'ap{meta.spec_hw}_bg{meta.bg_hw}'+os.sep
-    inputdir_raw = inputdir[len(meta.topdir):]
-    # Save the meta values already calculated for this stage
-    runs_s5 = meta.runs_s5
     # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
     meta.inputdir = inputdir
     s4_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S4', allowFail=False)

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -78,14 +78,11 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
         chanrng = meta.nspecchan
 
     # Create directories for Stage 5 outputs
-    meta.runs_s5 = []
+    meta.run_s5 = None
     for spec_hw_val in meta.spec_hw_range:
         for bg_hw_val in meta.bg_hw_range:
-            run = util.makedirectory(meta, 'S5', ap=spec_hw_val, bg=bg_hw_val)
-            meta.runs_s5.append(run)
+            meta.run_s5 = util.makedirectory(meta, 'S5', meta.run_s5, ap=spec_hw_val, bg=bg_hw_val)
 
-    run_i = 0
-    old_meta = meta
     for spec_hw_val in meta.spec_hw_range:
         for bg_hw_val in meta.bg_hw_range:
 
@@ -98,8 +95,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
             meta = load_specific_s4_meta_info(meta)
 
             # Get the directory for Stage 5 processing outputs
-            meta.outputdir = util.pathdirectory(meta, 'S5', meta.runs_s5[run_i], ap=spec_hw_val, bg=bg_hw_val)
-            run_i += 1
+            meta.outputdir = util.pathdirectory(meta, 'S5', meta.run_s5, ap=spec_hw_val, bg=bg_hw_val)
 
             # Copy existing S4 log file and resume log
             meta.s5_logname  = meta.outputdir + 'S5_' + meta.eventlabel + ".log"

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -15,17 +15,17 @@ class MetaClass:
     def __init__(self):
         return
 
-def fitlc(eventlabel, ecf_path='./', s4_meta=None):
+def fitlc(eventlabel, ecf_path=None, s4_meta=None):
     '''Fits 1D spectra with various models and fitters.
 
     Parameters
     ----------
-    eventlabel: str
+    eventlabel : str
         The unique identifier for these data.
-    ecf_path:   str
-        The absolute or relative path to where ecfs are stored
-    s4_meta:    MetaClass
-        The metadata object from Eureka!'s S4 step (if running S4 and S5 sequentially).
+    ecf_path : str, optional
+        The absolute or relative path to where ecfs are stored. Defaults to None which resolves to './'.
+    s4_meta : MetaClass, optional
+        The metadata object from Eureka!'s S4 step (if running S4 and S5 sequentially). Defaults to None.
 
     Returns
     -------
@@ -54,21 +54,25 @@ def fitlc(eventlabel, ecf_path='./', s4_meta=None):
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
 
-    # load savefile
-    if s4_meta == None:
-        s4_meta = read_s4_meta(meta)
+    if s4_meta is None:
+        # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
+        s4_meta, meta.inputdir, meta.inputdir_raw = me.findevent, meta.inputdir(meta, 'S4', allowFail=False)
+    else:
+        # Running these stages sequentially, so can safely assume the path hasn't changed
+        meta.inputdir = s4_meta.outputdir
+        meta.inputdir_raw = meta.inputdir[len(meta.topdir):]
+    
+    meta = me.mergeevents(meta, s4_meta)
 
-    meta = load_general_s4_meta_info(meta, ecf_path, s4_meta)
-
-    if (not meta.s4_allapers) or (not meta.allapers):
+    if not meta.allapers:
         # The user indicated in the ecf that they only want to consider one aperture
         # in which case the code will consider only the one which made s4_meta.
-        # Alternatively, S4 was run without allapers, so S5's allapers will only conside that one
+        # Alternatively, if S4 was run without allapers, S5 will already only consider that one
         meta.spec_hw_range = [meta.spec_hw,]
         meta.bg_hw_range = [meta.bg_hw,]
 
     if meta.testing_S5:
-        # Only fit a single channel while testing unless doing a shared fit then do two
+        # Only fit a single channel while testing unless doing a shared fit, then do two
         chanrng = 1
     else:
         chanrng = meta.nspecchan
@@ -87,7 +91,11 @@ def fitlc(eventlabel, ecf_path='./', s4_meta=None):
 
             t0 = time_pkg.time()
 
-            meta = load_specific_s4_meta_info(old_meta, ecf_path, run_i, spec_hw_val, bg_hw_val)
+            meta.spec_hw = spec_hw_val
+            meta.bg_hw = bg_hw_val
+
+            # Load in the S4 metadata used for this particular aperture pair
+            meta = load_specific_s4_meta_info(meta)
 
             # Get the directory for Stage 5 processing outputs
             meta.outputdir = util.pathdirectory(meta, 'S5', meta.runs_s5[run_i], ap=spec_hw_val, bg=bg_hw_val)
@@ -283,95 +291,17 @@ def make_longparamlist(meta, params, chanrng):
 
     return longparamlist, paramtitles
 
-def read_s4_meta(meta):
-
-    # Search for the S2 output metadata in the inputdir provided in
-    # First just check the specific inputdir folder
-    rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-    if rootdir[-1]!='/':
-        rootdir += '/'
-    fnames = glob.glob(rootdir+'S4_'+meta.eventlabel+'*_Meta_Save.dat')
-    if len(fnames)==0:
-        # There were no metadata files in that folder, so let's see if there are in children folders
-        fnames = glob.glob(rootdir+'**/S4_'+meta.eventlabel+'*_Meta_Save.dat', recursive=True)
-
-    if len(fnames)>=1:
-        # get the folder with the latest modified time
-        fname = max(fnames, key=os.path.getmtime)
-
-    if len(fnames)==0:
-        # There may be no metafiles in the inputdir - raise an error and give a helpful message
-        raise AssertionError('Unable to find an output metadata file from Eureka!\'s S4 step '
-                            +'in the inputdir: \n"{}"!'.format(rootdir))
-    elif len(fnames)>1:
-        # There may be multiple runs - use the most recent but warn the user
-        print('WARNING: There are multiple metadata save files in your inputdir: \n"{}"\n'.format(rootdir)
-                +'Using the metadata file: \n{}\n'.format(fname)
-                +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
-                +'of the run you intended, please provide a more precise folder for the metadata file.')
-
-    fname = fname[:-4] # Strip off the .dat ending
-
-    s4_meta = me.loadevent(fname)
-
-    # Code to not break backwards compatibility with old MetaClass save files but also use the new MetaClass going forwards
-    s4_meta = readECF.MetaClass(**s4_meta.__dict__)
-
-    return s4_meta
-
-def load_general_s4_meta_info(meta, ecf_path, s4_meta):
-    # Need to remove the topdir from the outputdir
-    s4_outputdir = s4_meta.outputdir[len(meta.topdir):]
-    if s4_outputdir[0]=='/':
-        s4_outputdir = s4_outputdir[1:]
-    if s4_outputdir[-1]!='/':
-        s4_outputdir += '/'
-    s4_allapers = s4_meta.allapers
-
-    # Overwrite the temporary meta object made above to be able to find s4_meta
-    meta = s4_meta
-
-    # Load Eureka! control file and store values in the S4 metadata object
-    ecffile = 'S5_' + meta.eventlabel + '.ecf'
-    meta.read(ecf_path, ecffile)
-
-    # Overwrite the inputdir with the exact output directory from S4
-    meta.inputdir = s4_outputdir
-    meta.old_datetime = s4_meta.datetime # Capture the date that the S4 data was made (to figure out it's foldername)
-    meta.datetime = None # Reset the datetime in case we're running this on a different day
-    meta.inputdir_raw = meta.inputdir
-    meta.outputdir_raw = meta.outputdir
-    meta.s4_allapers = s4_allapers
+def load_specific_s4_meta_info(meta):
+    inputdir = os.sep.join(meta.inputdir.split(os.sep)[:-2]) + os.sep
+    # Get directory containing S4 outputs for this aperture pair
+    inputdir += f'ap{meta.spec_hw}_bg{meta.bg_hw}'+os.sep
+    inputdir_raw = inputdir[len(meta.topdir):]
+    # Save the meta values already calculated for this stage
+    runs_s5 = meta.runs_s5
+    # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
+    meta.inputdir = inputdir
+    s4_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S4', allowFail=False)
+    # Merge S5 meta into old S4 meta
+    meta = me.mergeevents(meta, s4_meta)
 
     return meta
-
-def load_specific_s4_meta_info(meta, ecf_path, run_i, spec_hw_val, bg_hw_val):
-    # Do some folder swapping to be able to reuse this function to find the correct S4 outputs
-    tempfolder = meta.outputdir_raw
-    meta.outputdir_raw = '/'.join(meta.inputdir_raw.split('/')[:-2])
-    meta.inputdir = util.pathdirectory(meta, 'S4', meta.runs_s4[run_i], old_datetime=meta.old_datetime, ap=spec_hw_val, bg=bg_hw_val)
-    meta.outputdir_raw = tempfolder
-
-    # Read in the correct S4 metadata for this aperture pair
-    tempfolder = meta.inputdir
-    meta.inputdir = meta.inputdir[len(meta.topdir):]
-    new_meta = read_s4_meta(meta)
-    meta.inputdir = tempfolder
-
-    # Load S5 Eureka! control file and store values in the S4 metadata object
-    ecffile = 'S5_' + meta.eventlabel + '.ecf'
-    new_meta.read(ecf_path, ecffile)
-
-    # Save correctly identified folders from earlier
-    new_meta.inputdir = meta.inputdir
-    new_meta.outputdir = meta.outputdir
-    new_meta.inputdir_raw = meta.inputdir_raw
-    new_meta.outputdir_raw = meta.outputdir_raw
-
-    new_meta.runs_s5 = meta.runs_s5
-    new_meta.datetime = meta.datetime
-
-    new_meta.spec_hw = spec_hw_val
-    new_meta.bg_hw = bg_hw_val
-
-    return new_meta

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -56,7 +56,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
 
     if s4_meta is None:
         # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
-        s4_meta, meta.inputdir, meta.inputdir_raw = me.findevent, meta.inputdir(meta, 'S4', allowFail=False)
+        s4_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S4', allowFail=False)
     else:
         # Running these stages sequentially, so can safely assume the path hasn't changed
         meta.inputdir = s4_meta.outputdir

--- a/eureka/S5_lightcurve_fitting/utils.py
+++ b/eureka/S5_lightcurve_fitting/utils.py
@@ -15,7 +15,6 @@ import urllib
 from astropy.io import fits
 import bokeh.palettes as bpal
 from scipy.interpolate import RegularGridInterpolator
-import matplotlib.pyplot as plt
 import numpy as np
 from svo_filters import svo
 

--- a/eureka/S6_planet_spectra/plots_s6.py
+++ b/eureka/S6_planet_spectra/plots_s6.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import numpy as np
+import os
 import matplotlib.pyplot as plt
 
 from ..lib.plots import figure_filetype
@@ -59,9 +60,9 @@ def plot_spectrum(meta, model_x=None, model_y=None,
         ax2 = ax.secondary_yaxis('right', functions=(H, r))
         ax2.set_ylabel('Scale Height')
 
-        fname = 'figs/fig6301'
+        fname = 'figs'+os.sep+'fig6301'
     else:
-        fname = 'figs/fig6101'
+        fname = 'figs'+os.sep+'fig6101'
 
     if 'R_' in ylabel:
         fname += '_transmission'

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -86,7 +86,6 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None):
 
             # Get the directory for Stage 6 processing outputs
             meta.outputdir = util.pathdirectory(meta, 'S6', meta.run_s6, ap=spec_hw_val, bg=bg_hw_val)
-            run_i += 1
 
             # Copy existing S5 log file and resume log
             meta.s6_logname  = meta.outputdir + 'S6_' + meta.eventlabel + ".log"

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -19,17 +19,17 @@ class MetaClass:
     def __init__(self):
         return
 
-def plot_spectra(eventlabel, ecf_path='./', s5_meta=None):
+def plot_spectra(eventlabel, ecf_path=None, s5_meta=None):
     '''Gathers together different wavelength fits and makes transmission/emission spectra.
 
     Parameters
     ----------
-    eventlabel: str
+    eventlabel : str
         The unique identifier for these data.
-    ecf_path:   str
-        The absolute or relative path to where ecfs are stored
-    s5_meta:    MetaClass
-        The metadata object from Eureka!'s S5 step (if running S5 and S6 sequentially).
+    ecf_path : str, optional
+        The absolute or relative path to where ecfs are stored. Defaults to None which resolves to './'.
+    s5_meta : MetaClass, optional
+        The metadata object from Eureka!'s S5 step (if running S5 and S6 sequentially). Defaults to None.
 
     Returns
     -------
@@ -50,16 +50,20 @@ def plot_spectra(eventlabel, ecf_path='./', s5_meta=None):
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
 
-    # load savefile
-    if s5_meta == None:
-        s5_meta = read_s5_meta(meta)
+    if s5_meta is None:
+        # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
+        s5_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S5', allowFail=False)
+    else:
+        # Running these stages sequentially, so can safely assume the path hasn't changed
+        meta.inputdir = s5_meta.outputdir
+        meta.inputdir_raw = meta.inputdir[len(meta.topdir):]
+    
+    meta = me.mergeevents(meta, s5_meta)
 
-    meta = load_general_s5_meta_info(meta, ecf_path, s5_meta)
-
-    if (not meta.s5_allapers) or (not meta.allapers):
+    if not meta.allapers:
         # The user indicated in the ecf that they only want to consider one aperture
-        # in which case the code will consider only the one which made s4_meta.
-        # Alternatively, S4 was run without allapers, so S6's allapers will only conside that one
+        # in which case the code will consider only the one which made s5_meta.
+        # Alternatively, if S4 or S5 was run without allapers, S6 will already only consider that one
         meta.spec_hw_range = [meta.spec_hw,]
         meta.bg_hw_range = [meta.bg_hw,]
 
@@ -77,7 +81,11 @@ def plot_spectra(eventlabel, ecf_path='./', s5_meta=None):
 
             t0 = time_pkg.time()
 
-            meta = load_specific_s5_meta_info(old_meta, ecf_path, run_i, spec_hw_val, bg_hw_val)
+            meta.spec_hw = spec_hw_val
+            meta.bg_hw = bg_hw_val
+
+            # Load in the S5 metadata used for this particular aperture pair
+            meta = load_specific_s5_meta_info(meta)
 
             # Get the directory for Stage 6 processing outputs
             meta.outputdir = util.pathdirectory(meta, 'S6', meta.runs_s6[run_i], ap=spec_hw_val, bg=bg_hw_val)
@@ -298,93 +306,17 @@ def parse_s5_saves(meta, fit_methods, y_param, channel_key='shared'):
 
     return medians, errs
 
-def read_s5_meta(meta):
-
-    # Search for the S5 output metadata in the inputdir provided in
-    # First just check the specific inputdir folder
-    rootdir = os.path.join(meta.topdir, *meta.inputdir.split(os.sep))
-    if rootdir[-1]!='/':
-        rootdir += '/'
-    files = glob.glob(rootdir+'S5_'+meta.eventlabel+'*_Meta_Save.dat')
-    if len(files)==0:
-        # There were no metadata files in that folder, so let's see if there are in children folders
-        files = glob.glob(rootdir+'**/S5_'+meta.eventlabel+'*_Meta_Save.dat', recursive=True)
-        files = sn.sort_nicely(files)
-
-    if len(files)==0:
-        # There may be no metafiles in the inputdir - raise an error and give a helpful message
-        raise AssertionError('Unable to find an output metadata file from Eureka!\'s S5 step '
-                            +'in the inputdir: \n"{}"!'.format(rootdir))
-
-    elif len(files)>1:
-        # There may be multiple runs - use the most recent but warn the user
-        print('WARNING: There are multiple metadata save files in your inputdir: \n"{}"\n'.format(rootdir)
-                +'Using the metadata file: \n{}\n'.format(files[-1])
-                +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
-                +'of the run you intended, please provide a more precise folder for the metadata file.')
-
-    fname = files[-1] # Pick the last file name (should be the most recent or only file)
-    fname = fname[:-4] # Strip off the .dat ending
-
-    s5_meta = me.loadevent(fname)
-
-    # Code to not break backwards compatibility with old MetaClass save files but also use the new MetaClass going forwards
-    s5_meta = readECF.MetaClass(**s5_meta.__dict__)
-
-    return s5_meta
-
-def load_general_s5_meta_info(meta, ecf_path, s5_meta):
-
-    # Need to remove the topdir from the outputdir
-    s5_outputdir = s5_meta.outputdir[len(meta.topdir):]
-    if s5_outputdir[0]=='/':
-        s5_outputdir = s5_outputdir[1:]
-    if s5_outputdir[-1]!='/':
-        s5_outputdir += '/'
-    s5_allapers = s5_meta.allapers
-
-    # Overwrite the temporary meta object made above to be able to find s5_meta
-    meta = s5_meta
-
-    # Load Eureka! control file and store values in the S4 metadata object
-    ecffile = 'S6_' + meta.eventlabel + '.ecf'
-    meta.read(ecf_path, ecffile)
-
-    # Overwrite the inputdir with the exact output directory from S5
-    meta.inputdir = s5_outputdir
-    meta.old_datetime = s5_meta.datetime # Capture the date that the S5 data was made (to figure out it's foldername)
-    meta.datetime = None # Reset the datetime in case we're running this on a different day
-    meta.inputdir_raw = meta.inputdir
-    meta.outputdir_raw = meta.outputdir
-
-    meta.s5_allapers = s5_allapers
+def load_specific_s5_meta_info(meta):
+    inputdir = os.sep.join(meta.inputdir.split(os.sep)[:-2]) + os.sep
+    # Get directory containing S5 outputs for this aperture pair
+    inputdir += f'ap{meta.spec_hw}_bg{meta.bg_hw}'+os.sep
+    inputdir_raw = inputdir[len(meta.topdir):]
+    # Save the meta values already calculated for this stage
+    runs_s6 = meta.runs_s6
+    # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
+    meta.inputdir = inputdir
+    s5_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S5', allowFail=False)
+    # Merge S6 meta into old S5 meta
+    meta = me.mergeevents(meta, s5_meta)
 
     return meta
-
-def load_specific_s5_meta_info(meta, ecf_path, run_i, spec_hw_val, bg_hw_val):
-    # Do some folder swapping to be able to reuse this function to find the correct S5 outputs
-    tempfolder = meta.outputdir_raw
-    meta.outputdir_raw = '/'.join(meta.inputdir_raw.split('/')[:-2])
-    meta.inputdir = util.pathdirectory(meta, 'S5', meta.runs_s5[run_i], old_datetime=meta.old_datetime, ap=spec_hw_val, bg=bg_hw_val)
-    meta.outputdir_raw = tempfolder
-
-    # Read in the correct S5 metadata for this aperture pair
-    tempfolder = meta.inputdir
-    meta.inputdir = meta.inputdir[len(meta.topdir):]
-    new_meta = read_s5_meta(meta)
-    meta.inputdir = tempfolder
-
-    # Load S6 Eureka! control file and store values in the S5 metadata object
-    ecffile = 'S6_' + meta.eventlabel + '.ecf'
-    new_meta.read(ecf_path, ecffile)
-
-    # Save correctly identified folders from earlier
-    new_meta.inputdir = meta.inputdir
-    new_meta.outputdir = meta.outputdir
-    new_meta.inputdir_raw = meta.inputdir_raw
-    new_meta.outputdir_raw = meta.outputdir_raw
-
-    new_meta.runs_s6 = meta.runs_s6
-    new_meta.datetime = meta.datetime
-
-    return new_meta

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -68,14 +68,11 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None):
         meta.bg_hw_range = [meta.bg_hw,]
 
     # Create directories for Stage 6 outputs
-    meta.runs_s6 = []
+    meta.run_s6 = None
     for spec_hw_val in meta.spec_hw_range:
         for bg_hw_val in meta.bg_hw_range:
-            run = util.makedirectory(meta, 'S6', ap=spec_hw_val, bg=bg_hw_val)
-            meta.runs_s6.append(run)
+            meta.run_s6 = util.makedirectory(meta, 'S6', meta.run_s6, ap=spec_hw_val, bg=bg_hw_val)
 
-    run_i = 0
-    old_meta = meta
     for spec_hw_val in meta.spec_hw_range:
         for bg_hw_val in meta.bg_hw_range:
 
@@ -88,7 +85,7 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None):
             meta = load_specific_s5_meta_info(meta)
 
             # Get the directory for Stage 6 processing outputs
-            meta.outputdir = util.pathdirectory(meta, 'S6', meta.runs_s6[run_i], ap=spec_hw_val, bg=bg_hw_val)
+            meta.outputdir = util.pathdirectory(meta, 'S6', meta.run_s6, ap=spec_hw_val, bg=bg_hw_val)
             run_i += 1
 
             # Copy existing S5 log file and resume log

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -307,9 +307,6 @@ def load_specific_s5_meta_info(meta):
     inputdir = os.sep.join(meta.inputdir.split(os.sep)[:-2]) + os.sep
     # Get directory containing S5 outputs for this aperture pair
     inputdir += f'ap{meta.spec_hw}_bg{meta.bg_hw}'+os.sep
-    inputdir_raw = inputdir[len(meta.topdir):]
-    # Save the meta values already calculated for this stage
-    runs_s6 = meta.runs_s6
     # Locate the old MetaClass savefile, and load new ECF into that old MetaClass
     meta.inputdir = inputdir
     s5_meta, meta.inputdir, meta.inputdir_raw = me.findevent(meta, 'S5', allowFail=False)

--- a/eureka/lib/manageevent.py
+++ b/eureka/lib/manageevent.py
@@ -289,12 +289,16 @@ def mergeevents(new_meta, old_meta):
     - April 25, 2022 Taylor Bell
         Initial version.
     """
-    # Load current MetaClass into old MetaClass
+    # Load current ECF into old MetaClass
+    old_meta.read(new_meta.folder, new_meta.filename)
+
+    # Load any missing parameters from current MetaClass into old MetaClass
     for key in new_meta.__dict__:
-        setattr(old_meta, key, getattr(new_meta, key))
-    new_meta = old_meta
+        if key not in old_meta.__dict__:
+            setattr(old_meta, key, getattr(new_meta, key))
 
-    # Make sure new_meta's inputdir_raw is correct
-    new_meta.inputdir_raw = new_meta.inputdir[len(new_meta.topdir)]
+    # Make sure inputdir is correct
+    old_meta.inputdir = new_meta.inputdir
+    old_meta.inputdir_raw = new_meta.inputdir_raw
 
-    return new_meta
+    return old_meta

--- a/eureka/lib/manageevent.py
+++ b/eureka/lib/manageevent.py
@@ -1,5 +1,7 @@
 import h5py as h5
-import pickle
+import pickle, os, glob
+
+from . import readECF
 
 
 """
@@ -190,3 +192,109 @@ def updateevent(event, filename, add):
             exec('event.post' + param + ' = event2.post' + param)
 
     return event
+
+def findevent(meta, stage, allowFail=False):
+    """Loads in an earlier stage meta file.
+
+    Parameters
+    ----------
+    meta : MetaClass
+        The new meta object for the current processing.
+    stage : str
+        The previous stage (e.g. "S2" for Stage 3).
+    allowFail : bool, optional
+        Whether to allow the code to find no previous stage metadata files (for S2, S3)
+        or throw an error if no metadata files are found. Default is False.
+
+    Returns
+    -------
+    old_meta : MetaClass
+        The old metadata object.
+    inputdir : str
+        The new inputdir to use (based on the present location of the located metadata file).
+    inputdir_raw : str
+        The new inputdir_raw to use (based on the present location of the located metadata file).
+
+    Raises
+    ------
+    AssertionError
+        Unable to find a metadata save file and allowFail was False.
+
+    Notes
+    -------
+    History:
+
+    - April 25, 2022 Taylor Bell
+        Initial version.
+    """
+    # Search for the output metadata in the inputdir provided
+    # First just check the specific inputdir folder
+    fnames = glob.glob(meta.inputdir+stage+'_'+meta.eventlabel+'*_Meta_Save.dat')
+    if len(fnames)==0:
+        # There were no metadata files in that folder, so let's see if there are in children folders
+        fnames = glob.glob(meta.inputdir+'**'+os.sep+stage+'_'+meta.eventlabel+'*_Meta_Save.dat', recursive=True)
+
+    if len(fnames)>=1:
+        # get the folder with the latest modified time
+        fname = max(fnames, key=os.path.getmtime)
+    
+    if len(fnames)==0 and allowFail:
+        # There may be no rateints files in the inputdir or any of its children directories - raise an error and give a helpful message
+        print('WARNING: Unable to find an output metadata file from Eureka!\'s '+stage
+             +' in the folder:\n"{}"\n'.format(meta.inputdir)
+             +'Assuming this '+stage+' data was produced by the JWST pipeline instead.')
+        return None, meta.inputdir, meta.inputdir_raw
+    elif len(fnames)==0:
+        # There may be no metafiles in the inputdir - raise an error and give a helpful message
+        raise AssertionError('Unable to find an output metadata file from Eureka!\'s '+stage
+                            +' in the folder:\n"{}"!'.format(meta.inputdir))
+    elif len(fnames)>1:
+        # There may be multiple runs - use the most recent but warn the user
+        print('WARNING: There are multiple metadata save files in the folder: \n"{}"\n'.format(meta.inputdir)
+                +'Using the metadata file: \n{}\n'.format(fname)
+                +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
+                +'of the run you intended, please provide a more precise folder for the metadata file.')
+
+    fname = fname[:-4] # Strip off the .dat ending
+
+    # Load old savefile
+    old_meta = loadevent(fname)
+    # Code to not break backwards compatibility with old MetaClass save files but also use the new MetaClass going forwards
+    old_meta = readECF.MetaClass(**old_meta.__dict__)
+
+    old_meta.folder = os.sep.join(fname.split(os.sep)[:-1])+os.sep
+    old_meta.filename = fname.split(os.sep)[-1]
+
+    return old_meta, old_meta.folder, old_meta.folder[len(meta.topdir):]
+
+def mergeevents(new_meta, old_meta):
+    """Merge the current MetaClass data into the MetaClass object from a previous stage.
+
+    Parameters
+    ----------
+    new_meta : MetaClass
+        The metadata object for the current stage.
+    old_meta : MetaClass
+        The metadata object for the previous stage.
+
+    Returns
+    -------
+    new_meta : MetaClass
+        The current MetaClass object containing the details from the previous MetaClass object.
+
+    Notes
+    -------
+    History:
+
+    - April 25, 2022 Taylor Bell
+        Initial version.
+    """
+    # Load current MetaClass into old MetaClass
+    for key in new_meta.__dict__:
+        setattr(old_meta, key, getattr(new_meta, key))
+    new_meta = old_meta
+
+    # Make sure new_meta's inputdir_raw is correct
+    new_meta.inputdir_raw = new_meta.inputdir[len(new_meta.topdir)]
+
+    return new_meta

--- a/eureka/lib/medstddev.py
+++ b/eureka/lib/medstddev.py
@@ -96,7 +96,7 @@ def medstddev(data, mask=None, medi=False, axis=0):
     # residuals is data - median, masked values don't count:
     residuals = data - median
     # calculate standar deviation:
-    std = np.array(np.ma.sqrt(np.ma.sum(residuals**2.0) / (ngood - 1.0)))
+    std = np.ma.sqrt(np.ma.sum(residuals**2.0) / (ngood - 1.0))
 
     # Convert masked arrays to just arrays
     std = np.array(std)

--- a/eureka/lib/readECF.py
+++ b/eureka/lib/readECF.py
@@ -272,11 +272,7 @@ class MetaClass:
                 else:
                     line_segs = line.strip().split()
                     if line_segs[0]=='inputdir':
-                        if self.topdir in self.inputdir:
-                            inputdir_string = self.inputdir[len(self.topdir):]
-                        else:
-                            inputdir_string = self.inputdir
-                        new_file.write(line_segs[0]+'\t\t'+inputdir_string+'\t'+' '.join(line_segs[2:])+'\n')
+                        new_file.write(line_segs[0]+'\t\t'+self.inputdir_raw+'\t'+' '.join(line_segs[2:])+'\n')
                     else:
                         new_file.write(line)
         return

--- a/eureka/lib/readECF.py
+++ b/eureka/lib/readECF.py
@@ -23,13 +23,13 @@ class MetaClass:
     '''A class to hold Eureka! metadata.
     '''
 
-    def __init__(self, folder='./', file=None, **kwargs):
+    def __init__(self, folder=None, file=None, **kwargs):
         '''Initialize the MetaClass object.
 
         Parameters
         ----------
         folder: str, optional
-            The folder containing an ECF file to be read in. Defaults to './'.
+            The folder containing an ECF file to be read in. Defaults to None which resolves to './'.
         file:   str, optional
             The ECF filename to be read in. Defaults to None which results in an empty MetaClass object.
         **kwargs:   dict, optional
@@ -42,6 +42,9 @@ class MetaClass:
         - Mar 2022 Taylor J Bell
             Initial Version based on old readECF code.
         '''
+        if folder is None:
+            folder = '.'+os.sep
+        
         self.params = {}
         if file is not None and folder is not None:
             if os.path.exists(os.path.join(folder,file)):
@@ -162,6 +165,8 @@ class MetaClass:
         History:
         - Mar 2022 Taylor J Bell
             Initial Version based on old readECF code.
+        - April 25, 2022 Taylor J Bell
+            Joining topdir and inputdir/outputdir here.
         """
         self.filename = file
         self.folder = folder
@@ -194,14 +199,19 @@ class MetaClass:
         for param, value in self.params.items():
             setattr(self, param, value)
 
-        if self.inputdir[0]=='/':
-            self.inputdir = self.inputdir[1:]
-        if self.inputdir[-1]!='/':
-            self.inputdir += '/'
-        if self.outputdir[0]=='/':
-            self.outputdir = self.outputdir[1:]
-        if self.outputdir[-1]!='/':
-            self.outputdir += '/'
+        self.inputdir_raw = self.inputdir
+        self.outputdir_raw = self.outputdir
+
+        # Join inputdir_raw and outputdir_raw to topdir for convenience
+        # Use split to avoid issues from beginning
+        self.inputdir = os.path.join(self.topdir, *self.inputdir.split(os.sep))
+        self.outputdir = os.path.join(self.topdir, *self.outputdir.split(os.sep))
+
+        # Make sure there's a trailing slash at the end of the paths
+        if self.inputdir[-1] != os.sep:
+            self.inputdir += os.sep
+        if self.outputdir[-1] != os.sep:
+            self.outputdir += os.sep
 
         return
 

--- a/eureka/lib/readEPF.py
+++ b/eureka/lib/readEPF.py
@@ -102,7 +102,7 @@ class Parameter:
         # Get the fully qualified name of the class
         output = type(self).__module__+'.'+type(self).__qualname__+'('
         # Get the list of Parameter.__init__ arguments (excluding self)
-        keys = inspect.getargspec(self.__init__)[0].remove('self')
+        keys = inspect.getfullargspec(Parameter.__init__).args[1:]
         # Show how the Parameter could be initialized (e.g. name='rp', val=0.01, ptype='free')
         for name in keys:
             val = getattr(self, name)

--- a/eureka/lib/readEPF.py
+++ b/eureka/lib/readEPF.py
@@ -147,14 +147,21 @@ class Parameter:
 class Parameters:
     """A class to hold the Parameter instances
     """
-    def __init__(self, param_path='./', param_file=None, **kwargs):
+    def __init__(self, param_path=None, param_file=None, **kwargs):
         """Initialize the parameter object
 
         Parameters
         ----------
-        param_file: str
-            A text file of the parameters to parse
+        param_path : str
+            The path to the parameters.
+        param_file : str
+            A text file of the parameters to parse.
+        **kwargs : dict
+            Any additional settings to set in the Parameters object.
         """
+
+        if param_path is None:
+            param_path = '.'+os.sep
 
         # Make an empty params dict
         self.params = {}

--- a/eureka/lib/util.py
+++ b/eureka/lib/util.py
@@ -1,7 +1,7 @@
 import numpy as np
 from . import sort_nicely as sn
-import os, time
-import re
+import os, time, glob
+
 
 def readfiles(meta):
     """Reads in the files saved in topdir + inputdir and saves them into a list
@@ -105,33 +105,38 @@ def makedirectory(meta, stage, **kwargs):
 
     # This code allows the input and output files to be stored outside of the Eureka! folder
     rootdir = os.path.join(meta.topdir, *meta.outputdir_raw.split(os.sep))
-    if rootdir[-1]!='/':
-      rootdir += '/'
+    if rootdir[-1] != os.sep:
+      rootdir += os.sep
 
-    outputdir = rootdir + stage + '_' + datetime + '_' + meta.eventlabel +'_'
+    outputdir = rootdir + stage + '_' + datetime + '_' + meta.eventlabel + '_run'
 
-    for key, value in kwargs.items():
-
-        outputdir += key+str(value)+'_'
-
-    outputdir += 'run'
-
-    counter=1
-
+    counter = 1
     while os.path.exists(outputdir+str(counter)):
         counter += 1
+    outputdir = outputdir+str(counter)+os.sep
 
-    meta.outputdir = outputdir+str(counter)+'/'
-    if not os.path.exists(meta.outputdir):
+    # Nest the different folders underneath one main folder for this run
+    for key, value in kwargs.items():
+        outputdir += key+str(value)+'_'
+
+    # Remove trailing _ if present
+    if outputdir[-1] == '_':
+        outputdir = outputdir[:-1]
+    
+    # Add trailing slash
+    if outputdir[-1] != os.sep:
+        outputdir += os.sep
+
+    if not os.path.exists(outputdir):
         try:
-            os.makedirs(meta.outputdir)
+            os.makedirs(outputdir)
         except (PermissionError, OSError) as e:
             # Raise a more helpful error message so that users know to update topdir in their ecf file
-            raise PermissionError(f'You do not have the permissions to make the folder {meta.outputdir}\n'+
+            raise PermissionError(f'You do not have the permissions to make the folder {outputdir}\n'+
                                   f'Your topdir is currently set to {meta.topdir}, but your user account is called {os.getenv("USER")}.\n'+
                                   f'You likely need to update the topdir setting in your {stage} .ecf file.') from e
-    if not os.path.exists(meta.outputdir + "figs"):
-        os.makedirs(meta.outputdir + "figs")
+    if not os.path.exists(os.path.join(outputdir, "figs")):
+        os.makedirs(os.path.join(outputdir, "figs"))
 
     return counter
 
@@ -164,20 +169,76 @@ def pathdirectory(meta, stage, run, old_datetime=None, **kwargs):
 
     # This code allows the input and output files to be stored outside of the Eureka! folder
     rootdir = os.path.join(meta.topdir, *meta.outputdir_raw.split(os.sep))
-    if rootdir[-1]!='/':
-      rootdir += '/'
+    if rootdir[-1] != os.sep:
+      rootdir += os.sep
 
-    outputdir = rootdir + stage + '_' + datetime + '_' + meta.eventlabel +'_'
+    outputdir = rootdir + stage + '_' + datetime + '_' + meta.eventlabel +'_run' + str(run) + os.sep
 
     for key, value in kwargs.items():
-
         outputdir += key+str(value)+'_'
 
-    outputdir += 'run'
+    # Remove trailing _ if present
+    if outputdir[-1] == '_':
+        outputdir = outputdir[:-1]
+    
+    # Add trailing slash
+    if outputdir[-1] != os.sep:
+        outputdir += os.sep
 
-    path = outputdir+str(run)+'/'
+    return outputdir
 
-    return path
+def find_fits(meta):
+    '''Locates S1 or S2 output FITS files if unable to find an metadata file.
+
+    Parameters
+    ----------
+    meta:    MetaClass
+        The new meta object for the current stage processing.
+
+    Returns
+    -------
+    meta:   MetaClass
+        The meta object with the updated inputdir pointing to the location of
+        the input files to use.
+
+    Notes
+    -------
+    History:
+
+    - April 25, 2022 Taylor Bell
+        Initial version.
+    '''
+    fnames = glob.glob(meta.inputdir+'*'+meta.suffix + '.fits')
+    if len(fnames)==0:
+        # There were no rateints files in that folder, so let's see if there are in children folders
+        fnames = glob.glob(meta.inputdir+'**'+os.sep+'*'+meta.suffix + '.fits', recursive=True)
+        fnames = sn.sort_nicely(fnames)
+
+    if len(fnames)==0:
+        # If the code can't find any of the reqested files, raise an error and give a helpful message
+        raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files in the inputdir: \n"{meta.inputdir}"!\n'+
+                             f'You likely need to change the inputdir in {meta.filename} to point to the folder containing the "{meta.suffix}.fits" files.')
+
+    folders = np.unique([os.sep.join(fname.split(os.sep)[:-1]) for fname in fnames])
+    if len(folders)>=1:
+        # get the file with the latest modified time
+        folder = max(folders, key=os.path.getmtime)
+
+    if len(folders)>1:
+        # There may be multiple runs - use the most recent but warn the user
+        print(f'WARNING: There are multiple folders containing "{meta.suffix}.fits" files in your inputdir: \n"{meta.inputdir}"\n'
+             +f'Using the files in: \n{folder}\n'
+              +'and will consider aperture ranges listed there. If this metadata file is not a part\n'
+              +'of the run you intended, please provide a more precise folder for the metadata file.')
+
+    meta.inputdir = folder
+    meta.inputdir_raw = folder[len(meta.topdir):]
+
+    # Make sure there's a trailing slash at the end of the paths
+    if meta.inputdir[-1] != os.sep:
+        meta.inputdir += os.sep
+
+    return meta
 
 def get_mad(meta, wave_1d, optspec, wave_min=None, wave_max=None):
     """Computes variation on median absolute deviation (MAD) using ediff1d for 2D data.

--- a/eureka/lib/util.py
+++ b/eureka/lib/util.py
@@ -83,7 +83,7 @@ def check_nans(data, mask, log, name=''):
         mask[inan]  = 0
     return mask
 
-def makedirectory(meta, stage, **kwargs):
+def makedirectory(meta, stage, counter=None, **kwargs):
     """Creates a directory for the current stage
 
     Parameters
@@ -92,6 +92,9 @@ def makedirectory(meta, stage, **kwargs):
         The metadata object.
     stage:  str
         'S#' string denoting stage number (i.e. 'S3', 'S4')
+    counter : int
+        The run number if you want to force a particular run number.
+        Defaults to None which automatically finds the run number.
     **kwargs
 
     Returns
@@ -110,10 +113,13 @@ def makedirectory(meta, stage, **kwargs):
 
     outputdir = rootdir + stage + '_' + datetime + '_' + meta.eventlabel + '_run'
 
-    counter = 1
-    while os.path.exists(outputdir+str(counter)):
-        counter += 1
-    outputdir = outputdir+str(counter)+os.sep
+    if counter is None:
+        counter = 1
+        while os.path.exists(outputdir+str(counter)):
+            counter += 1
+        outputdir += str(counter)+os.sep
+    else:
+        outputdir += str(counter)+os.sep
 
     # Nest the different folders underneath one main folder for this run
     for key, value in kwargs.items():

--- a/tests/test_MIRI.py
+++ b/tests/test_MIRI.py
@@ -4,7 +4,7 @@ import numpy as np
 import sys, os
 from importlib import reload
 
-sys.path.insert(0, '../')
+sys.path.insert(0, '..'+os.sep)
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import pathdirectory
 import eureka.lib.plots
@@ -40,8 +40,8 @@ def test_MIRI(capsys):
     # explicitly define meta variables to be able to run pathdirectory fn locally
     meta = MetaClass()
     meta.eventlabel='MIRI'
-    meta.topdir='../tests'
-    ecf_path='./MIRI_ecfs/'
+    meta.topdir=f'..{os.sep}tests'
+    ecf_path=f'.{os.sep}MIRI_ecfs{os.sep}'
 
     if s2_installed:
         # Only run S1-2 stuff if jwst package has been installed
@@ -65,43 +65,44 @@ def test_MIRI(capsys):
     # run assertions for S2
     if s2_installed:
         # Only run S1-2 stuff if jwst package has been installed
-        # meta.outputdir_raw='/data/JWST-Sim/MIRI/Stage1/'
+        # meta.outputdir_raw=f'{os.sep}data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage1{os.sep}'
         # name = pathdirectory(meta, 'S1', 1)
         # assert os.path.exists(name)
 
-        meta.outputdir_raw='/data/JWST-Sim/MIRI/Stage2/'
+        meta.outputdir_raw=f'{os.sep}data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage2{os.sep}'
         name = pathdirectory(meta, 'S2', 1)
         assert os.path.exists(name)
-        assert os.path.exists(name+'/figs')
+        assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S3
-    meta.outputdir_raw='data/JWST-Sim/MIRI/Stage3/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage3{os.sep}'
     name = pathdirectory(meta, 'S3', 1, ap=2, bg=4)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S4
-    meta.outputdir_raw='data/JWST-Sim/MIRI/Stage4/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage4{os.sep}'
     name = pathdirectory(meta, 'S4', 1, ap=2, bg=4)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S5
-    meta.outputdir_raw='data/JWST-Sim/MIRI/Stage5/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage5{os.sep}'
     name = pathdirectory(meta, 'S5', 1, ap=2, bg=4)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S6
-    meta.outputdir_raw='data/JWST-Sim/MIRI/Stage6/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage6{os.sep}'
     name = pathdirectory(meta, 'S6', 1, ap=2, bg=4)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # remove temporary files
-    # os.system("rm -r data/JWST-Sim/MIRI/Stage1/S1_*")
-    os.system("rm -r data/JWST-Sim/MIRI/Stage2/S2_*")
-    os.system("rm -r data/JWST-Sim/MIRI/Stage3")
-    os.system("rm -r data/JWST-Sim/MIRI/Stage4")
-    os.system("rm -r data/JWST-Sim/MIRI/Stage5")
-    os.system("rm -r data/JWST-Sim/MIRI/Stage6")
+    if s2_installed:
+        # os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage1{os.sep}S1_*")
+        os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage2{os.sep}S2_*")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage3")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage4")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage5")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}MIRI{os.sep}Stage6")

--- a/tests/test_NIRCam.py
+++ b/tests/test_NIRCam.py
@@ -4,7 +4,7 @@ import numpy as np
 import sys, os
 from importlib import reload
 
-sys.path.insert(0, '../')
+sys.path.insert(0, '..'+os.sep)
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import pathdirectory
 import eureka.lib.plots
@@ -31,8 +31,8 @@ def test_NIRCam(capsys):
     # explicitly define meta variables to be able to run pathdirectory fn locally
     meta = MetaClass()
     meta.eventlabel='NIRCam'
-    meta.topdir='../tests'
-    ecf_path='./NIRCam_ecfs/'
+    meta.topdir=f'..{os.sep}tests'
+    ecf_path=f'.{os.sep}NIRCam_ecfs{os.sep}'
 
     reload(s3)
     reload(s4)
@@ -44,31 +44,31 @@ def test_NIRCam(capsys):
     s6_meta = s6.plot_spectra(meta.eventlabel, ecf_path=ecf_path, s5_meta=s5_meta)
 
     # run assertions for S3
-    meta.outputdir_raw='data/JWST-Sim/NIRCam/Stage3/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage3{os.sep}'
     name = pathdirectory(meta, 'S3', 1, ap=20, bg=20)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S4
-    meta.outputdir_raw='data/JWST-Sim/NIRCam/Stage4/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage4{os.sep}'
     name = pathdirectory(meta, 'S4', 1, ap=20, bg=20)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S5
-    meta.outputdir_raw='data/JWST-Sim/NIRCam/Stage5/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage5{os.sep}'
     name = pathdirectory(meta, 'S5', 1, ap=20, bg=20)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S6
-    meta.outputdir_raw='data/JWST-Sim/NIRCam/Stage6/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage6{os.sep}'
     name = pathdirectory(meta, 'S6', 1, ap=20, bg=20)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # remove temporary files
-    os.system("rm -r data/JWST-Sim/NIRCam/Stage3")   
-    os.system("rm -r data/JWST-Sim/NIRCam/Stage4")
-    os.system("rm -r data/JWST-Sim/NIRCam/Stage5")
-    os.system("rm -r data/JWST-Sim/NIRCam/Stage6")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage3")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage4")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage5")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage6")

--- a/tests/test_NIRSpec.py
+++ b/tests/test_NIRSpec.py
@@ -4,7 +4,7 @@ import numpy as np
 import sys, os
 from importlib import reload
 
-sys.path.insert(0, '../')
+sys.path.insert(0, '..'+os.sep)
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import pathdirectory
 import eureka.lib.plots
@@ -38,8 +38,8 @@ def test_NIRSpec(capsys):
     # explicitly define meta variables to be able to run pathdirectory fn locally
     meta = MetaClass()
     meta.eventlabel='NIRSpec'
-    meta.topdir='../tests'
-    ecf_path='./NIRSpec_ecfs/'
+    meta.topdir=f'..{os.sep}tests'
+    ecf_path=f'.{os.sep}NIRSpec_ecfs{os.sep}'
 
     if s2_installed:
         # Only run S2 stuff if jwst package has been installed
@@ -57,34 +57,33 @@ def test_NIRSpec(capsys):
     # run assertions for S2
     if s2_installed:
         # Only run S2 stuff if jwst package has been installed
-        meta.outputdir_raw='/data/JWST-Sim/NIRSpec/Stage2/'
+        meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}NIRSpec{os.sep}Stage2{os.sep}'
         name = pathdirectory(meta, 'S2', 1)
         assert os.path.exists(name)
-        assert os.path.exists(name+'/figs')
+        assert os.path.exists(name+os.sep+'figs')
     
     # run assertions for S3
-    meta.outputdir_raw='/data/JWST-Sim/NIRSpec/Stage3/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}NIRSpec{os.sep}Stage3{os.sep}'
     name = pathdirectory(meta, 'S3', 1, ap=8, bg=10)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S4
-    meta.outputdir_raw='data/JWST-Sim/NIRSpec/Stage4/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}NIRSpec{os.sep}Stage4{os.sep}'
     name = pathdirectory(meta, 'S4', 1, ap=8, bg=10)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # run assertions for S5
-    meta.outputdir_raw='data/JWST-Sim/NIRSpec/Stage5/'
+    meta.outputdir_raw=f'data{os.sep}JWST-Sim{os.sep}NIRSpec{os.sep}Stage5{os.sep}'
     name = pathdirectory(meta, 'S5', 1, ap=8, bg=10)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
     
-    # remove temp files
+    # remove temporary files
     if s2_installed:
         # Only run S2 stuff if jwst package has been installed
-        os.system("rm -r data/JWST-Sim/NIRSpec/Stage2/S2_*")
-        pass
-    os.system("rm -r data/JWST-Sim/NIRSpec/Stage3")
-    os.system("rm -r data/JWST-Sim/NIRSpec/Stage4")
-    os.system("rm -r data/JWST-Sim/NIRSpec/Stage5")
+        os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRSpec{os.sep}Stage2{os.sep}S2_*")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRSpec{os.sep}Stage3")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRSpec{os.sep}Stage4")
+    os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRSpec{os.sep}Stage5")

--- a/tests/test_WFC3.py
+++ b/tests/test_WFC3.py
@@ -4,7 +4,7 @@ import numpy as np
 import sys, os
 from importlib import reload
 
-sys.path.insert(0, '../')
+sys.path.insert(0, '..'+os.sep)
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import pathdirectory
 import eureka.lib.plots
@@ -24,17 +24,17 @@ def test_WFC3(capsys):
     # explicitly define meta variables to be able to run pathdirectory fn locally
     meta = MetaClass()
     meta.eventlabel='WFC3'
-    meta.topdir='../tests'
-    ecf_path='./WFC3_ecfs/'
+    meta.topdir=f'..{os.sep}tests'
+    ecf_path=f'.{os.sep}WFC3_ecfs{os.sep}'
 
     reload(s3)
     s3_meta = s3.reduce(meta.eventlabel, ecf_path=ecf_path)
 
     # run assertions for S3
-    meta.outputdir_raw='data/WFC3/Stage3/'
+    meta.outputdir_raw=f'data{os.sep}WFC3{os.sep}Stage3{os.sep}'
     name = pathdirectory(meta, 'S3', 1, ap=8, bg=40)
     assert os.path.exists(name)
-    assert os.path.exists(name+'/figs')
+    assert os.path.exists(name+os.sep+'figs')
 
     # remove temporary files
-    os.system("rm -r data/WFC3/Stage3")
+    os.system(f"rm -r data{os.sep}WFC3{os.sep}Stage3")

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,9 +1,9 @@
 # Last Updated: 2022-04-05
 
 import numpy as np
-import sys
+import sys, os
 
-sys.path.insert(0, '../')
+sys.path.insert(0, '..'+os.sep)
 from eureka.lib import util
 from eureka.lib.readECF import MetaClass
 from eureka.lib.medstddev import medstddev

--- a/tests/test_lightcurve_fitting.py
+++ b/tests/test_lightcurve_fitting.py
@@ -23,7 +23,7 @@ import numpy as np
 
 import os
 import sys
-sys.path.insert(0, '../')
+sys.path.insert(0, '..'+os.sep)
 from eureka.S5_lightcurve_fitting import lightcurve, models, simulations
 from eureka.lib.readEPF import Parameters, Parameter
 from eureka.lib.readECF import MetaClass
@@ -150,12 +150,12 @@ class TestModels(unittest.TestCase):
         meta = MetaClass()
         meta.sharedp = False
         longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        log = logedit.Logedit('./data/test.log')
+        log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.e_model = models.BatmanEclipseModel(parameters=params, name='transit', fmt='r--', log=log,
                                                  longparamlist=longparamlist, nchan=1, paramtitles=paramtitles)
 
         # Remove the temporary log file
-        os.system("rm ./data/test.log")
+        os.system(f"rm .{os.sep}data{os.sep}test.log")
 
         # Evaluate and test output
         self.e_model.time = self.time
@@ -189,7 +189,7 @@ class TestModels(unittest.TestCase):
         meta = MetaClass()
         meta.sharedp = False
         longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        log = logedit.Logedit('./data/test.log')
+        log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_model = models.BatmanTransitModel(parameters=params, name='transit', fmt='r--',
                                                  longparamlist=longparamlist, nchan=1, paramtitles=paramtitles)
         self.e_model = models.BatmanEclipseModel(parameters=params, name='transit', fmt='r--', log=log,
@@ -199,7 +199,7 @@ class TestModels(unittest.TestCase):
                                                          transit_model=self.t_model, eclipse_model=self.e_model)
 
         # Remove the temporary log file
-        os.system("rm ./data/test.log")
+        os.system(f"rm .{os.sep}data{os.sep}test.log")
 
         # Evaluate and test output
         self.phasecurve.time = self.time


### PR DESCRIPTION
Alright, I've now cleaned up the way that stages are connected, so we no longer have weird behaviours if folders get renamed between stages. To do this, I moved the different aperture folders from Stages 3+ into a single folder for that stage (e.g. Stage3/S3_2022-04-25_miri_run1/ which contains the folders ap4_bg5 and ap4_bg10, and similarly for Stages 4-6).

I also wanted to be able to try Eureka! on Windows which uses back slashes instead of forward slashes, so I updated all the slashes to os.sep which figures out whether to use forward or back slashes.

I've run the code through all the tests successfully and manually tested it as well.