### PR TITLE
Set meta.datetime once at the start of every stage

### DIFF
--- a/eureka/S1_detector_processing/s1_process.py
+++ b/eureka/S1_detector_processing/s1_process.py
@@ -1,5 +1,5 @@
 import os
-import time
+import time as time_pkg
 import numpy as np
 from astropy.io import fits
 
@@ -43,12 +43,13 @@ def rampfitJWST(eventlabel, ecf_path=None):
     - February 2022 Aarynn Carter and Eva-Maria Ahrer
         Updated for JWST version 1.3.3, code restructure
     """
-    t0 = time.time()
+    t0 = time_pkg.time()
 
     # Load Eureka! control file and store values in Event object
     ecffile = 'S1_' + eventlabel + '.ecf'
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
     # Create directories for Stage 1 processing outputs
     run = util.makedirectory(meta, 'S1')
@@ -97,7 +98,7 @@ def rampfitJWST(eventlabel, ecf_path=None):
             EurekaS1Pipeline().run_eurekaS1(filename, meta, log)
 
     # Calculate total run time
-    total = (time.time() - t0) / 60.
+    total = (time_pkg.time() - t0) / 60.
     log.writelog('\nTotal time (min): ' + str(np.round(total, 2)))
 
     # Save results

--- a/eureka/S2_calibrations/s2_calibrate.py
+++ b/eureka/S2_calibrations/s2_calibrate.py
@@ -12,7 +12,7 @@
 
 import os
 import shutil
-import time
+import time as time_pkg
 import numpy as np
 import matplotlib.pyplot as plt
 from astropy.io import fits
@@ -55,12 +55,13 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None):
     - 03 Nov 2021 Taylor Bell
         Initial version
     '''
-    t0 = time.time()
+    t0 = time_pkg.time()
 
     # Load Eureka! control file and store values in Event object
     ecffile = 'S2_' + eventlabel + '.ecf'
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
     if s1_meta is None:
         # Locate the old MetaClass savefile, and load new ECF into
@@ -157,7 +158,7 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None):
         pipeline.run_eurekaS2(filename, meta, log)
 
     # Calculate total run time
-    total = (time.time() - t0) / 60.
+    total = (time_pkg.time() - t0) / 60.
     log.writelog('\nTotal time (min): ' + str(np.round(total, 2)))
 
     # Save results

--- a/eureka/S3_data_reduction/s3_reduce.py
+++ b/eureka/S3_data_reduction/s3_reduce.py
@@ -70,6 +70,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
     ecffile = 'S3_' + eventlabel + '.ecf'
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
     if s2_meta is None:
         # Locate the old MetaClass savefile, and load new ECF into

--- a/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -62,6 +62,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None):
     ecffile = 'S4_' + eventlabel + '.ecf'
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
     if s3_meta is None:
         # Locate the old MetaClass savefile, and load new ECF into

--- a/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -52,6 +52,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
     ecffile = 'S5_' + eventlabel + '.ecf'
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
     if s4_meta is None:
         # Locate the old MetaClass savefile, and load new ECF into

--- a/eureka/S6_planet_spectra/s6_spectra.py
+++ b/eureka/S6_planet_spectra/s6_spectra.py
@@ -43,6 +43,7 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None):
     ecffile = 'S6_' + eventlabel + '.ecf'
     meta = readECF.MetaClass(ecf_path, ecffile)
     meta.eventlabel = eventlabel
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
     if s5_meta is None:
         # Locate the old MetaClass savefile, and load new ECF into

--- a/eureka/lib/util.py
+++ b/eureka/lib/util.py
@@ -1,7 +1,6 @@
 import numpy as np
 from . import sort_nicely as sn
 import os
-import time
 import glob
 
 
@@ -115,17 +114,13 @@ def makedirectory(meta, stage, counter=None, **kwargs):
     run : int
         The run number
     """
