### PR TITLE
fix manual clip bug in S5

### DIFF
--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -135,7 +135,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
 
             if hasattr(meta, 'manual_clip') and meta.manual_clip is not None:
                 # Remove requested data points
-                util.manual_clip(lc, meta, log)
+                meta, lc, log = util.manual_clip(lc, meta, log)
 
             # Subtract off the user provided time value to avoid floating
             # point precision problems when fitting for values like t0


### PR DESCRIPTION
this PR fixes a bug in S5 for manually clipping data points. The lc and meta arrays are now updated when the manual_clip function is called in s5_fit.py