### PR TITLE
Fixing MIRI gain file

### DIFF
--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -129,8 +129,8 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None):
             # wavelength range that you want to trim to.
             jwst.assign_wcs.nirspec.nrs_wcs_set_input = \
                 partial(jwst.assign_wcs.nirspec.nrs_wcs_set_input, 
-                    wavelength_range=[meta.waverange_start,
-                                        meta.waverange_end])
+                        wavelength_range=[meta.waverange_start,
+                                          meta.waverange_end])
     elif telescope == 'HST':
         log.writelog('There is no Stage 2 for HST - skipping.')
         # Clean up temporary folder

--- a/src/eureka/S3_data_reduction/bright2flux.py
+++ b/src/eureka/S3_data_reduction/bright2flux.py
@@ -91,7 +91,8 @@ def dn2electrons(data, meta):
     ystart_trim = ystart-ystart_gain + 1  # 1 indexed, NOT zero                                                         
     xstart_trim = xstart-xstart_gain + 1
 
-    gain = fits.getdata(meta.gainfile)[ystart_trim:ystart_trim+ny, xstart_trim:xstart_trim+nx]
+    gain = fits.getdata(meta.gainfile)[ystart_trim:ystart_trim+ny,
+                                       xstart_trim:xstart_trim+nx]
 
     # Like in the case of MIRI data, the gain file data has to be
     # rotated by 90 degrees

--- a/src/eureka/S3_data_reduction/bright2flux.py
+++ b/src/eureka/S3_data_reduction/bright2flux.py
@@ -94,10 +94,11 @@ def dn2electrons(data, meta):
     gain = fits.getdata(meta.gainfile)[ystart_trim:ystart_trim+ny,
                                        xstart_trim:xstart_trim+nx]
 
-    # Like in the case of MIRI data, the gain file data has to be
-    # rotated by 90 degrees
     if data.attrs['shdr']['DISPAXIS'] == 2:
-        gain = np.swapaxes(gain, 0, 1)
+        # In the case of MIRI data, the gain file data has to be
+        # rotated by 90 degrees and mirrored along that new x-axis
+        # so that wavelength increases to the right
+        gain = np.swapaxes(gain, 0, 1)[:, ::-1]
 
     # Gain subarray
     subgain = gain[meta.ywindow[0]:meta.ywindow[1],


### PR DESCRIPTION
I realized that the MIRI gain file was being rotated 90 degrees like the data, but was not then being mirrored along the new x-axis to have wavelength increasing to the right like the data array. While I was at it, I fixed the two minor flake8 issues that were recently introduced