### PR TITLE
Quick bokeh bug fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - asdf
     - astropy
     - batman-package
-    - bokeh==2.4.3
+    - bokeh=2.4.3
     - ccdproc
     - celerite
     - corner

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - asdf
     - astropy
     - batman-package
-    - bokeh=2.4.3
+    - bokeh[version='<3.0']
     - ccdproc
     - celerite
     - corner

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - asdf
     - astropy
     - batman-package
-    - bokeh
+    - bokeh[version=='2.4.3']
     - ccdproc
     - celerite
     - corner

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - asdf
     - astropy
     - batman-package
-    - bokeh[version=='2.4.3']
+    - bokeh[version='2.4.3']
     - ccdproc
     - celerite
     - corner

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     - asdf
     - astropy
     - batman-package
-    - bokeh[version='2.4.3']
+    - bokeh==2.4.3
     - ccdproc
     - celerite
     - corner

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     astropy
     astroquery
     batman-package
-    bokeh
+    bokeh < 3.0
     ccdproc
     celerite # Needed for GP
     corner


### PR DESCRIPTION
I found that upon doing a clean install with v0.6 I was getting the following error about bokeh not having some required packages set up the right way:

ImportError: cannot import name 'Panel' from 'bokeh.models.widgets' 

It looks like this problem is because the default install now installs bokeh v3.0.1, while previously Eureka! had been automatically installing v2.4.3. I'm not sure if it definitely needs to be v2.4.3 or just <v3.0, but I added a strict requirement for the version. We can change that to an upper limit if you think it would be better though!