### PR TITLE
Handling S3 NaN wavelengths

### DIFF
--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -262,10 +262,6 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
                 # Dataset object no longer contains untrimmed data
                 data, meta = util.trim(data, meta)
 
-                # Check for bad wavelength pixels (beyond wavelength solution)
-                util.check_nans(data.wave_1d.values, np.ones(meta.nx), log,
-                                name='wavelength')
-
                 # Create bad pixel mask (1 = good, 0 = bad)
                 data['mask'] = (['time', 'y', 'x'],
                                 np.ones(data.flux.shape, dtype=bool))
@@ -306,6 +302,10 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
                                        data.wave_2d[meta.src_ypos].values)
                     data['wave_1d'].attrs['wave_units'] = \
                         data.wave_2d.attrs['wave_units']
+                
+                # Check for bad wavelength pixels (beyond wavelength solution)
+                util.check_nans(data.wave_1d.values, np.ones(meta.subnx), log,
+                                name='wavelength')
 
                 # Convert flux units to electrons
                 # (eg. MJy/sr -> DN -> Electrons)

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -262,6 +262,10 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
                 # Dataset object no longer contains untrimmed data
                 data, meta = util.trim(data, meta)
 
+                # Check for bad wavelength pixels (beyond wavelength solution)
+                util.check_nans(data.wave_1d.values, np.ones(meta.nx), log,
+                                name='wavelength')
+
                 # Create bad pixel mask (1 = good, 0 = bad)
                 data['mask'] = (['time', 'y', 'x'],
                                 np.ones(data.flux.shape, dtype=bool))

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -159,13 +159,19 @@ def check_nans(data, mask, log, name=''):
         or infs.
     """
     data = np.ma.masked_where(mask == 0, np.copy(data))
-    num_nans = np.sum(np.ma.masked_invalid(data).mask)
+    masked = np.ma.masked_invalid(data).mask
+    inan = np.where(masked)
+    num_nans = np.sum(masked)
     num_pixels = np.size(data)
     perc_nans = 100*num_nans/num_pixels
-    if num_nans > 0:
+    if num_nans > 0 and name == 'wavelength':
+        log.writelog(f"  WARNING: Your {name} array has {num_nans} NaNs, which"
+                     f" are outside of the wavelength solution. You should "
+                     f"consider removing indices {inan} as their data quality "
+                     f"may be poor.")
+    elif num_nans > 0:
         log.writelog(f"  {name} has {num_nans} NaNs/infs, which is "
                      f"{perc_nans:.2f}% of all pixels.")
-        inan = np.where(np.ma.masked_invalid(data).mask)
         mask[inan] = 0
     if perc_nans > 10:
         log.writelog("  WARNING: Your region of interest may be off the edge "


### PR DESCRIPTION
Resolves #457

This PR adds a warning to users that they're using pixels that do not have a wavelength solution. This also adds an extrapolation to the NaN wavelengths for Figure 3101 just for plotting purposes. I found that a cubic spline was able to perfectly predict the wavelength solution of two wavelengths artificially set to NaN for MIRI data.