### PR TITLE
Fixing overly RAM intensive S3 NaN masking

### DIFF
--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -302,16 +302,19 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
                 # Check if arrays have NaNs
                 log.writelog('  Masking NaNs in data arrays...',
                              mute=(not meta.verbose))
-                data['mask'] = util.check_nans(data['flux'], data['mask'],
-                                               log, name='FLUX')
-                data['mask'] = util.check_nans(data['err'], data['mask'],
-                                               log, name='ERR')
-                data['mask'] = util.check_nans(data['v0'], data['mask'],
-                                               log, name='V0')
+                data.mask.values = util.check_nans(data.flux.values,
+                                                   data.mask.values,
+                                                   log, name='FLUX')
+                data.mask.values = util.check_nans(data.err.values,
+                                                   data.mask.values,
+                                                   log, name='ERR')
+                data.mask.values = util.check_nans(data.v0.values,
+                                                   data.mask.values,
+                                                   log, name='V0')
 
                 # Manually mask regions [colstart, colend, rowstart, rowend]
                 if hasattr(meta, 'manmask'):
-                    util.manmask(data, meta, log)
+                    data = util.manmask(data, meta, log)
 
                 # Perform outlier rejection of sky background along time axis
                 data = inst.flag_bg(data, meta, log)

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -96,7 +96,7 @@ def check_nans(data, mask, log, name=''):
     mask : ndarray
         Output mask where 0 will be written where the input data array has NaNs
     """
-    num_nans = np.sum(np.isnan(data.values))
+    num_nans = np.sum(np.isnan(data))
     if num_nans > 0:
         log.writelog(f"  WARNING: {name} has {num_nans} NaNs. Your subregion "
                      f"may be off the edge of the detector subarray.\n"


### PR DESCRIPTION
Need to do masking on numpy arrays rather than xarrays to avoid extreme
RAM usage