### PR TITLE
More useful error message if no FITS files found

### DIFF
--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -70,11 +70,7 @@ def rampfitJWST(eventlabel, ecf_path=None):
     meta.copy_ecf()
 
     # Create list of file segments
-    meta = util.readfiles(meta)
-    meta.num_data_files = len(meta.segment_list)
-
-    log.writelog(f'\nFound {meta.num_data_files} data file(s) ending in ' +
-                 f'{meta.suffix}.fits')
+    meta = util.readfiles(meta, log)
 
     # If testing, only run the last file
     if meta.testing_S1:

--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -98,17 +98,7 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None):
     meta.copy_ecf()
 
     # Create list of file segments
-    meta = util.readfiles(meta)
-    meta.num_data_files = len(meta.segment_list)
-    if meta.num_data_files == 0:
-        raise AssertionError(f'Unable to find any "{meta.suffix}.fits" files '
-                             f'in the inputdir: \n"{meta.inputdir}"!\n'
-                             f'You likely need to change the inputdir in '
-                             f'{meta.filename} to point to the folder '
-                             f'containing the "{meta.suffix}.fits" files.')
-    else:
-        log.writelog(f'\nFound {meta.num_data_files} data file(s) ending in '
-                     f'{meta.suffix}.fits')
+    meta = util.readfiles(meta, log)
 
     # If testing, only run the last file
     if meta.testing_S2:

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -153,19 +153,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
             meta.copy_ecf()
 
             # Create list of file segments
-            meta = util.readfiles(meta)
-            meta.num_data_files = len(meta.segment_list)
-            if meta.num_data_files == 0:
-                log.writelog(f'Unable to find any "{meta.suffix}.fits" files '
-                             f'in the inputdir: \n"{meta.inputdir}"!',
-                             mute=True)
-                raise AssertionError(f'Unable to find any "{meta.suffix}.fits"'
-                                     f' files in the inputdir: \n'
-                                     f'"{meta.inputdir}"!')
-            else:
-                log.writelog(f'\nFound {meta.num_data_files} data file(s) '
-                             f'ending in {meta.suffix}.fits',
-                             mute=(not meta.verbose))
+            meta = util.readfiles(meta, log)
 
             # Load instrument module
             if meta.inst == 'miri':

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -52,9 +52,10 @@ def readfiles(meta, log):
                              f'{meta.filename} to point to the folder '
                              f'containing the "{meta.suffix}.fits" files.')
     else:
+        mute = hasattr(meta, 'verbose') and not meta.verbose
         log.writelog(f'\nFound {meta.num_data_files} data file(s) '
                      f'ending in {meta.suffix}.fits',
-                     mute=(not meta.verbose))
+                     mute=mute)
 
         with fits.open(meta.segment_list[-1]) as hdulist:
             # Figure out which instrument we are using


### PR DESCRIPTION
Because of an update I made to util.readfiles, an unhelpful error
message would be raised if no files were found. This patch reduces
duplicated code between S1-3 and raises a better message if no
files are found