### PR TITLE
M1 installation instructions and quickstart typo

### DIFF
--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -30,7 +30,7 @@ boundary        'fill'  # Use 'fill' to extend the boundary values by the median
 fill_value      mask    # Either the string 'mask' to mask the outlier values (recommended), 'boxcar' to replace data with the mean from the box-car filter, or a constant float-type fill value.
 
 # Limb-darkening parameters needed to compute exotic-ld
-compute_ld      True
+compute_ld      False
 inst_filter     Prism #filter of JWST/HST instrument, supported list see https://exotic-ld.readthedocs.io/en/latest/views/supported_instruments.html 
 metallicity     0.1 #metallicity of the star 
 teff            6000 #effective temperature of the star in K

--- a/demos/JWST/S5_template.ecf
+++ b/demos/JWST/S5_template.ecf
@@ -12,11 +12,8 @@ fit_method      [dynesty]               #options are: lsq, emcee, dynesty (can l
 run_myfuncs     [batman_tr,polynomial]  #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, polynomial, step, and GP (can list multiple types separated by commas)
 
 # Limb darkening controls
-use_generate_ld  exotic-ld #use the generated limb-darkening coefficients from Stage 4? Options: exotic-ld, None
+use_generate_ld  None #use the generated limb-darkening coefficients from Stage 4? Options: exotic-ld, None
 #important: limb-darkening coefficients are not automatically fixed then, change to 'fixed' in .epf file whether they should be fixed or fitted! The limb-darkening laws available are linear, quadratic, 3-parameter and 4-parameter non-linear.
-#(not yet implemented)
-#fix_ld          True #use limb darkening file?
-#ld_file         /path/to/limbdarkening/ld_outputfile.txt  #location of limb darkening file
 
 # General fitter
 old_fitparams   None # filename relative to topdir that points to a fitparams csv to resume where you left off (set to None to start from scratch)

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -22,6 +22,13 @@ If you are following the installation instructions and still encounter an error,
 `GitHub Issues <https://github.com/kevin218/Eureka/issues>`__ and paste the full error message you are getting along
 with details about which python version and operating system you are using.
 
+Installation issues with M1 processors
+''''''''''''''''''''''''''''''''''''''
+
+Note that if you are using a macOS device with an M1 processor, you will need to use the ``conda`` environment.yml file
+installation instructions as we have had reports that the pip dependencies fail to build on the M1 processor.
+
+
 Issues installing or importing batman
 '''''''''''''''''''''''''''''''''''''
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,6 +8,8 @@ Installation methods
 In order to have consistent, repeatable results across the ``Eureka!`` user community, we recommend that all general users install
 the most recent stable release of ``Eureka!``, v0.3. The following installation instructions are written with this in mind,
 and the most recent stable release is also available as a zipped archive `here <https://github.com/kevin218/Eureka/releases/tag/v0.3>`_.
+Also note that if you are using a macOS device with an M1 processor, you will need to use the ``conda`` environment.yml file
+installation instructions below as the pip dependencies fail to build on the M1 processor.
 
 
 Initial environment preparation

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -110,7 +110,7 @@ To speed up the Stage 5 dynesty fit, you can also reduce the number of live poin
 	ndim * (ndim + 1) / 2
 
 and our fit presently has ndim=10 free values in the EPF, so that means a bare minimum of 55 live points. As a compromise, let's use 256 live points instead to
-get a fairly nice corner plot but also speed up the fit, so set the following in ``S5_fit_par_wasp39b.epf``:
+get a fairly nice corner plot but also speed up the fit, so set the following in ``S5_wasp39b.ecf``:
 
 .. code-block:: bash
 	

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -96,7 +96,17 @@ However, for the later stages you can use something simpler, e.g. for the ``S3_w
 	inputdir	/Stage2
 	outputdir	/Stage3
 
-The explicit settings for the ``S4_wasp39b.ecf``, ``S5_wasp39b.ecf`` and ``S6_wasp39b.ecf`` will be skipped here for brevity (but you should still do them!). However, it is important to notice a few settings in the ``S5_wasp39b.ecf``. Specifically, you need to assign the correct ``.epf`` file, and modify the number of processors you want to use during the light curve fitting.
+The explicit settings for the ``S4_wasp39b.ecf``, ``S5_wasp39b.ecf`` and ``S6_wasp39b.ecf`` will be skipped here for brevity (but you should still do them!). However, there are a few important settings we must adjust.
+
+First, you must decide if you want to freely fit for your limb-darkening parameters in Stage 5 or if you want to fix them to model predictions made using the ``exotic-ld`` package. If you want to fit
+for limb-darkening, you can simply use the template files as they currently are. However, if you want to use ``exotic-ld``, you must download the ``exotic-ld`` `ancillary files <https://zenodo.org/record/6344946>_`
+and change the ``exotic_ld_direc`` in the ``S4_wasp39b.ecf`` file to point to the location you saved those ancillary files. You also need to set ``compute_ld`` to True. In general, you must also
+update the stellar parameters for your target, but these have already been set for WASP-39. You will also need to adjust your ``S5_fit_par_template.epf`` limb-darkening parameters to use the
+limb-darkening law you want to use (note that not all laws are supported by exotic-ld), and you will also need to change your limb-darkening parameters to be fixed instead of free if you don't
+want to fit them. Finally, you will also need to set the ``use_generate_ld`` parameter to ``exotic-ld`` in your ``S5_wasp39b.ecf`` file.
+
+
+Also, it is important to notice a few settings in the ``S5_wasp39b.ecf``. Specifically, you need to assign the correct ``.epf`` file, and modify the number of processors you want to use during the light curve fitting.
 
 .. code-block:: bash
 	


### PR DESCRIPTION
Noting to use environment.yml on M1 processors: resolves #415 and resolves #421

Fixing small typo in quickstart: resolves #422