### PR TITLE
Remove unnecessarily complicated mergeevent steps

### DIFF
--- a/src/eureka/lib/manageevent.py
+++ b/src/eureka/lib/manageevent.py
@@ -260,16 +260,7 @@ def mergeevents(new_meta, old_meta):
         Initial version.
     """
     # Load current ECF into old MetaClass
-    old_meta.read(new_meta.folder, new_meta.filename)
-
-    # Load any missing parameters from current MetaClass into old MetaClass
     for key in new_meta.__dict__:
-        if key not in old_meta.__dict__:
-            setattr(old_meta, key, getattr(new_meta, key))
-
-    # Make sure inputdir is correct
-    old_meta.inputdir = new_meta.inputdir
-    old_meta.inputdir_raw = new_meta.inputdir_raw
-    old_meta.datetime = new_meta.datetime
+        setattr(old_meta, key, getattr(new_meta, key))
 
     return old_meta


### PR DESCRIPTION
The old mergeevent code can be greatly simplified which also has an important on how Evie and Megan are wanting to interact with Eureka for the ERS notebook. Importantly, this function no longer re-loads the ECF file and just uses the already read-in ECF values