### PR TITLE
Fixing time arrays for real data

### DIFF
--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -68,8 +68,7 @@ def read(filename, data, meta, log):
         wave_2d = np.tile(wave_MIRI_hardcoded(), (sci.shape[2], 1))[:, ::-1]
     else:
         wave_2d = hdulist['WAVELENGTH', 1].data
-    int_times = hdulist['INT_TIMES', 1].data[data.attrs['intstart']:
-                                             data.attrs['intend']]
+    int_times = hdulist['INT_TIMES', 1].data
 
     # Record integration mid-times in BJD_TDB
     if (hasattr(meta, 'time_file') and meta.time_file is not None):

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -56,8 +56,7 @@ def read(filename, data, meta, log):
     dq = hdulist['DQ', 1].data
     v0 = hdulist['VAR_RNOISE', 1].data
     wave_2d = hdulist['WAVELENGTH', 1].data
-    int_times = hdulist['INT_TIMES', 1].data[data.attrs['intstart']:
-                                             data.attrs['intend']]
+    int_times = hdulist['INT_TIMES', 1].data
 
     # Record integration mid-times in BJD_TDB
     if (hasattr(meta, 'time_file') and meta.time_file is not None):

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -63,6 +63,10 @@ def read(filename, data, meta, log):
         time = read_time(meta, data, log)
     else:
         time = int_times['int_mid_BJD_TDB']
+        if len(time) > len(sci):
+            # This line is needed to still handle the simulated data
+            # which had the full time array for all segments
+            time = time[data.attrs['intstart']:data.attrs['intend']]
 
     # Record units
     flux_units = data.attrs['shdr']['BUNIT']

--- a/src/eureka/S3_data_reduction/nirspec.py
+++ b/src/eureka/S3_data_reduction/nirspec.py
@@ -60,8 +60,7 @@ def read(filename, data, meta, log):
     dq = hdulist['DQ', 1].data
     v0 = hdulist['VAR_RNOISE', 1].data
     wave_2d = hdulist['WAVELENGTH', 1].data
-    int_times = hdulist['INT_TIMES', 1].data[data.attrs['intstart']:
-                                             data.attrs['intend']]
+    int_times = hdulist['INT_TIMES', 1].data
 
     # Record integration mid-times in BJD_TDB
     if (hasattr(meta, 'time_file') and meta.time_file is not None):


### PR DESCRIPTION
We incorrectly guessed that each segment would have the whole time
array. Each segment only has the time values for that segment, so no
need to crop the arrays