### PR TITLE
Fixing bug with instart and intend for NIRSpec

### DIFF
--- a/eureka/S3_data_reduction/nirspec.py
+++ b/eureka/S3_data_reduction/nirspec.py
@@ -40,8 +40,6 @@ def read(filename, data, meta):
     data.attrs['filename'] = filename
     data.attrs['mhdr'] = hdulist[0].header
     data.attrs['shdr'] = hdulist['SCI', 1].header
-    data.attrs['intstart'] = data.attrs['mhdr']['INTSTART']
-    data.attrs['intend'] = data.attrs['mhdr']['INTEND']
     try:
         data.attrs['intstart'] = data.attrs['mhdr']['INTSTART']
         data.attrs['intend'] = data.attrs['mhdr']['INTEND']


### PR DESCRIPTION
The values are not defined for the simulations, so they should be inside
a try/except which they are, but they were also duplicated outside of
the try/except.

Thanks to Erin May for pointing this out!