### PR TITLE
Tweaking S5 EPF template to use scatter_mult

### DIFF
--- a/demos/JWST/S5_fit_par_template.epf
+++ b/demos/JWST/S5_fit_par_template.epf
@@ -56,5 +56,4 @@ c1           0              'free'         0            0.01          N
 # Use scatter_ppm to fit the noise level in ppm
 # Use WN parameter in GP model parameters to account for white noise in the GP model
 # -----------
-#scatter_mult 1.1            'free'         1            0.1          N
-scatter_ppm  500            'free'         500          100          N
+scatter_mult 1.1            'free'         1.1            1          N

--- a/docs/media/S5_fit_par_template.epf
+++ b/docs/media/S5_fit_par_template.epf
@@ -56,5 +56,4 @@ c1           0              'free'         0            0.01          N
 # Use scatter_ppm to fit the noise level in ppm
 # Use WN parameter in GP model parameters to account for white noise in the GP model
 # -----------
-#scatter_mult 1.1            'free'         1            0.1          N
-scatter_ppm  500            'free'         500          100          N
+scatter_mult 1.1            'free'         1.1            1          N


### PR DESCRIPTION
Previously the EPF template used scatter_ppm because there was a bug
the estimated noise from S4, but that has since been fixed, and users
should use scatter_mult instead as it is far more robust and less prone
to user error.