### PR TITLE
Bug fixes and new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,7 @@ dmypy.json
 
 # VS Code workspaces
 *.code-workspace
-.vscode/settings.json
+.vscode
 
 # Compiled niriss_cython file
 niriss_cython.c
@@ -148,4 +148,7 @@ niriss_cython.c
 Dockerfile
 docker-compose.yml
 docker-setup.sh
-eureka_analysis/JWST/run_eureka_demo.py
+
+# Compiled JOSS paper files
+paper.pdf
+paper.jats

--- a/demos/JWST/S6_template.ecf
+++ b/demos/JWST/S6_template.ecf
@@ -30,7 +30,7 @@ model_spectrum  None # Path to the model spectrum relative to topdir. Set to Non
 model_x_unit    um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
 model_y_unit    Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
 model_y_scalar  1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
-model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, np.inf for above the data)
+model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, 1 for above the data)
 model_delimiter None # Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to topdir

--- a/demos/JWST/S6_template.ecf
+++ b/demos/JWST/S6_template.ecf
@@ -30,6 +30,7 @@ model_spectrum  None # Path to the model spectrum relative to topdir. Set to Non
 model_x_unit    um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
 model_y_unit    Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
 model_y_scalar  1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
+model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, np.inf for above the data)
 model_delimiter None # Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to topdir

--- a/docs/media/S6_template.ecf
+++ b/docs/media/S6_template.ecf
@@ -30,7 +30,7 @@ model_spectrum  None # Path to the model spectrum relative to topdir. Set to Non
 model_x_unit    um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
 model_y_unit    Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
 model_y_scalar  1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
-model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, np.inf for above the data)
+model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, 1 for above the data)
 model_delimiter None # Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to topdir

--- a/docs/media/S6_template.ecf
+++ b/docs/media/S6_template.ecf
@@ -30,6 +30,7 @@ model_spectrum  None # Path to the model spectrum relative to topdir. Set to Non
 model_x_unit    um # Options include any measurement of light included in astropy.units.spectral (e.g. um, nm, Hz, etc.)
 model_y_unit    Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
 model_y_scalar  1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
+model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, np.inf for above the data)
 model_delimiter None # Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to topdir

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -294,7 +294,7 @@ The path to the directory in which to output the Stage 3 JWST data and plots.
 
 topdir + time_file
 ''''''''''''''''''
-The path to a file which contains the time array you want to use instead of the one contained in the FITS file.
+The path to a file that contains the time array you want to use instead of the one contained in the FITS file.
 
 
 
@@ -645,7 +645,7 @@ model_spectrum is in ppm).
 
 model_zorder
 ''''''''''''
-The zorder of the model on the plot (0 for beneath the data, np.inf for above the data).
+The zorder of the model on the plot (0 for beneath the data, 1 for above the data).
 
 model_delimiter
 '''''''''''''''

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -643,6 +643,10 @@ model_y_scalar
 Indicate whether model y-values have already been scaled (e.g. write 1e6 if
 model_spectrum is in ppm).
 
+model_zorder
+''''''''''''
+The zorder of the model on the plot (0 for beneath the data, np.inf for above the data).
+
 model_delimiter
 '''''''''''''''
 Delimiter between columns. Typical options: None (for whitespace), ',' for comma.

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -292,8 +292,9 @@ topdir + outputdir
 ''''''''''''''''''
 The path to the directory in which to output the Stage 3 JWST data and plots.
 
-
-
+topdir + time_file
+''''''''''''''''''
+The path to a file which contains the time array you want to use instead of the one contained in the FITS file.
 
 
 

--- a/eureka/S1_detector_processing/s1_process.py
+++ b/eureka/S1_detector_processing/s1_process.py
@@ -49,29 +49,20 @@ def rampfitJWST(eventlabel, ecf_path=None):
     ecffile = 'S1_' + eventlabel + '.ecf'
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
-    # This will break for any instruments/observations that do not make uncal
-    meta.suffix = 'uncal'
-
-    meta.inputdir_raw = meta.inputdir
-    meta.outputdir_raw = meta.outputdir
 
     # Create directories for Stage 1 processing outputs
-    # Allows the input and output files to be stored anywhere
-    outputdir = os.path.join(meta.topdir, *meta.outputdir.split(os.sep))
-    if outputdir[-1] != os.sep:
-        outputdir += os.sep
     run = util.makedirectory(meta, 'S1')
