### PR TITLE
Fixing bugs with quickstart

### DIFF
--- a/demos/JWST/S5_fit_par_template.epf
+++ b/demos/JWST/S5_fit_par_template.epf
@@ -10,8 +10,8 @@
 # ------------------
 # ** Transit/eclipse parameters **
 # ------------------
-rp           0.173010       'free'         0.1         0.3          U
-#fp           0.008         'free'         0            0.5          U
+rp           0.148          'free'         0.15         0.1          N
+#fp           0.008          'free'         0           0.5          U
 # ----------------------
 # ** Phase curve parameters **
 # ----------------------
@@ -22,35 +22,36 @@ rp           0.173010       'free'         0.1         0.3          U
 # ------------------
 # ** Orbital parameters **
 # ------------------
-per          4.055259   	'free'         4.055259   	1e-5		 N
-t0           0.5		 	'free'         0.4     0.6     U
-time_offset  0            	'independent'
-inc          87.93        	'free'         85       90        U
-a            11.612         'free'         10         13         U
-ecc          0.0           	'fixed'        0            1            U
-w            90.           	'fixed'        0            180          U
+per          4.055259       'free'         4.055259     1e-5         N
+t0           57394.524      'free'         57394.524    0.05         N
+time_offset  0              'independent'
+inc          87.83          'free'         87.83        0.25         N
+a            10.9           'free'         10.9         1            N  # An incorrect a/R* seems to have been used in the simulations
+ecc          0.0            'fixed'        0            1            U
+w            90.            'fixed'        0            180          U
 # -------------------------
 # ** Limb darkening parameters **
 # Choose limb_dark from ['uniform', 'linear', 'quadratic', 'kipping2013', 'square-root', 'logarithmic', 'exponential', '4-parameter']
 # -------------------------
-limb_dark    'kipping2013'	'independent'
-u1           0.5           	'free'         0            1            U
-u2           0.5           	'free'         0            1            U
+limb_dark    'kipping2013'  'independent'
+u1           0.59           'free'         0            1            U
+u2           0.84           'free'         0            1            U
 # --------------------
 # ** Systematic variables **
 # polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
 # expramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
 # GP model parameters (A, WN, m1, m2) in log scale
 # --------------------
-c0           1             	'free'         0.95         1.05         U
-c1           0           	'free'         -0.1         0.1          U
-#A            -5           	'free'         -20.         -5.          U
-#WN           -15          	'free'         -20.         -10.         U
-#m1           -5          	'free'         -10.         0.           U
+c0           1.015          'free'         1            0.05         N
+c1           0              'free'         0            0.01          N
+#A            -5             'free'         -20.         -5.          U
+#WN           -15            'free'         -20.         -10.         U
+#m1           -5             'free'         -10.         0.           U
 # -----------
 # ** White noise **
 # Use scatter_mult to fit a multiplier to the expected noise level from Stage 3 (recommended)
 # Use scatter_ppm to fit the noise level in ppm
 # Use WN parameter in GP model parameters to account for white noise in the GP model
 # -----------
-scatter_mult 1             	'free'         1            0.1          N
+#scatter_mult 1.1            'free'         1            0.1          N
+scatter_ppm  500            'free'         500          100          N

--- a/demos/JWST/run_eureka.py
+++ b/demos/JWST/run_eureka.py
@@ -1,6 +1,6 @@
 import sys
 import os
-sys.path.append(f'..{os.sep}..{os.sep}')
+sys.path.insert(0, f'..{os.sep}..{os.sep}')
 import eureka.lib.plots
 import eureka.S1_detector_processing.s1_process as s1
 import eureka.S2_calibrations.s2_calibrate as s2
@@ -15,8 +15,8 @@ eureka.lib.plots.set_rc(style='eureka', usetex=False, filetype='.png')
 
 # eventlabel = 'imaging_template'
 # eventlabel = 'miri_lrs_template'
-# eventlabel = 'nirspec_fs_template'
-eventlabel = 'nircam_wfss_template'
+eventlabel = 'nirspec_fs_template'
+# eventlabel = 'nircam_wfss_template'
 ecf_path = '.'+os.sep
 
 if __name__ == '__main__':

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -99,7 +99,20 @@ The explicit settings for the ``S4_wasp39b.ecf``, ``S5_wasp39b.ecf`` and ``S6_wa
 	ncpu		4
 	fit_par		S5_fit_par_wasp39b.epf
 
-While editing those files you may have noticed that there are a whole range of other inputs that can be tweaked and adjusted at each different stage. For now you can ignore these, as the demo files have been specifically tailored to this simulated dataset of WASP-39b.
+To speed up the Stage 5 dynesty fit, you can also reduce the number of live points (``run_nlive``) at the cost of a more coarse corner plot in the end. The bare minimum recommended value is
+
+.. code-block:: bash
+	
+	ndim * (ndim + 1) / 2
+
+and our fit presently has ndim=10 free values in the EPF, so that means a bare minimum of 55 live points. As a compromise, let's use 256 live points instead to
+get a fairly nice corner plot but also speed up the fit, so set the following in ``S5_fit_par_wasp39b.epf``:
+
+.. code-block:: bash
+	
+	run_nlive    256
+
+While editing all those files, you may have noticed that there is a whole range of other inputs that can be tweaked and adjusted at each different stage. For now you can ignore these as the demo files have been specifically tailored to this simulated dataset of WASP-39b.
 
 
 4. Run Eureka! 💡

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -390,7 +390,7 @@ def parse_s5_saves(meta, fit_methods, y_param, channel_key='shared'):
                                      ' of fitted parameters which includes: '
                                      ', '.join(samples.keys()))
             medians = np.array([fitted_values[key] for key in keys])
-            errs = np.ones_like(medians)*np.nan
+            errs = np.ones((2, len(medians)))*np.nan
 
     return medians, errs
 


### PR DESCRIPTION
The EPF template was still optimized for NIRCam simulations and had several issues for the NIRSpec tiny dataset used in the quickstart guide. The updated values resolve #326

I also edited the quickstart guide to explain run_nlive and have users edit it during the quickstart so they understand how to do so. This also helps make the quickstart quicker to run by a factor of a few for Stage 5 at the cost of a fairly unimportant degredation to the corner plot.

Finally, I also changed the order of S5 outputs for easier debugging. Specifically, I moved the S5 outputs that are most likely to fail (e.g. corner plot) to the end of each fitter function and moved the most helpful outputs for debugging (e.g. text logging, simpler plots) to earlier on.