### PR TITLE
Updating jwst package version to 1.6.0

### DIFF
--- a/demos/HST/S3_wfc3_template.ecf
+++ b/demos/HST/S3_wfc3_template.ecf
@@ -18,7 +18,7 @@ flatfile        flats/WFC3.IR.G102.flat.2.fits         # The calibration file to
 # Subarray region of interest
 ywindow         [80,250]    # Vertical axis as seen in DS9
 xwindow         [80,250]    # Horizontal axis as seen in DS9
-src_pos_type    hst         # Determine source position when not given in header (Options: gaussian, weighted, max, or hst)
+src_pos_type    hst         # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Subarray region for direct images used for wavelength calibration
 centroidtrim    5           # The box width to cut around the centroid guess to perform centroiding on the direct images. This should be an integer.

--- a/demos/JWST/S3_miri_lrs_template.ecf
+++ b/demos/JWST/S3_miri_lrs_template.ecf
@@ -10,7 +10,7 @@ suffix          calints     # Data file suffix
 # Subarray region of interest
 ywindow         [150,380]   # Vertical axis as seen in DS9
 xwindow         [7,70]      # Horizontal axis as seen in DS9
-src_pos_type    gaussian    # Determine source position when not given in header (Options: gaussian, weighted, or max)
+src_pos_type    gaussian    # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Background parameters
 bg_hw           8           # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -10,7 +10,7 @@ suffix          calints     # Data file suffix
 # Subarray region of interest
 ywindow         [5,64]      # Vertical axis as seen in DS9
 xwindow         [100,1700]  # Horizontal axis as seen in DS9
-src_pos_type    gaussian    # Determine source position when not given in header (Options: gaussian, weighted, or max)
+src_pos_type    gaussian    # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Background parameters
 bg_hw           8           # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -10,7 +10,7 @@ suffix          calints     # Data file suffix
 # Subarray region of interest
 ywindow         [2,28]      # Vertical axis as seen in DS9
 xwindow         [60,410]    # Horizontal axis as seen in DS9
-src_pos_type    gaussian    # Determine source position when not given in header (Options: gaussian, weighted, or max)
+src_pos_type    gaussian    # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Background parameters
 bg_hw           7           # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/docs/media/S3_template.ecf
+++ b/docs/media/S3_template.ecf
@@ -10,7 +10,7 @@ suffix          calints     # Data file suffix
 # Subarray region of interest
 ywindow         [2,28]      # Vertical axis as seen in DS9
 xwindow         [60,410]    # Horizontal axis as seen in DS9
-src_pos_type    gaussian    # Determine source position when not given in header (Options: gaussian, weighted, or max)
+src_pos_type    gaussian    # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Background parameters
 bg_hw           7           # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -201,7 +201,7 @@ Everything outside of the box will be discarded and not used in the analysis.
 
 src_pos_type
 ''''''''''''
-Determine the source position on the detector when not given in header (Options: gaussian, weighted, max, or hst).
+Determine the source position on the detector. Options: header, gaussian, weighted, max, or hst. The value 'header' uses the value of SRCYPOS in the FITS header.
 
 centroidtrim
 ''''''''''''

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
     - defaults
 dependencies:
     - python==3.9.7
-    - asdf[version='>=2.7.1,<2.11.0'] # Needed for jwst==1.3.3
+    - asdf
     - astropy
     - batman-package
     - bokeh
@@ -33,7 +33,7 @@ dependencies:
         - astraeus @ git+https://github.com/kevin218/Astraeus@main#egg=astraeus
         - crds
         - image_registration @ git+https://github.com/keflavich/image_registration.git@master#egg=image_registration
-        - jwst==1.3.3
+        - jwst==1.6.0
         - myst-parser # Needed for documentation
         - sphinx-rtd-theme # Needed for documentation
         - stcal

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,9 +60,9 @@ where = src
 
 [options.extras_require]
 jwst =
-    jwst==1.3.3
+    jwst==1.6.0
     stcal
-    asdf>=2.7.1,<2.11.0
+    asdf
 hst =
     # Need the GitHub version as 0.2.6 is required for python>=3.10, but 0.2.6 is not yet on PyPI
     image_registration @ git+https://github.com/keflavich/image_registration@master

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ where = src
 [options.extras_require]
 jwst =
     jwst==1.6.0
