### PR TITLE
Fixing docs with new .readthedocs.yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required: Readthedocs Config-file 
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/source/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs, jwst

--- a/docs/source/copyright.rst
+++ b/docs/source/copyright.rst
@@ -16,4 +16,5 @@ The current main developers of Eureka! are (ordered alphabetically by first name
 - Megan Mansfield
 - Sebastian Zieba
 - Taylor Bell
+- Yoni Brande
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,7 @@ The code is separated into six parts or "Stages":
 - Stage 1: An optional step that calibrates Raw data (converts ramps to slopes). This step can be skipped if you'd rather use STScI's JWST pipeline's Stage 1 outputs.
 - Stage 2: An optional step that calibrates Stage 1 data (performs flatfielding, unit conversion, etc.). This step can be skipped if you'd rather use STScI's JWST pipeline's Stage 2 outputs.
 - Stage 3: Starts with Stage 2 data and further calibrates (performs background subtraction, etc.) and reduces the data in order to convert 2D spectra into a time-series of 1D spectra.
-- Stage 4: Bins the 1D Spectra and generates light curves. Also removes spectral drift and jitter and sigma clips outliers.
+- Stage 4: Bins the 1D Spectra and generates light curves. Also removes 1D spectral drift/jitter and sigma clips outliers.
 - Stage 5: Fits the light curves with noise and astrophysical models.
 - Stage 6: Creates a table and a figure summarizing the transmission and/or emission spectra from your many fits.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,28 +3,23 @@ astropy
 batman-package
 bokeh
 ccdproc
-celerite
+celerite # Needed for GP
 corner
 crds
 cython
 dynesty>1.0
 emcee>3.0.0
-george
+george # Needed for GP
 gwcs
 h5py<3.2
 ipython
 lmfit
 matplotlib
-myst_parser # Needed for documentation
-nbsphinx # Needed for documentation
 numpy>=1.20.0
 pandas
 photutils
-pytest
-recommonmark # Needed for documentation
 requests
 scipy>=1.4.0 # Needed for scipy.fft
-sphinx-rtd-theme # Needed for documentation
 stdatamodels
 svo_filters
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,14 @@ with open('requirements.txt') as f:
     REQUIRES = f.read().splitlines()
 
 extras_require = {
-   'jwst': ["jwst==1.3.3", "stcal", "asdf>=2.7.1,<2.11.0"],
-   # Need the GitHub version as 0.2.6 is required for python>=3.10, but
-   # 0.2.6 is not yet on PyPI
-   'hst': ["image_registration @ git+https://github.com/keflavich/"
-           + "image_registration.git"]
+    'jwst': ["jwst==1.3.3", "stcal", "asdf>=2.7.1,<2.11.0"],
+    # Need the GitHub version as 0.2.6 is required for python>=3.10, but
+    # 0.2.6 is not yet on PyPI
+    'hst': ["image_registration @ git+https://github.com/keflavich/"
+            + "image_registration.git"],
+    'docs': ['myst_parser', 'nbsphinx', 'recommonmark', 'sphinx-rtd-theme',
+             'sphinx', 'sphinx-automodapi', 'numpydoc'],
+    'test': ['pytest', 'pytest-doctestplus', 'flake8', 'codecov', 'pytest-cov']
 }
 
 FILES = []


### PR DESCRIPTION
Because Astraeus requires a specific python version that is not consistent with the readthedocs default, the docs page has been failing to build since we added Astraeus to Eureka. This is now fixed with a new .readthedocs.yaml file which I have confirmed works on the readthedocs webpage (https://eurekadocs.readthedocs.io/en/fixing-docs/index.html).

Also adding Yoni who was missing from the copyright page and tweaking the phrasing of the Stage 4 description in docs index.