-    meta.workdir = util.pathdirectory(meta, 'S1', run)
-    # Add a trailing slash so we don't need to add it everywhere below
-    meta.workdir += os.sep
+    meta.outputdir = util.pathdirectory(meta, 'S1', run)
     # Make a separate folder for plot outputs
-    if not os.path.exists(meta.workdir+'figs'):
-        os.makedirs(meta.workdir+'figs')
+    if not os.path.exists(meta.outputdir+'figs'):
+        os.makedirs(meta.outputdir+'figs')
 
     # Output S2 log file
-    meta.s1_logname = meta.workdir + 'S1_' + meta.eventlabel + ".log"
+    meta.s1_logname = meta.outputdir + 'S1_' + meta.eventlabel + ".log"
     log = logedit.Logedit(meta.s1_logname)
     log.writelog("\nStarting Stage 1 Processing")
+    log.writelog(f"Input directory: {meta.inputdir}")
+    log.writelog(f"Output directory: {meta.outputdir}")
 
     # Copy ecf
     log.writelog('Copying S1 control file')
@@ -112,7 +103,7 @@ def rampfitJWST(eventlabel, ecf_path=None):
     # Save results
     if not meta.testing_S1:
         log.writelog('Saving Metadata')
-        me.saveevent(meta, meta.workdir+'S1_'+meta.eventlabel+"_Meta_Save",
+        me.saveevent(meta, meta.outputdir+'S1_'+meta.eventlabel+"_Meta_Save",
                      save=[])
 
     return meta

--- a/eureka/S2_calibrations/s2_calibrate.py
+++ b/eureka/S2_calibrations/s2_calibrate.py
@@ -242,7 +242,8 @@ class EurekaSpec2Pipeline(Spec2Pipeline):
         self.msa_flagging.skip = meta.skip_msa_flagging
         self.extract_2d.skip = meta.skip_extract_2d
         self.srctype.skip = meta.skip_srctype
-        self.master_background.skip = meta.skip_master_background
+        if hasattr(self, 'master_background'):
+            self.master_background.skip = meta.skip_master_background
         self.wavecorr.skip = meta.skip_wavecorr
         self.flat_field.skip = meta.skip_flat_field
         self.straylight.skip = meta.skip_straylight

--- a/eureka/S3_data_reduction/miri.py
+++ b/eureka/S3_data_reduction/miri.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 from astropy.io import fits
 import astraeus.xarrayIO as xrio
 from . import nircam
@@ -68,7 +69,14 @@ def read(filename, data, meta):
                                              data.attrs['intend']]
 
     # Record integration mid-times in BJD_TDB
