### PR TITLE
Fixing Stage 3 dirpath issue

### DIFF
--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -451,7 +451,7 @@ def load_general_s2_meta_info(meta, ecf_path, s2_meta):
     meta.read(ecf_path, ecffile)
 
     # Overwrite the inputdir with the exact output directory from S2
-    meta.inputdir = os.path.join(s2_topdir, s2_outputdir)
+    meta.inputdir = os.path.join(meta.topdir, s2_outputdir)
     meta.old_datetime = meta.datetime # Capture the date that the S2 data was made (to figure out it's foldername)
     meta.datetime = None # Reset the datetime in case we're running this on a different day
     meta.inputdir_raw = s2_outputdir


### PR DESCRIPTION
I just ran through the quickstart on the main branch and bumped into an issue where if the topdir for Stage 2 didn't match the topdir for Stage 3, then an error gets raised. 

STAGE2
```
# Project directory
topdir         /Users/acarter/Documents/TRANSITS/EUREKA

# Directories relative to project dir
inputdir       /QUICKSTART_DATA/NIRSpec   # The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
outputdir      /QUICKSTART/Stage2
```

STAGE3
```
# Project directory
topdir         /Users/acarter/Documents/TRANSITS/EUREKA/QUICKSTART

# Directories relative to project dir
inputdir       /Stage2   # The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
outputdir      /Stage3
```

I've figured out a quick fix for now, which is to change the following line (454 in s3_reduce):

` meta.inputdir = os.path.join(s2_topdir, s2_outputdir)`

to

` meta.inputdir = os.path.join(meta.topdir, s2_outputdir)`

But I'm not 100% sure this is the best route to take / whether I'll just break things in a different situation. 

Either way, I think it would be valuable to be able to have different topdirs between Stages. Particularly stage 1, 2, and 3, as they might use files in a different directory than the save directory (i.e. where you're keeping your JWST data).