### PR TITLE
Minor convenience improvements

### DIFF
--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -367,7 +367,7 @@ Sets how many plots should be saved when running Stage 3. A full description of 
 
 nplots
 ''''''
-Sets how many integrations will be used for per-integration figures (Figs 3301, 3302, 3303, 3501). Useful for in-depth diagnoses of a few integrations without making thousands of figures. If set to None, a plot will be made for every integration.
+Sets how many integrations will be used for per-integration figures (Figs 3301, 3302, 3303, 3307, 3501, 3505). Useful for in-depth diagnoses of a few integrations without making thousands of figures. If set to None, a plot will be made for every integration.
 
 vmin
 ''''

--- a/src/eureka/S1_detector_processing/ramp_fitting.py
+++ b/src/eureka/S1_detector_processing/ramp_fitting.py
@@ -296,7 +296,7 @@ def custom_power(snr, snr_bounds, exponents):
 
 def calc_opt_sums_uniform_weight(rn_sect, gain_sect, data_masked, mask_2d,
                                  xvalues, good_pix):
-    """Adjusted version of the calc_opt_sums() function from stcal ramp fitting.
+    """Adjusted version of calc_opt_sums() function from stcal ramp fitting.
 
     Now weights are all equal to 1, except for those that correspond to NaN or
     inf's in the inverse read noise^2 arrays.

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -107,7 +107,7 @@ def rampfitJWST(eventlabel, ecf_path=None):
 
 
 class EurekaS1Pipeline(Detector1Pipeline):
-    '''A wrapper class for the jwst.pipeline.calwebb_detector1.Detector1Pipeline
+    '''A wrapper class for jwst.pipeline.calwebb_detector1.Detector1Pipeline
 
     This wrapper class allows non-standard changes to Stage 1 for Eureka!.
 

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -66,9 +66,18 @@ def read(filename, data, meta, log):
 
     meta.photometry = False  # Photometry for MIRI not implemented yet.
 
-    # If wavelengths are all zero --> use jwst to get wavelengths
+    # If wavelengths are all zero or missing --> use jwst to get wavelengths
     # Otherwise use the wavelength array from the header
-    if np.all(hdulist['WAVELENGTH', 1].data == 0):
+    try:
+        hdulist['WAVELENGTH', 1]
+        wl_missing = False
+    except:
+        if meta.firstFile:
+            log.writelog('  WAVELENGTH extension not found, using '
+                         'miri.wave_MIRI_jwst function instead.')
+        wl_missing = True
+
+    if wl_missing or np.all(hdulist['WAVELENGTH', 1].data == 0):
         wave_2d = wave_MIRI_jwst(filename, meta, log)
     else:
         wave_2d = hdulist['WAVELENGTH', 1].data

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -315,7 +315,8 @@ def do_oneoverf_corr(data, meta, i, star_pos_x, log):
     data : Xarray Dataset
         The updated Dataset object after the 1/f correction has been completed.
     """
-    print('Correcting for 1/f noise...')
+    if i == 0:
+        log.writelog('Correcting for 1/f noise...', mute=(not meta.verbose))
 
     # Let's first determine which amplifier regions are left in the frame.
     # For NIRCam: 4 amplifiers, 512 pixels in x dimension per amplifier

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -75,12 +75,16 @@ def read(filename, data, meta, log):
         # FINDME: make this better for all filters
         if hdulist[0].header['FILTER'] == 'F210M':
             # will be deleted at the end of S3
-            wave_1d = np.ones_like(sci[0, 0]) * 2.1
+            wave_1d = np.ones_like(sci[0, 0]) * 2.095
             # Is used in S4 for plotting.
-            meta.phot_wave = 2.1
+            meta.phot_wave = 2.095
         elif hdulist[0].header['FILTER'] == 'F187N':
-            wave_1d = np.ones_like(sci[0, 0]) * 1.87
-            meta.phot_wave = 1.87
+            wave_1d = np.ones_like(sci[0, 0]) * 1.874
+            meta.phot_wave = 1.874
+        elif (hdulist[0].header['FILTER'] == 'WLP4'
+              or hdulist[0].header['FILTER'] == 'F212N'):
+            wave_1d = np.ones_like(sci[0, 0]) * 2.121
+            meta.phot_wave = 2.121
 
     # Record integration mid-times in BMJD_TDB
     if (hasattr(meta, 'time_file') and meta.time_file is not None):

--- a/src/eureka/S3_data_reduction/optspex.py
+++ b/src/eureka/S3_data_reduction/optspex.py
@@ -390,7 +390,7 @@ def profile_wavelet2D(subdata, mask, wavelet, numlvls, isplots=0):
 
 
 def profile_gauss(subdata, mask, threshold=10, guess=None, isplots=0):
-    '''Construct normalized spatial profile using a Gaussian smoothing function.
+    '''Construct normalized spatial profile using Gaussian smoothing function.
 
     Parameters
     ----------

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -419,7 +419,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
                             data = \
                                 inst.do_oneoverf_corr(data, meta, i,
                                                       position[1], log)
-                            if meta.isplots_S3 >= 3:
+                            if meta.isplots_S3 >= 3 and i < meta.nplots:
                                 plots_s3.phot_2d_frame_oneoverf(
                                     data, meta, m, i, flux_w_oneoverf)
 
@@ -442,7 +442,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None):
                         data['centroid_y'][i], data['centroid_x'][i] = position
                         data['centroid_sy'][i], data['centroid_sx'][i] = extra
                         # Plot 2D frame, the centroid and the centroid position
-                        if meta.isplots_S3 >= 3:
+                        if meta.isplots_S3 >= 3 and i < meta.nplots:
                             plots_s3.phot_2d_frame(data, meta, m, i)
 
                         # Interpolate masked pixels before we perform

--- a/src/eureka/S3_data_reduction/sigrej.py
+++ b/src/eureka/S3_data_reduction/sigrej.py
@@ -140,7 +140,7 @@ def sigrej(data, sigma, mask=None, estsig=None, ival=False, axis=0,
     retfmedstddev = fmedstddev
 
     # Remove axis
-    del(dims[axis])
+    del (dims[axis])
     ival = np.empty((2, nsig) + tuple(dims))
     ival[:] = np.nan
 

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -126,9 +126,12 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None):
             log.writelog('Copying S4 control file', mute=(not meta.verbose))
             meta.copy_ecf()
 
-            log.writelog(f"Loading S3 save file:\n{meta.filename_S3_SpecData}",
+            specData_savefile = (
+                meta.inputdir + 
+                meta.filename_S3_SpecData.split(os.path.sep)[-1])
+            log.writelog(f"Loading S3 save file:\n{specData_savefile}",
                          mute=(not meta.verbose))
-            spec = xrio.readXR(meta.filename_S3_SpecData)
+            spec = xrio.readXR(specData_savefile)
 
             wave_1d = spec.wave_1d.values
             if meta.wave_min is None:

--- a/src/eureka/S5_lightcurve_fitting/models/KeplerOrbit.py
+++ b/src/eureka/S5_lightcurve_fitting/models/KeplerOrbit.py
@@ -393,7 +393,9 @@ class KeplerOrbit(object):
         return E
 
     def FSSI_Eccentric_Inverse(self, M, xtol=1e-10):
-        """Convert mean anomaly to eccentric anomaly using FSSI (Tommasini+2018).
+        """Convert mean anomaly to eccentric anomaly using FSSI algorithm.
+        
+        Algorithm based on that from Tommasini+2018.
 
         Parameters
         ----------

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -100,8 +100,6 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
             # Load in the S4 metadata used for this particular aperture pair
             meta = load_specific_s4_meta_info(meta)
 
-            lc = xrio.readXR(meta.filename_S4_LCData)
-
             # Get the directory for Stage 5 processing outputs
             meta.outputdir = util.pathdirectory(meta, 'S5', meta.run_s5,
                                                 ap=spec_hw_val, bg=bg_hw_val)
@@ -115,6 +113,13 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None):
             # Copy ECF
             log.writelog('Copying S5 control file', mute=(not meta.verbose))
             meta.copy_ecf()
+
+            specData_savefile = (
+                meta.inputdir + 
+                meta.filename_S4_LCData.split(os.path.sep)[-1])
+            log.writelog(f"Loading S4 save file:\n{specData_savefile}",
+                         mute=(not meta.verbose))
+            lc = xrio.readXR(specData_savefile)
 
             # Set the intial fitting parameters
             params = Parameters(meta.folder, meta.fit_par)

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -980,6 +980,10 @@ def roundToDec(x, nDec=2):
     """
     if not np.isfinite(nDec):
         return str(x)
+
+    if isinstance(nDec, float):
+        nDec = int(np.round(nDec))
+
     rounded = np.round(x, nDec)
     if nDec <= 0:
         # format this as an integer
@@ -1076,12 +1080,12 @@ def transit_latex_table(meta, log):
             val = line[meta.y_param+'_value']*meta.y_scalar
             upper = line[meta.y_param+'_errorpos']
             lower = line[meta.y_param+'_errorneg']
-            if np.isnan(upper) or np.isnan(lower):
+            if np.isnan(upper) and np.isnan(lower):
                 nDec = 10
             else:
                 nDec1, _ = roundToSigFigs(upper*meta.y_scalar)
                 nDec2, _ = roundToSigFigs(lower*meta.y_scalar)
-                nDec = np.nanmax([nDec1, nDec2])
+                nDec = int(np.nanmax([nDec1, nDec2]))
             val = roundToDec(val, nDec)
             upper = roundToDec(upper, nDec)
             lower = roundToDec(lower, nDec)

--- a/src/eureka/lib/logedit.py
+++ b/src/eureka/lib/logedit.py
@@ -81,7 +81,8 @@ class Logedit:
                 pass
 
         # Initiate log
-        self.log = open(logname, 'w')
+        self.logname = logname
+        self.log = open(self.logname, 'w')
 
         # Append content if there is something
         if content != []:
@@ -104,7 +105,15 @@ class Logedit:
         if not mute:
             print(message, end=end, flush=True)
         # print to file:
-        print(message, file=self.log, flush=True)
+        try:
+            print(message, file=self.log, flush=True)
+        except:
+            # The file got closed, try reopening it and logging again
+            try:
+                self.log = open(self.logname, 'a')
+                print(message, file=self.log, flush=True)
+            except:
+                print('ERROR: Unable to write to log file')
 
     def closelog(self):
         """Closes an existing log file."""

--- a/src/eureka/lib/readECF.py
+++ b/src/eureka/lib/readECF.py
@@ -209,7 +209,7 @@ class MetaClass:
             self.outputdir += os.sep
 
     def write(self, folder):
-        """A function to write an ECF file based on the current MetaClass settings.
+        """Write an ECF file based on the current MetaClass values.
 
         NOTE: For now this only rewrites the input ECF file to a new ECF file
         in the requested folder. In the future this function should make a full

--- a/src/eureka/lib/smooth.py
+++ b/src/eureka/lib/smooth.py
@@ -91,7 +91,7 @@ def medfilt(x, window_len):
     ndarray
         A smoothed copy of x.
     """
-    assert(x.ndim == 1), "Input must be one-dimensional."
+    assert (x.ndim == 1), "Input must be one-dimensional."
     if window_len % 2 == 0:
         print("Median filter length ("+str(window_len)+") must be odd." +
               "Adding 1.")

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -615,7 +615,8 @@ def interp_masked(data, meta, i, log):
     data : Xarray Dataset
         The updated Dataset object with requested pixels masked.
     """
-    log.writelog('Interpolating masked values...', mute=(not meta.verbose))
+    if i == 0:
+        log.writelog('Interpolating masked values...', mute=(not meta.verbose))
     flux = data.flux.values[i]
     mask = data.mask.values[i]
     nx = flux.shape[1]

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -7,7 +7,7 @@ from scipy.interpolate import griddata
 
 
 def readfiles(meta, log):
-    """Reads in the files saved in topdir + inputdir and saves them into a list.
+    """Reads in files saved in topdir + inputdir and saves them in a list.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR does the following:

1. Fills the MIRI wavelength array in Stage 3 if the extract_1d step was skipped in Stage 2 (which greatly speeds up Stage 2). With our current version of the jwst pipeline, the wavelength array only gets created if extract_1d is run and even then it just gets filled with zeros. This Stage 3 tweak takes care of both of those situations and will end up doing nothing once we upgrade to a jwst version that properly fills the wavelength array in Stage 2.
2. Adds a few more wavelengths to the NIRCam photometery code to allow different observing parameters
3. Reduces the number of repeated log statements for photometry (now only logged for the first integration per segment which keeps the noise down).
4. Allows the `nplots` ECF parameter to work for the photometry figures 3307 and 3505 which greatly speeds up S3 photometry and reduces the number of uninteresting figures generated. Updated the ECF documentation page accordingly.
5. Fixes a bug where changing the path to an S3 folder would break the loading of the S3 save file.
6. Adds a feature which I've needed for a while now. I store all my analyses on an external hard drive, so if I accidentally unplug that drive or need to unplug it to transport the computer while an analysis is paused, then the entire analysis ends up crashing because the log file gets forcefully closed. I added a small tweak where a failure to print to the log is attempted to be fixed by reconnecting to the log file (assuming I've now reconnected my drive) and if that fails it just prints a warning to the terminal instead and continues on without crashing the code just for the log file (and will try to reconnect to the log file each time we log something). This has already saved me once which was a useful but unintentional test of the tweak.
7. flake8 tweaks