-    if len(int_times['int_mid_BJD_TDB']) == 0:
+    if (hasattr(meta, 'time_file') and meta.time_file is not None):
+        fname = os.path.join(meta.topdir,
+                             os.sep.join(meta.time_file.split(os.sep)))
+        if meta.firstFile:
+            print('  Note: Using the time stamps from:\n'+fname)
+        time = np.loadtxt(fname).flatten()[data.attrs['intstart']-1:
+                                           data.attrs['intend']-1]
+    elif len(int_times['int_mid_BJD_TDB']) == 0:
         if meta.firstFile:
             print('  WARNING: The timestamps for the simulated MIRI data are '
                   'currently hardcoded\n'

--- a/eureka/S3_data_reduction/miri.py
+++ b/eureka/S3_data_reduction/miri.py
@@ -1,8 +1,8 @@
 import numpy as np
-import os
 from astropy.io import fits
 import astraeus.xarrayIO as xrio
 from . import nircam
+from ..lib.util import read_time
 
 
 def read(filename, data, meta):
@@ -70,12 +70,7 @@ def read(filename, data, meta):
 
     # Record integration mid-times in BJD_TDB
     if (hasattr(meta, 'time_file') and meta.time_file is not None):
-        fname = os.path.join(meta.topdir,
-                             os.sep.join(meta.time_file.split(os.sep)))
-        if meta.firstFile:
-            print('  Note: Using the time stamps from:\n'+fname)
-        time = np.loadtxt(fname).flatten()[data.attrs['intstart']-1:
-                                           data.attrs['intend']-1]
+        time = read_time(meta, data)
     elif len(int_times['int_mid_BJD_TDB']) == 0:
         if meta.firstFile:
             print('  WARNING: The timestamps for the simulated MIRI data are '

--- a/eureka/S3_data_reduction/nircam.py
+++ b/eureka/S3_data_reduction/nircam.py
@@ -1,9 +1,8 @@
 # NIRCam specific rountines go here
-import numpy as np
-import os
 from astropy.io import fits
 import astraeus.xarrayIO as xrio
 from . import sigrej, background
+from ..lib.util import read_time
 
 
 def read(filename, data, meta):
@@ -57,12 +56,7 @@ def read(filename, data, meta):
 
     # Record integration mid-times in BJD_TDB
     if (hasattr(meta, 'time_file') and meta.time_file is not None):
-        fname = os.path.join(meta.topdir,
-                             os.sep.join(meta.time_file.split(os.sep)))
-        if meta.firstFile:
-            print('  Note: Using the time stamps from:\n'+fname)
-        time = np.loadtxt(fname).flatten()[data.attrs['intstart']-1:
-                                           data.attrs['intend']-1]
+        time = read_time(meta, data)
     else:
         time = int_times['int_mid_BJD_TDB']
 

--- a/eureka/S3_data_reduction/nircam.py
+++ b/eureka/S3_data_reduction/nircam.py
@@ -1,5 +1,6 @@
 # NIRCam specific rountines go here
-# import numpy as np
+import numpy as np
+import os
 from astropy.io import fits
 import astraeus.xarrayIO as xrio
 from . import sigrej, background
@@ -55,7 +56,15 @@ def read(filename, data, meta):
                                              data.attrs['intend']]
 
     # Record integration mid-times in BJD_TDB
-    time = int_times['int_mid_BJD_TDB']
+    if (hasattr(meta, 'time_file') and meta.time_file is not None):
+        fname = os.path.join(meta.topdir,
+                             os.sep.join(meta.time_file.split(os.sep)))
+        if meta.firstFile:
+            print('  Note: Using the time stamps from:\n'+fname)
+        time = np.loadtxt(fname).flatten()[data.attrs['intstart']-1:
+                                           data.attrs['intend']-1]
+    else:
+        time = int_times['int_mid_BJD_TDB']
 
     # Record units
     flux_units = data.attrs['shdr']['BUNIT']

--- a/eureka/S3_data_reduction/nirspec.py
+++ b/eureka/S3_data_reduction/nirspec.py
@@ -1,5 +1,6 @@
 # NIRSpec specific rountines go here
 import numpy as np
+import os
 from astropy.io import fits
 import astraeus.xarrayIO as xrio
 from . import nircam, sigrej
@@ -59,7 +60,14 @@ def read(filename, data, meta):
                                              data.attrs['intend']]
 
     # Record integration mid-times in BJD_TDB
-    if len(int_times['int_mid_BJD_TDB']) == 0:
+    if (hasattr(meta, 'time_file') and meta.time_file is not None):
+        fname = os.path.join(meta.topdir,
+                             os.sep.join(meta.time_file.split(os.sep)))
+        if meta.firstFile:
+            print('  Note: Using the time stamps from:\n'+fname)
+        time = np.loadtxt(fname).flatten()[data.attrs['intstart']-1:
+                                           data.attrs['intend']-1]
+    elif len(int_times['int_mid_BJD_TDB']) == 0:
         # There is no time information in the simulated NIRSpec data
         print('  WARNING: The timestamps for the simulated NIRSpec data are '
               'currently\n'

--- a/eureka/S3_data_reduction/nirspec.py
+++ b/eureka/S3_data_reduction/nirspec.py
@@ -1,9 +1,9 @@
 # NIRSpec specific rountines go here
 import numpy as np
-import os
 from astropy.io import fits
 import astraeus.xarrayIO as xrio
 from . import nircam, sigrej
+from ..lib.util import read_time
 
 
 def read(filename, data, meta):
@@ -61,12 +61,7 @@ def read(filename, data, meta):
 
     # Record integration mid-times in BJD_TDB
     if (hasattr(meta, 'time_file') and meta.time_file is not None):
-        fname = os.path.join(meta.topdir,
-                             os.sep.join(meta.time_file.split(os.sep)))
-        if meta.firstFile:
-            print('  Note: Using the time stamps from:\n'+fname)
-        time = np.loadtxt(fname).flatten()[data.attrs['intstart']-1:
-                                           data.attrs['intend']-1]
+        time = read_time(meta, data)
     elif len(int_times['int_mid_BJD_TDB']) == 0:
         # There is no time information in the simulated NIRSpec data
         print('  WARNING: The timestamps for the simulated NIRSpec data are '

--- a/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/eureka/S4_generate_lightcurves/plots_s4.py
@@ -109,13 +109,14 @@ def lc_driftcorr(meta, wave_1d, optspec):
                extent=[wmin, wmax, 0, n_int], vmin=vmin, vmax=vmax,
                cmap=plt.cm.RdYlBu_r)
     plt.title("MAD = " + str(np.round(meta.mad_s4).astype(int)) + " ppm")
-    if meta.nspecchan > 1:
-        # Insert vertical dashed lines at spectroscopic channel edges
-        secax = plt.gca().secondary_xaxis('top')
-        xticks = np.unique(np.concatenate([meta.wave_low, meta.wave_hi]))
-        secax.set_xticks(xticks, np.round(xticks, 6), rotation=90,
-                         fontsize='xx-small')
-        plt.vlines(xticks, 0, n_int, '0.3', 'dashed')
+
+    # Insert vertical dashed lines at spectroscopic channel edges
+    secax = plt.gca().secondary_xaxis('top')
+    xticks = np.unique(np.concatenate([meta.wave_low, meta.wave_hi]))
+    secax.set_xticks(xticks, np.round(xticks, 6), rotation=90,
+                     fontsize='xx-small')
+    plt.vlines(xticks, 0, n_int, '0.3', 'dashed')
+
     plt.ylabel('Integration Number')
     plt.xlabel(r'Wavelength ($\mu m$)')
     plt.colorbar(label='Normalized Flux')

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -180,6 +180,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None):
             lc['wave_err'] = (lc.wave_hi - lc.wave_low)/2
             lc.wave_low.attrs['wave_units'] = spec.wave_1d.attrs['wave_units']
             lc.wave_hi.attrs['wave_units'] = spec.wave_1d.attrs['wave_units']
