### PR TITLE
Bug fix for bug #436, plus smoothing trace option for G395 

### DIFF
--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -29,6 +29,7 @@ p7thresh        60          # X-sigma threshold for outlier rejection during opt
 
 # G395H curvature treatment
 curvature       None        # How to manage the curved trace on the detector (Options: None, correct). Use correct for NIRSpec/G395.
+smooth_trace    False       # Force a smooth trace
 
 # Diagnostics
 isplots_S3      3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -312,6 +312,10 @@ curvature
 '''''''''
 Current options: 'None', 'correct'. Using 'None' will not use any curvature correction and is strongly recommended against for instruments with strong curvature like NIRSpec/G395. Using 'correct' will bring the center of mass of each column to the center of the detector and perform the extraction on this straightened trace. If using 'correct', you should also be using fittype = 'meddata'.
 
+smooth_trace
+'''''''''
+Forces the trace found to be smoother, so the central location in one column cannot be too far off from the central location in an adjacent column.
+
 isplots_S3
 ''''''''''
 Sets how many plots should be saved when running Stage 3. A full description of these outputs is available here: :ref:`Stage 3 Output <s3-out>`

--- a/src/eureka/S3_data_reduction/source_pos.py
+++ b/src/eureka/S3_data_reduction/source_pos.py
@@ -346,10 +346,20 @@ def source_pos_gauss(flux, meta, m, n=0, plot=True):
 
     # Data cutout around the maximum row
     pos_max = source_pos_max(flux, meta, m, n=n, plot=False)
-    y_pixels = np.arange(0, x_dim)[pos_max-meta.spec_hw:pos_max+meta.spec_hw]
-    sum_row = np.ma.sum(flux, axis=1)[pos_max-meta.spec_hw:
-                                      pos_max+meta.spec_hw]
-
+        
+    source_min=pos_max-meta.spec_hw
+    source_max=pos_max+meta.spec_hw
+    
+    #check and ensure that the source range is within the ywindow
+    if source_min<meta.ywindow[0]:
+        source_min=meta.ywindow[0]
+    elif source_min<0:
+        source_min=0
+    if source_max>meta.ywindow[1]:
+        source_max=meta.ywindow[1]
+    y_pixels = np.arange(0, x_dim)[source_min:source_max]
+    sum_row = np.ma.sum(flux, axis=1)[source_min:source_max]
+    
     # Initial Guesses
     sigma0 = np.ma.sqrt(np.ma.sum(sum_row*(y_pixels-pos_max)**2) /
                         np.ma.sum(sum_row))

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -24,9 +24,25 @@ def find_column_median_shifts(data):
     # define an array of pixel positions (in their centers)
     pix_centers = np.arange(nb_rows) + 0.5
 
-    # Compute the center of mass of each column and convert to integer (pixels)
+    # Compute the center of mass of each column
     column_coms = (np.sum(pix_centers[:, None]*data, axis=0) /
                    np.sum(data, axis=0))
+    
+    #check if column_coms is smooth
+    coms=column_coms.flatten()
+    grad=np.gradient(coms)
+    badpix_f=np.where(np.abs(grad)>np.std(grad))
+    badpix_f=badpix_f[0]
+    for bp_l in badpix_f:
+        if (bp_l+2) in badpix_f:           
+            bp=bp_l+1
+            if (bp_l+3) not in badpix_f and (bp_l-1) not in badpix_f:
+                column_coms[bp,]=(coms[bp_l]+coms[bp_l+2])/2.
+            else:
+                column_coms[bp,]=(coms[bp_l-1]+coms[bp_l+3])/2.    
+
+    
+    #convert com to integers (pixels)
     column_coms = np.around(column_coms).astype(int)
 
     # define the new center (where we will align the trace) in the 

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+from scipy import interpolate
 
 def find_column_median_shifts(data, meta, log):
     '''Takes the median frame (in time) and finds the 
@@ -30,22 +30,14 @@ def find_column_median_shifts(data, meta, log):
     
     if meta.smooth_trace:
         log.writelog('  Smoothing the trace... ',
-                     mute=(not meta.verbose))        
+                     mute=(not meta.verbose)) 
         #check if column_coms is smooth
-        coms=column_coms.flatten()
-        grad=np.gradient(coms)
-        grad=grad-np.mean(grad)
-        badpix_f=np.where(np.abs(grad)>(2*np.std(grad)))
-        badpix_f=badpix_f[0]
-        for bp_l in badpix_f:
-            if (bp_l+2) in badpix_f:           
-                bp=bp_l+1
-                if (bp_l+3) not in badpix_f and (bp_l-1) not in badpix_f:
-                    column_coms[bp,]=(coms[bp_l]+coms[bp_l+2])/2.
-                else:
-                    column_coms[bp,]=(coms[bp_l-1]+coms[bp_l+3])/2.    
+        l=column_coms.shape[0]
+        xs=np.arange(l)
+        spline_func=interpolate.splrep(xs,column_coms,s=10000)
+        column_coms0=interpolate.splev(xs,spline_func)
+        column_coms=np.array(column_coms0).reshape((l,))
 
-    
     #convert com to integers (pixels)
     column_coms = np.around(column_coms).astype(int)
 


### PR DESCRIPTION
This is based on working with the G395H data.

The bug fix for bug #436 is confined to source_pos.py

The remaining edits are to force a smooth trace using a spline.  Currently, a hot pixel may result in the wrong center of mass when straightening the spectrum.  This is a robust way to avoid that.  

The below files are cuts taken from two versions of the flux files from S3.

Without the smooth trace:
![image](https://user-images.githubusercontent.com/12980648/182451940-46b76a92-5a5d-4b4b-b0c5-ad4267afd0a9.png)

With the smooth trace:
![image](https://user-images.githubusercontent.com/12980648/182452237-b4ecdc76-c8e6-4de1-945b-86000529a31f.png)