-    stcal
+    stcal >= 1.0.0 # Needed for our create_integration_model function
     asdf
 hst =
     # Need the GitHub version as 0.2.6 is required for python>=3.10, but 0.2.6 is not yet on PyPI

--- a/src/eureka/S1_detector_processing/ramp_fitting.py
+++ b/src/eureka/S1_detector_processing/ramp_fitting.py
@@ -731,7 +731,7 @@ def create_integration_model(input_model, integ_info):
     int_model : CubeModel
         The output CubeModel to be returned from the ramp fit step.
     """
-    data, dq, var_poisson, var_rnoise, int_times, err = integ_info
+    data, dq, var_poisson, var_rnoise, err = integ_info
     int_model = datamodels.CubeModel(
         data=np.zeros(data.shape, dtype=np.float32),
         dq=np.zeros(data.shape, dtype=np.uint32),
@@ -746,7 +746,6 @@ def create_integration_model(input_model, integ_info):
     int_model.var_poisson = var_poisson
     int_model.var_rnoise = var_rnoise
     int_model.err = err
-    int_model.int_times = int_times
 
     return int_model
 

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -257,8 +257,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
                 # Locate source postion
                 log.writelog('  Locating source position...',
                              mute=(not meta.verbose))
-                meta.src_ypos = source_pos.source_pos(
-                    data, meta, m, header=('SRCYPOS' in data.attrs['shdr']))
+                meta.src_ypos = source_pos.source_pos(data, meta, m)
                 log.writelog(f'    Source position on detector is row '
                              f'{meta.src_ypos}.', mute=(not meta.verbose))
 

--- a/src/eureka/S3_data_reduction/source_pos.py
+++ b/src/eureka/S3_data_reduction/source_pos.py
@@ -5,7 +5,7 @@ from scipy.optimize import curve_fit
 from . import plots_s3
 
 
-def source_pos(data, meta, m, header=False):
+def source_pos(data, meta, m):
     '''Make image+background plot.
 
     Parameters
@@ -16,16 +16,17 @@ def source_pos(data, meta, m, header=False):
         The metadata object.
     m : int
         The file number.
-    header : bool; optional
-        If True, use the source position in the FITS header.
-        Defaults to False.
 
     Returns
     -------
     src_ypos : int
         The central position of the star.
     '''
-    if header:
+    if meta.src_pos_type == 'header':
+        if 'SRCYPOS' not in data.attrs['shdr']:
+            raise AttributeError('There is no SRCYPOS in the FITS header. '
+                                 'You must select a different value for '
+                                 'meta.src_pos_type')
         src_ypos = data.attrs['shdr']['SRCYPOS'] - meta.ywindow[0]
     elif meta.src_pos_type == 'weighted':
         # find the source location using a flux-weighted mean approach

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -103,8 +103,7 @@ def get_reference_frames(meta, log):
         # Need to add guess after trimming and before cut_aperture
         meta.guess.append(data.guess)
         data, meta = b2f.convert_to_e(data, meta, log)
-        meta.src_ypos = source_pos.source_pos(
-            data, meta, i, header=('SRCYPOS' in data.attrs['shdr']))
+        meta.src_ypos = source_pos.source_pos(data, meta, i)
         data['mask'] = (['time', 'y', 'x'],
                         np.ones(data.flux.shape, dtype=bool))
         data['mask'] = util.check_nans(data['flux'], data['mask'],

--- a/tests/MIRI_ecfs/S3_MIRI.ecf
+++ b/tests/MIRI_ecfs/S3_MIRI.ecf
@@ -8,14 +8,13 @@ suffix		calints     # Data file suffix
 # Subarray region of interest
 ywindow     [155, 385]	# Vertical axis as seen in DS9
 xwindow     [13,64]		# Horizontal axis as seen in DS9
-src_pos_type gaussian   # Determine source position when not given in header (Options: gaussian, weighted, or max)
+src_pos_type gaussian   # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Background parameters
 bg_hw       4           # Half-width of exclusion region for BG subtraction (relative to source position)
 bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
-save_bgsub  True        # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     2           # Half-width of aperture region for spectral extraction (relative to source position)

--- a/tests/NIRCam_ecfs/S3_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S3_NIRCam.ecf
@@ -26,7 +26,7 @@ p5thresh    10          # X-sigma threshold for outlier rejection while construc
 p7thresh    10          # X-sigma threshold for outlier rejection during optimal spectral extraction
 
 # Diagnostics
-isplots_S3  5           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+isplots_S3  3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
 testing_S3  True        # Boolean, set True to only use last file and generate select figures
 hide_plots  True        # If True, plots will automatically be closed rather than popping up
 save_output True        # Save outputs for use in S4

--- a/tests/NIRCam_ecfs/S3_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S3_NIRCam.ecf
@@ -8,14 +8,13 @@ suffix      calints     # Data file suffix
 # Subarray region of interest
 ywindow     [5,64]      # Vertical axis as seen in DS9
 xwindow     [100,1700]  # Horizontal axis as seen in DS9
-src_pos_type gaussian   # Determine source position when not given in header (Options: gaussian, weighted, or max)
+src_pos_type gaussian   # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Background parameters
 bg_hw       20          # Half-width of exclusion region for BG subtraction (relative to source position)
 bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
-save_bgsub  False      # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     20			# Half-width of aperture region for spectral extraction (relative to source position)

--- a/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
+++ b/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
@@ -8,14 +8,13 @@ suffix      calints     # Data file suffix
 # Subarray region of interest
 ywindow     [0,31]      # Vertical axis as seen in DS9
 xwindow     [65,400]    # Horizontal axis as seen in DS9
-src_pos_type gaussian   # Determine source position when not given in header (Options: gaussian, weighted, or max)
+src_pos_type gaussian   # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Background parameters
 bg_hw       10         # Half-width of exclusion region for BG subtraction (relative to source position)
 bg_thresh   [15,15]    # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      0          # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    2          # X-sigma threshold for outlier rejection during background subtraction
-save_bgsub  False      # Whether or not to save background subtracted FITS files
 
 # Spectral extraction parameters
 spec_hw     8          # Half-width of aperture region for spectral extraction (relative to source position)

--- a/tests/WFC3_ecfs/S3_WFC3.ecf
+++ b/tests/WFC3_ecfs/S3_WFC3.ecf
@@ -16,7 +16,7 @@ flatfile        WFC3.IR.G102.flat.2.fits               # The calibration file to
 # Subarray region of interest
 ywindow         [80,250]    # Vertical axis as seen in DS9
 xwindow         [80,250]    # Horizontal axis as seen in DS9
-src_pos_type    hst         # Determine source position when not given in header (Options: gaussian, weighted, max, or hst)
+src_pos_type    hst         # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 
 # Subarray region for direct images used for wavelength calibration
 centroidtrim    5

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,5 +3,5 @@
 import os
 # VS Code runs tests from the root directory, so need to chdir into
 # the tests directory
-if os.getcwd().split(os.sep)[-1] == "Eureka":
+if os.getcwd().split(os.sep)[-1] != "tests":
     os.chdir('tests')


### PR DESCRIPTION
This PR updates the `jwst` package version from 1.3.3 to the latest 1.6.0 (resolves #335). In addition, for newer versions of `jwst` than 1.3.3 we don't need to specify an `asdf` version number (that was just a bug with `jwst` 1.3.3), so I removed that version number.

The main reason we couldn't do this before is that newer versions of the `jwst` pipeline broke for the NIRSpec simulations (see Issue #165). I found that this could be quickly resolved by allowing the value in the FITS header to be overridden using the source_pos function which already exists. Previously, if the FITS header had a SRCYPOS value, you had to use it, but now that behaviour is only the case if `meta.source_pos_type='header'`. Moving forward, I think if we want to use the SRCYPOS value with subarray observations it's possible we might need to account for the subarray offset, but I'm not sure if that's the case or if this is just an artifact from the simulated data. I'll note this in Issue #165 for now, and if we don't see this SRCYPOS issue with `meta.source_pos_type='header'` for real data then we can close that issue, or if we do see this issue then we can look into things like subarray offsets.

I have confirmed that all the tests pass now, but we should check S1-3 offline for the full MIRI, NIRCam, and NIRSpec simulations to make sure that they all still work correctly.