### PR TITLE
Fixing bug with code coverage

### DIFF
--- a/.github/workflows/pytest_testing.yml
+++ b/.github/workflows/pytest_testing.yml
@@ -26,7 +26,7 @@ jobs:
           echo "CRDS_PATH=$HOME/crds_cache" >> $GITHUB_ENV
           echo "CRDS_SERVER_URL=https://jwst-crds.stsci.edu" >> $GITHUB_ENV
       - name: Run tests, generate coverage report
-        run: pytest tests --cov=./src/ --cov-report=xml
+        run: pytest tests --cov=./src/eureka --cov-report=xml
       - name: Upload coverage reports to Codecov with GitHub Action
         uses: codecov/codecov-action@v2
         with:

--- a/tests/test_MIRI.py
+++ b/tests/test_MIRI.py
@@ -5,7 +5,7 @@ import os
 from importlib import reload
 import time as time_pkg
 
-sys.path.insert(0, '..'+os.sep)
+sys.path.insert(0, '..'+os.sep+'src'+os.sep)
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import pathdirectory
 import eureka.lib.plots

--- a/tests/test_NIRCam.py
+++ b/tests/test_NIRCam.py
@@ -5,7 +5,7 @@ import os
 from importlib import reload
 import time as time_pkg
 
-sys.path.insert(0, '..'+os.sep)
+sys.path.insert(0, '..'+os.sep+'src'+os.sep)
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import pathdirectory
 import eureka.lib.plots

--- a/tests/test_NIRSpec.py
+++ b/tests/test_NIRSpec.py
@@ -5,7 +5,7 @@ import os
 from importlib import reload
 import time as time_pkg
 
-sys.path.insert(0, '..'+os.sep)
+sys.path.insert(0, '..'+os.sep+'src'+os.sep)
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import pathdirectory
 import eureka.lib.plots

--- a/tests/test_WFC3.py
+++ b/tests/test_WFC3.py
@@ -5,7 +5,7 @@ import os
 from importlib import reload
 import time as time_pkg
 
-sys.path.insert(0, '..'+os.sep)
+sys.path.insert(0, '..'+os.sep+'src'+os.sep)
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import pathdirectory
 import eureka.lib.plots

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -4,7 +4,7 @@ import numpy as np
 import sys
 import os
 
-sys.path.insert(0, '..'+os.sep)
+sys.path.insert(0, '..'+os.sep+'src'+os.sep)
 from eureka.lib import util
 from eureka.lib.readECF import MetaClass
 from eureka.lib.medstddev import medstddev

--- a/tests/test_lightcurve_fitting.py
+++ b/tests/test_lightcurve_fitting.py
@@ -3,7 +3,8 @@ import unittest
 import numpy as np
 import os
 import sys
-sys.path.insert(0, '..'+os.sep)
+
+sys.path.insert(0, '..'+os.sep+'src'+os.sep)
 from eureka.S5_lightcurve_fitting import models, simulations
 from eureka.lib.readEPF import Parameters, Parameter
 from eureka.lib.readECF import MetaClass


### PR DESCRIPTION
I figured out the bug with the code coverage being zero after
Sebastian's PR. pytest was using the installed version of eureka rather
than using the source python files, so the code coverage could not be
tracked. This is now fixed by inserting the path to the source eureka
files at the start of the PATH variable.

Hopefully the codecov bot will comment below in ~10 minutes saying
the test coverage has gone back up to ~60%.