### PR TITLE
Enable GLBS for MIRI, fix GLBS plotting

### DIFF
--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -9,6 +9,9 @@ wave_min        1.5         # Minimum wavelength. Set to None to use the shortes
 wave_max        4.5         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
 allapers        False       # Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
+# Mannualy mask pixel columns by index number
+# mask_columns    []
+
 # Parameters for drift correction of 1D spectra
 recordDrift     False    # Set True to record drift/jitter in 1D spectra (always recorded if correctDrift is True)
 correctDrift    False   # Set True to correct drift/jitter in 1D spectra (not recommended for simulated data)

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
         - crds
         - exotic-ld
         - image_registration @ git+https://github.com/keflavich/image_registration.git@master#egg=image_registration
-        - jwst==1.6.0
+        - jwst==1.8.0
         - myst-parser # Needed for documentation
         - sphinx-rtd-theme # Needed for documentation
         - stcal

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -36,7 +36,7 @@ dependencies:
         - exotic-ld
         - exoplanet
         - image_registration @ git+https://github.com/keflavich/image_registration.git@master#egg=image_registration
-        - jwst==1.6.0
+        - jwst==1.8.0
         - myst-parser # Needed for documentation
         - pymc3
         - setuptools_scm # Needed for version number

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ where = src
 
 [options.extras_require]
 jwst =
-    jwst==1.6.0
+    jwst==1.8.0
     stcal >= 1.0.0 # Needed for our create_integration_model function
     asdf
 hst =

--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -38,8 +38,17 @@ def GLBS(input_model, log, meta):
     dq = input_model.groupdq
 
     meta.inst = input_model.meta.instrument.name.lower()
-    meta.int_start = 0
     meta.n_int = all_data.shape[0]
+    meta.int_start = 0
+    if not hasattr(meta, 'nplots') or meta.nplots is None:
+        meta.int_end = meta.n_int
+    elif meta.int_start+meta.nplots > meta.n_int:
+        # Too many figures requested, so reduce it
+        meta.int_end = meta.n_int
+    else:
+        meta.int_end = meta.int_start+meta.nplots
+    if meta.inst == 'miri':
+        meta.isrotate = False
 
     for ngrp in range(all_data.shape[1]):
         grp_data = all_data[:, ngrp, :, :]
@@ -61,10 +70,11 @@ def GLBS(input_model, log, meta):
         xrdict = dict(flux=xrdata, mask=xrmask)
         data = xrio.makeDataset(dictionary=xrdict)
         data['flux'].attrs['flux_units'] = 'n/a'
