### PR TITLE
Allows for custom bias file, saturation updates, group level background subtraction.

### DIFF
--- a/demos/JWST/S1_miri_template.ecf
+++ b/demos/JWST/S1_miri_template.ecf
@@ -26,10 +26,6 @@ skip_gain_scale     False
 #Pipeline stages parameters
 jump_rejection_threshold  4.0 #float, default is 4.0, CR sigma rejection threshold
 
-#Custom bias frames
-custom_bias         False
-superbias_file	   /path/to/custom/superbias/fits/file
-
 # Project directory
 topdir              /home/User
 

--- a/demos/JWST/S1_miri_template.ecf
+++ b/demos/JWST/S1_miri_template.ecf
@@ -26,6 +26,10 @@ skip_gain_scale     False
 #Pipeline stages parameters
 jump_rejection_threshold  4.0 #float, default is 4.0, CR sigma rejection threshold
 
+#Custom bias frames
+custom_bias         False
+superbias_file	   /path/to/custom/superbias/fits/file
+
 # Project directory
 topdir              /home/User
 

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -29,6 +29,13 @@ jump_rejection_threshold  4.0 #float, default is 4.0, CR sigma rejection thresho
 custom_bias         False
 superbias_file	   /path/to/custom/superbias/fits/file
 
+#Saturation
+update_sat_flags    False   #Wheter to update the saturation flags more aggressively
+expand_prev_group   False   #Expand saturation flags to previous group
+dq_sat_mode         percentile # options: [percentile, min, defined]
+dq_sat_percentile   50      # percentile of the entire time series to use to define the saturation mask (50=median)
+dq_sat_columns	    [[0, 0], [0,0], [0,0], [0,0], [0,0]]  #for dq_sat_mode = defined, user defined saturated columns 
+
 # Project directory
 topdir              /home/User
 

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -25,6 +25,10 @@ skip_gain_scale     False
 #Pipeline stages parameters
 jump_rejection_threshold  4.0 #float, default is 4.0, CR sigma rejection threshold
 
+#Custom bias frames
+custom_bias         False
+superbias_file	   /path/to/custom/superbias/fits/file
+
 # Project directory
 topdir              /home/User
 

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -36,6 +36,19 @@ dq_sat_mode         percentile # options: [percentile, min, defined]
 dq_sat_percentile   50      # percentile of the entire time series to use to define the saturation mask (50=median)
 dq_sat_columns	    [[0, 0], [0,0], [0,0], [0,0], [0,0]]  #for dq_sat_mode = defined, user defined saturated columns 
 
+#Background subtraction
+grouplevel_bg 		True
+ncpu				6
+bg_y1 				6
+bg_y2 				26
+bg_y_width          [None, None] # bkg from y[bg_y1-1-bg_y_width[0]: bg_y1-1] and y[bg_y2 + 1, bg_y2 + 1 + bg_y_width[1]]. ignored if None, can be [None, 4] or [4, None]  
+bg_deg 				0 
+p3thresh			5
+verbose				True
+isplots 			1
+isplots_S3 			False  #calling a S3 function requires this separate input
+hide_plots          True
+
 # Project directory
 topdir              /home/User
 

--- a/src/eureka/S1_detector_processing/ramp_fitting.py
+++ b/src/eureka/S1_detector_processing/ramp_fitting.py
@@ -18,6 +18,8 @@ from jwst.datamodels import dqflags
 from jwst.lib import reffile_utils
 from jwst.lib import pipe_utils
 
