### PR TITLE
Adding setuptools_scm to environment.yml

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,8 +6,8 @@ Installation methods
 --------------------
 
 In order to have consistent, repeatable results across the ``Eureka!`` user community, we recommend that all general users install
-the most recent stable release of ``Eureka!``, v0.5. The following installation instructions are written with this in mind,
-and the most recent stable release is also available as a zipped archive `here <https://github.com/kevin218/Eureka/releases/tag/v0.5>`_.
+the most recent stable release of ``Eureka!``, v0.7. The following installation instructions are written with this in mind,
+and the most recent stable release is also available as a zipped archive `here <https://github.com/kevin218/Eureka/releases/tag/v0.7>`_.
 Also note that if you are using a macOS device with an M1 processor, you will need to use the ``conda`` environment.yml file
 installation instructions below as the pip dependencies fail to build on the M1 processor.
 
@@ -31,7 +31,7 @@ Once in your new conda environment, you can install ``Eureka!`` directly from so
 
 .. code-block:: bash
 
-	git clone -b v0.5 https://github.com/kevin218/Eureka.git
+	git clone -b v0.7 https://github.com/kevin218/Eureka.git
 	cd Eureka
 	pip install -e '.[jwst]'
 
@@ -49,7 +49,7 @@ Once in your new conda environment, you can install the ``Eureka!`` package with
 
 .. code-block:: bash
 
-	pip install -e git+https://github.com/kevin218/Eureka.git@v0.5#egg=eureka[jwst]
+	pip install -e git+https://github.com/kevin218/Eureka.git@v0.7#egg=eureka[jwst]
 
 Other specific branches can be installed using:
 
@@ -68,7 +68,7 @@ you'd prefer not to use ``pip`` to install dependencies. This can be done follow
 
 .. code-block:: bash
 
-	git clone -b v0.5 https://github.com/kevin218/Eureka.git
+	git clone -b v0.7 https://github.com/kevin218/Eureka.git
 	cd Eureka
 	conda env create --file environment.yml --force
 	conda activate eureka

--- a/environment.yml
+++ b/environment.yml
@@ -36,6 +36,7 @@ dependencies:
         - image_registration @ git+https://github.com/keflavich/image_registration.git@master#egg=image_registration
         - jwst==1.6.0
         - myst-parser # Needed for documentation
+        - setuptools_scm # Needed for version number
         - sphinx-rtd-theme # Needed for documentation
         - stcal
         - stdatamodels


### PR DESCRIPTION
Resolves #497

Adding setuptools_scm to environment.yml is needed to properly set the Eureka version number. Successfully tested with Docker to ensure a fresh installation environment (I hadn't noticed this as I had a cached version.py file from doing pip install previously)