+        data.attrs['intstart'] = meta.intstart
         if ngrp == all_data.shape[1]-1:
             data = bkg.BGsubtraction(data, meta, 
                                      log, 0, 
-                                     meta.isplots)
+                                     meta.isplots_S1)
         else:
             # do not show plots except for the last group
             data = bkg.BGsubtraction(data, meta, 

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -98,6 +98,8 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
                 hdulist[0].header['NDITHPTS'] = 1
                 hdulist[0].header['NRIMDTPT'] = 1
 
+            meta.intstart = hdulist[0].header['INTSTART']-1
+            meta.intend = hdulist[0].header['INTEND']
             EurekaS1Pipeline().run_eurekaS1(filename, meta, log)
 
     # Calculate total run time

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -288,7 +288,7 @@ def fitbg(dataim, meta, mask, x1, x2, deg=1, threshold=5, isrotate=False,
                     plt.plot(goodxvals, dataslice, 'bo')
                     plt.plot(range(nx), bg[j], 'g-')
                     fname = ('figs'+os.sep+'Fig3601_BG_'+str(j) +
-                             plots.plots.figure_filetype)
+                             plots.figure_filetype)
                     plt.savefig(meta.outputdir + fname, dpi=300)
                     plt.pause(0.01)
 

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -261,11 +261,11 @@ def fitbg(dataim, meta, mask, x1, x2, deg=1, threshold=5, isrotate=False,
                     residuals = dataslice - model
                     # Simple standard deviation (faster but prone to missing
                     # scanned background stars)
-                    # stdres = np.std(residuals)
+                    stdres = np.std(residuals)
                     # Median Absolute Deviation (slower but more robust)
                     # stdres  = np.median(np.abs(np.ediff1d(residuals)))
                     # Mean Absolute Deviation (good compromise)
-                    stdres = np.mean(np.abs(np.ediff1d(residuals)))
+                    # stdres = np.mean(np.abs(np.ediff1d(residuals)))
                     if stdres == 0:
                         stdres = np.inf
                     stdevs = np.abs(residuals) / stdres
@@ -281,7 +281,7 @@ def fitbg(dataim, meta, mask, x1, x2, deg=1, threshold=5, isrotate=False,
             # background image
             if len(goodxvals) != 0:
                 bg[j] = np.polyval(coeffs, range(nx))
-                if isplots >= 6:
+                if isplots == 6:
                     plt.figure(3601)
                     plt.clf()
                     plt.title(str(j))

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -172,7 +172,7 @@ def read(filename, data, meta, log):
             temp = np.copy(meta.ywindow)
             meta.ywindow = meta.xwindow
             meta.xwindow = sci.shape[2] - temp[::-1]
-    
+
     # Figure out the x-axis (aka the original y-axis) pixel numbers since we've
     # reversed the order of the x-axis
     x = np.arange(sci.shape[2])[::-1]
@@ -294,7 +294,6 @@ def fit_bg(dataim, datamask, n, meta, isplots=0):
                                 threshold=meta.p3thresh, isrotate=isrotate,
                                 isplots=isplots)
     return bg, mask, n
-    # return nircam.fit_bg(dataim, datamask, n, meta, isplots=isplots, **kwargs)
 
 
 def cut_aperture(data, meta, log):

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -1,6 +1,7 @@
 import numpy as np
 from astropy.io import fits
 import astraeus.xarrayIO as xrio
+from . import background
 try:
     from jwst import datamodels
 except ImportError:
@@ -284,7 +285,16 @@ def fit_bg(dataim, datamask, n, meta, isplots=0):
     n : int
         The current integration number.
     """
-    return nircam.fit_bg(dataim, datamask, n, meta, isplots=isplots)
+    if hasattr(meta, 'isrotate'):
+        isrotate = meta.isrotate
+    else:
+        isrotate = 2
+    bg, mask = background.fitbg(dataim, meta, datamask, meta.bg_y1,
+                                meta.bg_y2, deg=meta.bg_deg,
+                                threshold=meta.p3thresh, isrotate=isrotate,
+                                isplots=isplots)
+    return bg, mask, n
+    # return nircam.fit_bg(dataim, datamask, n, meta, isplots=isplots, **kwargs)
 
 
 def cut_aperture(data, meta, log):

--- a/src/eureka/S3_data_reduction/optspex.py
+++ b/src/eureka/S3_data_reduction/optspex.py
@@ -534,17 +534,27 @@ def clean_median_flux(data, meta, log, m):
     if meta.window_len > 1:
         # Apply smoothing filter along dispersion direction
         smoothflux = spn.median_filter(interp_med, size=(1, meta.window_len))
-
-        # Compute residuals
-        residuals = medflux - smoothflux
+        # Compute median error array
+        err_ma = np.ma.masked_where(data.mask.values == 0, data.err.values)
+        mederr = np.ma.median(err_ma, axis=0)
+        # Compute residuals in units of std dev
+        residuals = (medflux - smoothflux)/mederr
 
         # Flag outliers
         if not hasattr(meta, 'median_thresh'):
             log.writelog('  Using a default value of median_thresh=5',
                          mute=(not meta.verbose))
             meta.median_thresh = 5
-        outliers = sigma_clip(residuals, sigma=meta.median_thresh, maxiters=5,
-                              axis=1, cenfunc='median')
+        outliers = sigma_clip(residuals, sigma=meta.median_thresh,
+                              maxiters=None, axis=1, cenfunc='median')
+
+        #FINDME: Need to move this figure to plots_s3.py
+        # plt.figure(2, figsize=(8, 4))
+        # plt.clf()
+        # plt.title("Outliers")
+        # plt.imshow(outliers, origin='lower', aspect='auto')
+        # plt.colorbar()
+        # plt.pause(1)
 
         # Interpolate over bad pixels
         clean_med = np.zeros((ny, nx))
@@ -565,7 +575,7 @@ def clean_median_flux(data, meta, log, m):
         data['medflux'] = (['y', 'x'], medflux.data)
     data['medflux'].attrs['flux_units'] = data.flux.attrs['flux_units']
 
-    if meta.isplots_S3 >= 4:
+    if meta.isplots_S3 >= 3:
         plots_s3.median_frame(data, meta, m)
 
     return data
@@ -761,18 +771,8 @@ def optimize(meta, subdata, mask, bg, spectrum, Q, v0, p5thresh=10,
             variance = np.abs(expected + bg) / Q + v0
             # STEP 7: Mask cosmic ray hits
             stdevs = np.abs(subdata - expected)*submask / np.sqrt(variance)
-            if meta.isplots_S3 == 8:
-                try:
-                    plt.figure(3801)
-                    plt.clf()
-                    plt.plot(variance[20])
-                    plt.figure(3802)
-                    plt.clf()
-                    plt.plot(variance[:, 10])
-                    plt.pause(1)
-                except:
-                    # FINDME: Need to only catch the expected exception
-                    pass
+            if meta.isplots_S3 >= 5 and n < meta.int_end:
+                plots_s3.stddev_profile(meta, n, m, stdevs, p7thresh)
             isoutliers = False
             if len(stdevs) > 0:
                 # Find worst data point in each column
@@ -784,7 +784,9 @@ def optimize(meta, subdata, mask, bg, spectrum, Q, v0, p5thresh=10,
                             plt.figure(3803)
                             plt.clf()
                             plt.suptitle(str(i) + "/" + str(nx))
-                            plt.plot(subdata[:, i], 'bo')
+                            plt.errorbar(np.arange(ny), subdata[:, i],
+                                         np.sqrt(variance[:, i]),
+                                         fmt='.', color='b')
                             plt.plot(expected[:, i], 'g-')
                             plt.pause(0.01)
                         except:
@@ -797,7 +799,7 @@ def optimize(meta, subdata, mask, bg, spectrum, Q, v0, p5thresh=10,
                         # Generate plot
                         if meta.isplots_S3 >= 5 and n < meta.int_end:
                             plots_s3.subdata(meta, i, n, m, subdata, submask,
-                                             expected, loc)
+                                             expected, loc, variance)
                         # Check for insufficient number of good points
                         if sum(submask[:, i]) < ny/2.:
                             submask[:, i] = 0

--- a/src/eureka/S3_data_reduction/optspex.py
+++ b/src/eureka/S3_data_reduction/optspex.py
@@ -548,14 +548,6 @@ def clean_median_flux(data, meta, log, m):
         outliers = sigma_clip(residuals, sigma=meta.median_thresh,
                               maxiters=None, axis=1, cenfunc='median')
 
-        #FINDME: Need to move this figure to plots_s3.py
-        # plt.figure(2, figsize=(8, 4))
-        # plt.clf()
-        # plt.title("Outliers")
-        # plt.imshow(outliers, origin='lower', aspect='auto')
-        # plt.colorbar()
-        # plt.pause(1)
-
         # Interpolate over bad pixels
         clean_med = np.zeros((ny, nx))
         xx = np.arange(nx)
@@ -785,7 +777,7 @@ def optimize(meta, subdata, mask, bg, spectrum, Q, v0, p5thresh=10,
                             plt.clf()
                             plt.suptitle(str(i) + "/" + str(nx))
                             plt.errorbar(np.arange(ny), subdata[:, i],
-                                         np.sqrt(variance[:, i]),
+                                         yerr=np.sqrt(variance[:, i]),
                                          fmt='.', color='b')
                             plt.plot(expected[:, i], 'g-')
                             plt.pause(0.01)

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -409,9 +409,9 @@ def subdata(meta, i, n, m, subdata, submask, expected, loc, variance):
     plt.clf()
     plt.suptitle(f'Integration {n}, Columns {i}/{nx}')
     plt.errorbar(np.arange(ny)[np.where(submask[:, i])[0]],
-             subdata[np.where(submask[:, i])[0], i],
-             np.sqrt(variance[np.where(submask[:, i])[0], i]),
-             fmt='.', color='b')
+                 subdata[np.where(submask[:, i])[0], i],
+                 np.sqrt(variance[np.where(submask[:, i])[0], i]),
+                 fmt='.', color='b')
     plt.plot(np.arange(ny)[np.where(submask[:, i])[0]],
              expected[np.where(submask[:, i])[0], i], 'g-')
     plt.plot((loc[i]), (subdata[loc[i], i]), 'ro')
@@ -1116,6 +1116,7 @@ def phot_2d_frame_diff(data, meta):
         if not meta.hide_plots:
             plt.pause(0.2)
 
+
 def stddev_profile(meta, n, m, stdevs, p7thresh):
     """
     Plots the difference between the data and optimal profile in units
@@ -1156,7 +1157,7 @@ def stddev_profile(meta, n, m, stdevs, p7thresh):
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
     int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
     fname = (f'figs{os.sep}fig3506_file{file_number}_int{int_number}' +
-             f'_Std_Dev_Profile'+plots.figure_filetype)
+             '_Std_Dev_Profile'+plots.figure_filetype)
     plt.savefig(meta.outputdir + fname, dpi=200)
     if not meta.hide_plots:
         plt.pause(0.1)

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -137,12 +137,18 @@ def image_and_background(data, meta, log, m):
     log.writelog('  Creating figures for background subtraction...',
                  mute=(not meta.verbose))
 
+    # If need be, transpose array so that largest dimension is on x axis
+    if len(data.flux.x.values) < len(data.flux.y.values):
+        data = data.transpose('time', 'x', 'y')
+        ymin, ymax = data.flux.x.min().values, data.flux.x.max().values
+        xmin, xmax = data.flux.y.min().values, data.flux.y.max().values
+    else:
+        xmin, xmax = data.flux.x.min().values, data.flux.x.max().values
+        ymin, ymax = data.flux.y.min().values, data.flux.y.max().values
+
     intstart = data.attrs['intstart']
     subdata = np.ma.masked_where(~data.mask.values, data.flux.values)
     subbg = np.ma.masked_where(~data.mask.values, data.bg.values)
-
-    xmin, xmax = data.flux.x.min().values, data.flux.x.max().values
-    ymin, ymax = data.flux.y.min().values, data.flux.y.max().values
 
     # Commented out vmax calculation is sensitive to unflagged hot pixels
     # vmax = np.ma.max(np.ma.masked_invalid(subdata))/40

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -358,9 +358,9 @@ def profile(meta, profile, submask, n, m):
     vmin = np.ma.min(profile*submask)
     vmax = vmin + 0.05*np.ma.max(profile*submask)
     cmap = plt.cm.viridis.copy()
-    plt.figure(3303)
+    plt.figure(3303, figsize=(8, 4))
     plt.clf()
-    plt.suptitle(f"Profile - Integration {n}")
+    plt.title(f"Optimal Profile - Integration {n}")
     plt.imshow(profile*submask, aspect='auto', origin='lower',
                vmax=vmax, vmin=vmin, interpolation='nearest', cmap=cmap)
     plt.ylabel('Relative Pixel Position')
@@ -375,7 +375,7 @@ def profile(meta, profile, submask, n, m):
         plt.pause(0.2)
 
 
-def subdata(meta, i, n, m, subdata, submask, expected, loc):
+def subdata(meta, i, n, m, subdata, submask, expected, loc, variance):
     '''Show 1D view of profile for each column. (Figs 3501)
 
     Parameters
@@ -401,8 +401,10 @@ def subdata(meta, i, n, m, subdata, submask, expected, loc):
     plt.figure(3501)
     plt.clf()
     plt.suptitle(f'Integration {n}, Columns {i}/{nx}')
-    plt.plot(np.arange(ny)[np.where(submask[:, i])[0]],
-             subdata[np.where(submask[:, i])[0], i], 'bo')
+    plt.errorbar(np.arange(ny)[np.where(submask[:, i])[0]],
+             subdata[np.where(submask[:, i])[0], i],
+             np.sqrt(variance[np.where(submask[:, i])[0], i]),
+             fmt='.', color='b')
     plt.plot(np.arange(ny)[np.where(submask[:, i])[0]],
              expected[np.where(submask[:, i])[0], i], 'g-')
     plt.plot((loc[i]), (subdata[loc[i], i]), 'ro')
@@ -1106,3 +1108,46 @@ def phot_2d_frame_diff(data, meta):
         plt.savefig(meta.outputdir + fname, dpi=250)
         if not meta.hide_plots:
             plt.pause(0.2)
+
+def stddev_profile(meta, n, m, stdevs, p7thresh):
+    """
+    Plots the difference between the data and optimal profile in units
+    of standard deviations.  The scale goes from 0 to p7thresh. (Fig 3506)
+
+    Parameters
+    ----------
+    meta : eureka.lib.readECF.MetaClass
+        The metadata object.
+    n : int
+        The current integration number.
+    m : int
+        The file number.
+    stdevs : 2D array
+        Difference between data and profile in standard deviations
+    p7thresh : int
+        X-sigma threshold for outlier rejection during optimal spectral
+        extraction
+
+    Notes
+    -----
+    History:
+
+    - 2022-12-29 Kevin Stevenson
+        Initial version
+    """
+    plt.figure(3506, figsize=(8, 4))
+    plt.clf()
+    cmap = plt.cm.viridis.copy()
+    plt.title(f'Std. Dev. from Optimal Profile - Integration {n}')
+    plt.imshow(stdevs, origin='lower', aspect='auto',
+               vmax=p7thresh, vmin=0, cmap=cmap,
+               interpolation='nearest')
+    plt.ylabel('Relative Pixel Position')
+    plt.xlabel('Relative Pixel Position')
+    plt.colorbar()
+    plt.tight_layout()
+    file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
+    int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
+    fname = (f'figs{os.sep}fig3506_file{file_number}_int{int_number}' +
+             f'_Std_Dev_Profile'+plots.figure_filetype)
+    plt.savefig(meta.outputdir + fname, dpi=200)

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -401,6 +401,8 @@ def subdata(meta, i, n, m, subdata, submask, expected, loc, variance):
         Expected profile
     loc : ndarray
         Location of worst outliers.
+    variance : ndarray
+        Variance of background subtracted data.
     '''
     ny, nx = subdata.shape
     plt.figure(3501)
@@ -1156,3 +1158,5 @@ def stddev_profile(meta, n, m, stdevs, p7thresh):
     fname = (f'figs{os.sep}fig3506_file{file_number}_int{int_number}' +
              f'_Std_Dev_Profile'+plots.figure_filetype)
     plt.savefig(meta.outputdir + fname, dpi=200)
+    if not meta.hide_plots:
+        plt.pause(0.1)

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -53,8 +53,13 @@ def lc_nodriftcorr(meta, wave_1d, optspec, optmask=None):
     wmin = np.nanmin(wave_1d)
     wmax = np.nanmax(wave_1d)
     # Don't do min and max because MIRI is backwards
-    pmin = int(optspec.x[0].values)
-    pmax = int(optspec.x[-1].values)
+    # Correctly place label at center of pixel
+    if meta.inst == 'miri':
+        pmin = int(optspec.x[0].values+0.5)
+        pmax = int(optspec.x[-1].values-0.5)
+    else:
+        pmin = int(optspec.x[0].values-0.5)
+        pmax = int(optspec.x[-1].values+0.5)
     if not hasattr(meta, 'vmin') or meta.vmin is None:
         meta.vmin = 0.97
     if not hasattr(meta, 'vmax') or meta.vmin is None:

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -36,6 +36,8 @@ def find_column_median_shifts(data, meta, m):
 
     # Smooth CoM values to get rid of outliers
     smooth_coms = smooth.medfilt(column_coms, 11)
+    # if a value in smooth coms is nan, set it to the last non-nan value
+    smooth_coms[np.isnan(smooth_coms)] = smooth_coms[~np.isnan(smooth_coms)][-1]
 
     # Convert to interget pixels
     int_coms = np.around(smooth_coms).astype(int)
@@ -45,7 +47,7 @@ def find_column_median_shifts(data, meta, m):
 
     # define the new center (where we will align the trace) in the
     # middle of the detector
-    new_center = int(nb_rows/2)
+    new_center = int(nb_rows/2) - 1
 
     # define an array containing the needed shift to bring the COMs to the
     # new center for each column of each integration

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -35,7 +35,7 @@ def find_column_median_shifts(data, meta, m):
                    np.sum(data, axis=0))
 
     # Smooth CoM values to get rid of outliers