+from . import update_saturation
+
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -87,6 +89,12 @@ default='none') # max number of processes to create
             Updated for JWST version 1.3.3, code restructure
         '''
         with datamodels.RampModel(input) as input_model:
+
+            if self.s1_meta.update_sat_flags:
+                input_model = update_saturation.update_sat(input_model, 
+                                                           self.s1_log, 
+                                                           self.s1_meta)
+
             readnoise_filename = self.get_reference_file(input_model,
                                                          'readnoise')
             gain_filename = self.get_reference_file(input_model, 'gain')

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -191,6 +191,8 @@ class EurekaS1Pipeline(Detector1Pipeline):
         self.ramp_fit.algorithm = meta.ramp_fit_algorithm
         self.ramp_fit.maximum_cores = meta.ramp_fit_max_cores
         self.ramp_fit.skip = meta.skip_ramp_fitting
+        self.ramp_fit.s1_meta = meta
+        self.ramp_fit.s1_log = log
 
         # Default ramp fitting settings
         if self.ramp_fit.algorithm == 'default':

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -179,6 +179,8 @@ class EurekaS1Pipeline(Detector1Pipeline):
         if instrument in ['NIRCAM', 'NIRISS', 'NIRSPEC']:
             self.persistence.skip = meta.skip_persistence
             self.superbias.skip = meta.skip_superbias
+            if meta.custom_bias:
+                self.superbias.override_superbias = meta.superbias_file
         elif instrument in ['MIRI']:
             self.firstframe.skip = meta.skip_firstframe
             self.lastframe.skip = meta.skip_lastframe

--- a/src/eureka/S1_detector_processing/update_saturation.py
+++ b/src/eureka/S1_detector_processing/update_saturation.py
@@ -92,7 +92,7 @@ def update_sat(input_model, log, meta):
     # Saturation flagging condition
     # Where our saturation mask is True and dq is not already flagged
 
-    condition = ((new_sat_mask == True) & (input_model.groupdq == 0))
+    condition = np.where((new_sat_mask) & (input_model.groupdq == 0))
     # Now update the groupdq map
     input_model.groupdq[condition] = sat_flag
 

--- a/src/eureka/S1_detector_processing/update_saturation.py
+++ b/src/eureka/S1_detector_processing/update_saturation.py
@@ -1,0 +1,99 @@
+#! /usr/bin/env python
+
+# File with functions to modify the saturation
+# flagging routines
+# PA Roy, July 27th 2022
+import numpy as np
+from jwst.datamodels import dqflags
+
+
+def update_sat(input_model, log, meta):
+    '''Function that flags saturated pixels more aggressively.
+    The flags are added to the group_dq array.
+
+    Parameters:
+    -----------
+    input_model : jwst.datamodels.QuadModel
+        The input group-level data product before ramp fitting.
+    log : logedit.Logedit
+        The open log in which notes from this step can be added.
+    meta : eureka.lib.readECF.MetaClass
+        The metadata object.
+
+    Returns:
+    --------
+    input_model : jwst.datamodels.QuadModel
+        The input group-level data product with updated saturation flags.
+    '''
+    log.writelog('  Applying a more severe saturation flagging.')
+
+    # Compute the median of the groupdq map
+    if meta.dq_sat_mode == "percentile":
+        log.writelog('Creating a saturation map based on the\n' +
+                     'percentile set in the ecf file.')
+        median_sat = np.percentile(input_model.groupdq, 
+                                   meta.dq_sat_percentile, axis=0).astype(int)
+    elif meta.dq_sat_mode == "min":
+        log.writelog('Creating a saturation map based on the\n' +
+                     'minimum saturated group for each pixel.')
+        median_sat = np.max(input_model.groupdq, axis=0).astype(int)    
+    elif meta.dq_sat_mode == "defined":
+        log.writelog('Creating a saturation map based on the\n' +
+                     'user defined columns.')
+        median_sat = np.zeros_like(np.median(input_model.groupdq, axis=0))
+        
+    # Store the saturation flag value
+    sat_flag = dqflags.pixel['SATURATED']
+    median_sat_mask = (median_sat == sat_flag)
+ 
+    # Expand saturated pixels to full columns
+    log.writelog('    Expand flags along columns.')
+    new_sat_mask = 1 * median_sat_mask
+    ngrp = new_sat_mask.shape[0]
+    ncols = new_sat_mask.shape[1]
+    nrows = new_sat_mask.shape[2]
+    if meta.dq_sat_mode == "percentile" or meta.dq_sat_mode == "min":
+        for i in range(ngrp):
+            is_col_sat = np.sum(median_sat_mask[i, :, :], axis=0).astype(bool)
+            new_sat_mask[i, :, :] = np.broadcast_to(is_col_sat, (ncols, nrows))
+    elif meta.dq_sat_mode == "defined":
+        for i in range(ngrp):
+            c1 = meta.dq_sat_columns[i][0]
+            c2 = meta.dq_sat_columns[i][1]
+            new_sat_mask[i, :, c1:c2] = sat_flag
+            
+    # Expand saturation flags to one group before
+    if meta.expand_prev_group:
+        log.writelog('    Expand flags to previous group.')
+        for i in range(ngrp-1):
+            new_sat_mask[i, :, :] += new_sat_mask[i+1, :, :] 
+
+    # Make sure that we did not put saturation in Group 1
+    # If so, remove it (o.w. no info at all for ramp_fitting)
+    if np.count_nonzero(new_sat_mask[0]) > 0:
+        log.writelog('    WARNING')
+        log.writelog('    Some saturated flags found in the first group.')
+        log.writelog('    Removing the flags so the first group is fully used')
+        new_sat_mask[0, :, :] *= False
+
+    # If flags in the second group, just raise a warning
+    if np.count_nonzero(new_sat_mask[1]) > 0:
+        log.writelog('    WARNING')
+        log.writelog('    Saturation flags found in the 2nd group ')
+        log.writelog('    This means some columns only have nGroup=1... ')
+        log.writelog('    Use caution for this part of the detector.')
+                
+    # Ensure we still have a boolean mask
+    new_sat_mask = new_sat_mask.astype(bool)
+    
+    # Now broadcast that mask back to the number of ints
+    new_sat_mask = np.broadcast_to(new_sat_mask, input_model.groupdq.shape)
+
+    # Saturation flagging condition
+    # Where our saturation mask is True and dq is not already flagged
+
+    condition = ((new_sat_mask == True) & (input_model.groupdq == 0))
+    # Now update the groupdq map
+    input_model.groupdq[condition] = sat_flag
+
+    return input_model


### PR DESCRIPTION
Contains updated options for partial saturation that all the user to expand the saturation flag along the cross-dispersion axis and to specify their own saturated regions. Saturation code provided by @cpiaulet 

Includes group level background subtraction for non-curved traces. GLBS code provided by @AarynnCarter and calls S3 background removal code. 

All components are tested for NIRSpec PRISM and represent updates that are used in the PRISM ERS paper. 