+            lc.wave_mid.attrs['wave_units'] = spec.wave_1d.attrs['wave_units']
             lc.wave_err.attrs['wave_units'] = spec.wave_1d.attrs['wave_units']
 
             if not hasattr(meta, 'boundary'):

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -185,8 +185,8 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
 
                     # Normalize flux and uncertainties to avoid large
                     # flux values
-                    flux_err = flux_err/flux.mean()
-                    flux = flux/flux.mean()
+                    flux_err = flux_err/np.nanmean(flux)
+                    flux = flux/np.nanmean(flux)
 
                     meta = fit_channel(meta, time, flux, channel, flux_err,
                                        eventlabel, sharedp, params, log,

--- a/eureka/S6_planet_spectra/plots_s6.py
+++ b/eureka/S6_planet_spectra/plots_s6.py
@@ -53,8 +53,10 @@ def plot_spectrum(meta, model_x=None, model_y=None,
     if err is not None:
         err *= y_scalar
 
+    # Set zorder to 0.5 so model can easily be placed above or below
     ax.errorbar(wavelength, spectrum, fmt='o', capsize=3, ms=3,
-                xerr=wavelength_error, yerr=err, color='k')
+                xerr=wavelength_error, yerr=err, color='k',
+                zorder=0.5)
     if (model_x is not None) and (model_y is not None):
         in_range = np.logical_and(model_x >= wavelength[0]-wavelength_error[0],
                                   model_x <= (wavelength[-1] +

--- a/eureka/S6_planet_spectra/plots_s6.py
+++ b/eureka/S6_planet_spectra/plots_s6.py
@@ -59,7 +59,10 @@ def plot_spectrum(meta, model_x=None, model_y=None,
         in_range = np.logical_and(model_x >= wavelength[0]-wavelength_error[0],
                                   model_x <= (wavelength[-1] +
                                               wavelength_error[-1]))
-        ax.plot(model_x[in_range], model_y[in_range], color='r', zorder=0)
+        if not hasattr(meta, 'model_zorder'):
+            meta.model_zorder = 0
+        ax.plot(model_x[in_range], model_y[in_range], color='r',
+                zorder=meta.model_zorder)
         if wavelength_error is not None:
             # Compute the binned model for easlier comparisons
             binned_model = []
@@ -70,7 +73,7 @@ def plot_spectrum(meta, model_x=None, model_y=None,
                 binned_model.append(model_val)
             # Plot the binned model as well
             ax.plot(wavelength, binned_model, 'o', ms=3, color='r', mec='k',
-                    mew=0.5, zorder=0)
+                    mew=0.5, zorder=meta.model_zorder)
     ax.set_ylabel(ylabel)
     ax.set_xlabel(xlabel)
 

--- a/eureka/lib/readECF.py
+++ b/eureka/lib/readECF.py
@@ -1,5 +1,8 @@
 import os
 
+# Required in case user passes in a numpy object (e.g. np.inf)
+import numpy as np
+
 
 class MetaClass:
     '''A class to hold Eureka! metadata.

--- a/eureka/lib/util.py
+++ b/eureka/lib/util.py
@@ -345,3 +345,28 @@ def get_mad_1d(data, ind_min=0, ind_max=-1):
         Single MAD value in ppm
     """
     return 1e6 * np.ma.median(np.ma.abs(np.ma.ediff1d(data[ind_min:ind_max])))
+
+
+def read_time(meta, data):
+    """Read in a time CSV file instead of using the FITS time array.
+
+    Parameters
+    ----------
+    meta : eureka.lib.readECF.MetaClass
+        The metadata object.
+    data : Xarray Dataset
+        The Dataset object with the fits data stored inside.
+
+    Returns
+    -------
+    time : ndarray
+        The time array stored in the meta.time_file CSV file.
+    """
+    fname = os.path.join(meta.topdir,
+                         os.sep.join(meta.time_file.split(os.sep)))
+    if meta.firstFile:
+        print('  Note: Using the time stamps from:\n'+fname)
+    time = np.loadtxt(fname).flatten()[data.attrs['intstart']-1:
+                                       data.attrs['intend']-1]
+
+    return time

--- a/tests/MIRI_ecfs/S6_MIRI.ecf
+++ b/tests/MIRI_ecfs/S6_MIRI.ecf
@@ -32,7 +32,7 @@ model_spectrum	None
 model_x_unit	um
 model_y_unit	Fp/Fs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
 model_y_scalar	1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
-model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, np.inf for above the data)
+model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, 1 for above the data)
 model_delimiter None # Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to project dir

--- a/tests/MIRI_ecfs/S6_MIRI.ecf
+++ b/tests/MIRI_ecfs/S6_MIRI.ecf
@@ -32,6 +32,8 @@ model_spectrum	None
 model_x_unit	um
 model_y_unit	Fp/Fs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
 model_y_scalar	1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
+model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, np.inf for above the data)
+model_delimiter None # Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to project dir
 inputdir        /data/JWST-Sim/MIRI/Stage5/

--- a/tests/NIRCam_ecfs/S6_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S6_NIRCam.ecf
@@ -29,6 +29,8 @@ model_spectrum	None
 model_x_unit	um
 model_y_unit	Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
 model_y_scalar	1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
+model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, np.inf for above the data)
+model_delimiter None # Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to project dir
 inputdir        /data/JWST-Sim/NIRCam/Stage5/    # The folder containing the outputs from Eureka!'s S3 or JWST's S3 pipeline (will be overwritten if calling S3 and S4 sequentially)

--- a/tests/NIRCam_ecfs/S6_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S6_NIRCam.ecf
@@ -29,7 +29,7 @@ model_spectrum	None
 model_x_unit	um
 model_y_unit	Rp/Rs # Options include Rp/Rs, (Rp/Rs)^2, Fp/Fs
 model_y_scalar	1 # Indicate whether model y-values have already been scaled (e.g. write 1e6 if model_spectrum is in ppm)
-model_zorder    0 # The zorder of the model on the plot (0 for beneath the data, np.inf for above the data)
+model_zorder    1 # The zorder of the model on the plot (0 for beneath the data, 1 for above the data)
 model_delimiter None # Delimiter between columns. Typical options: None (for space), ',' for comma
 
 # Directories relative to project dir


### PR DESCRIPTION
This PR resolves #320 (allow setting of S6 model zorder) and resolves #337 (NaN uncertainties going into S5 fits). It also updates now out-of-date Stage 1 code that was broken when files were updated in the lib folder - we didn't catch that earlier since we don't have tests for Stage 1. I've also more generally fixed the `EurekaSpec2Pipeline has no attribute master_background` issue by first checking that such a step exists - this will also resolve the same issue Adina found for NIRISS but do so for all instruments (since I just encountered it on MIRI data). I also fixed a bug in Stage 4 clipping where `lc.wave_mid.attrs['wave_units']` was undefined.

I also now made it so that the bin edges are always plotted in Fig 4101 while they were previously only plotted if there was more than one bin. However, since the bin edges are not necessarily aligned with the edges of the figure, the lines are still useful even if there is only one bin (for a white-light fit).

I also allowed a `meta.time_file` setting in Stage 3 to allow users to pass in a file with the time array they want to use instead of the one inside the FITS files. For the MIRI simulations we've had to directly edit the code for each new simulation, and this will now remove that requirement and also allow users to use their own time array in case there are issues with the values from the FITS headers.

I also moved the NIRISS testing files to the right location.