-    smooth_coms = smooth.medfilt(column_coms, meta.window_len)
+    smooth_coms = smooth.medfilt(column_coms, 11)
 
     # Convert to interget pixels
     int_coms = np.around(smooth_coms).astype(int)

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -139,7 +139,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
             meta.copy_ecf()
 
             specData_savefile = (
-                meta.inputdir + 
+                meta.inputdir +
                 meta.filename_S3_SpecData.split(os.path.sep)[-1])
             log.writelog(f"Loading S3 save file:\n{specData_savefile}",
                          mute=(not meta.verbose))
@@ -270,6 +270,13 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
             if not hasattr(meta, 'boundary'):
                 # The default value before this was added as an option
                 meta.boundary = 'extend'
+
+            # Manually mask pixel columns by index number
+            if hasattr(meta, 'mask_columns') and len(meta.mask_columns) > 0:
+                for w in meta.mask_columns:
+                    log.writelog(f"Masking absolute pixel column {w}.")
+                    offset = spec.optmask.x[0]
+                    spec.optmask[:, w-offset] = True
 
             # Do 1D sigma clipping (along time axis) on unbinned spectra
             if meta.clip_unbinned:
@@ -504,7 +511,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                                                 ld_3para)
                 lc['exotic-ld_nonlin_4para'] = (['wavelength', 'exotic-ld_4'],
                                                 ld_4para)
-                
+
                 if meta.compute_white:
                     ld_lin_w, ld_quad_w, ld_3para_w, ld_4para_w = \
                         generate_LD.exotic_ld(meta, spec, log, white=True)
@@ -574,7 +581,7 @@ def load_specific_s3_meta_info(meta):
     filename_S3_SpecData = s3_meta.filename_S3_SpecData
     # Merge S4 meta into old S3 meta
     meta = me.mergeevents(meta, s3_meta)
-    
+
     # Make sure the filename_S3_SpecData is kept
     meta.filename_S3_SpecData = filename_S3_SpecData
 


### PR DESCRIPTION
This PR enables group-level background subtraction for MIRI.  However, the spectra are cleaner when GLBS is **NOT** used, so I wouldn't recommend people apply this step with MIRI data.  

Fortunately, I was able to get plots_s3.image_and_background() working when using GLBS, so that's a small win.