-    if not hasattr(meta, 'datetime') or meta.datetime is None:
-        meta.datetime = time.strftime('%Y-%m-%d')
-    datetime = meta.datetime
-
     # This code allows the input and output files to be stored outside
     # of the Eureka! folder
     rootdir = os.path.join(meta.topdir, *meta.outputdir_raw.split(os.sep))
     if rootdir[-1] != os.sep:
         rootdir += os.sep
 
-    outputdir = rootdir+stage+'_'+datetime+'_'+meta.eventlabel+'_run'
+    outputdir = rootdir+stage+'_'+meta.datetime+'_'+meta.eventlabel+'_run'
 
     if counter is None:
         counter = 1
@@ -192,8 +187,6 @@ def pathdirectory(meta, stage, run, old_datetime=None, **kwargs):
     if old_datetime is not None:
         datetime = old_datetime
     else:
-        if not hasattr(meta, 'datetime') or meta.datetime is None:
-            meta.datetime = time.strftime('%Y-%m-%d')
         datetime = meta.datetime
 
     # This code allows the input and output files to be stored outside

--- a/tests/test_MIRI.py
+++ b/tests/test_MIRI.py
@@ -3,6 +3,7 @@
 import sys
 import os
 from importlib import reload
+import time as time_pkg
 
 sys.path.insert(0, '..'+os.sep)
 from eureka.lib.readECF import MetaClass
@@ -45,6 +46,7 @@ def test_MIRI(capsys):
     # pathdirectory fn locally
     meta = MetaClass()
     meta.eventlabel = 'MIRI'
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
     meta.topdir = f'..{os.sep}tests'
     ecf_path = f'.{os.sep}MIRI_ecfs{os.sep}'
 

--- a/tests/test_NIRCam.py
+++ b/tests/test_NIRCam.py
@@ -3,6 +3,7 @@
 import sys
 import os
 from importlib import reload
+import time as time_pkg
 
 sys.path.insert(0, '..'+os.sep)
 from eureka.lib.readECF import MetaClass
@@ -35,6 +36,7 @@ def test_NIRCam(capsys):
     # pathdirectory fn locally
     meta = MetaClass()
     meta.eventlabel = 'NIRCam'
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
     meta.topdir = f'..{os.sep}tests'
     ecf_path = f'.{os.sep}NIRCam_ecfs{os.sep}'
 

--- a/tests/test_NIRSpec.py
+++ b/tests/test_NIRSpec.py
@@ -3,6 +3,7 @@
 import sys
 import os
 from importlib import reload
+import time as time_pkg
 
 sys.path.insert(0, '..'+os.sep)
 from eureka.lib.readECF import MetaClass
@@ -43,6 +44,7 @@ def test_NIRSpec(capsys):
     # pathdirectory fn locally
     meta = MetaClass()
     meta.eventlabel = 'NIRSpec'
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
     meta.topdir = f'..{os.sep}tests'
     ecf_path = f'.{os.sep}NIRSpec_ecfs{os.sep}'
 

--- a/tests/test_WFC3.py
+++ b/tests/test_WFC3.py
@@ -3,6 +3,7 @@
 import sys
 import os
 from importlib import reload
+import time as time_pkg
 
 sys.path.insert(0, '..'+os.sep)
 from eureka.lib.readECF import MetaClass
@@ -28,6 +29,7 @@ def test_WFC3(capsys):
     # pathdirectory fn locally
     meta = MetaClass()
     meta.eventlabel = 'WFC3'
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
     meta.topdir = f'..{os.sep}tests'
     ecf_path = f'.{os.sep}WFC3_ecfs{os.sep}'
 


### PR DESCRIPTION
Resolves #339

I thought about setting meta.datetime elsewhere, but I wanted to avoid
setting it multiple times per stage (e.g. once per aperture pair) in
case analyses are being run near midnight

I also renamed the imported package `time` to `time_pkg` as its name
all too often conflicts with a local variable for the observation times