### PR TITLE
fitters.py bug fix

### DIFF
--- a/eureka/S5_lightcurve_fitting/fitters.py
+++ b/eureka/S5_lightcurve_fitting/fitters.py
@@ -396,7 +396,7 @@ def emceefitter(lc, model, meta, log, **kwargs):
     log.writelog(f"Mean acceptance fraction: {acceptance_fraction:.3f}",
                  mute=(not meta.verbose))
     try:
-        autocorr = sampler.get_autocorr_time()
+        autocorr = np.mean(sampler.get_autocorr_time())
         log.writelog(f"Mean autocorrelation time: {autocorr:.3f} steps",
                      mute=(not meta.verbose))
     except:


### PR DESCRIPTION
Fixed a typo in calculating the autocorrelation time with emcee that made it never output an autocorrelation time