### PR TITLE
Add full frame outlier rejection capabilities

### DIFF
--- a/demos/JWST/S3_miri_lrs_template.ecf
+++ b/demos/JWST/S3_miri_lrs_template.ecf
@@ -15,9 +15,9 @@ record_ypos     True        # Option to record the y position and width for each
 dqmask          True        # Mask pixels with an odd entry in the DQ array
 
 # Outlier rejection along time axis
-ff_outlier      False       # Set True to use full frame; set False to use only background region
-ff_thresh       [5,5]       # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
-bg_thresh       [5,5]       # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+ff_outlier      False       # Set False to use only background region (recommended for deep transits)
+                            # Set True to use full frame (works well for shallow transits/eclipses)
+bg_thresh       [4,4]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 
 # Background parameters
 bg_hw           10          # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/demos/JWST/S3_miri_lrs_template.ecf
+++ b/demos/JWST/S3_miri_lrs_template.ecf
@@ -14,9 +14,13 @@ src_pos_type    gaussian    # Determine source position when not given in header
 record_ypos     True        # Option to record the y position and width for each integration (only records if src_pos_type is gaussian)
 dqmask          True        # Mask pixels with an odd entry in the DQ array
 
+# Outlier rejection along time axis
+ff_outlier      False       # Set True to use full frame; set False to use only background region
+ff_thresh       [5,5]       # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
+bg_thresh       [5,5]       # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+
 # Background parameters
 bg_hw           10          # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
 

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -12,11 +12,16 @@ ywindow         [5,64]      # Vertical axis as seen in DS9
 xwindow         [100,1700]  # Horizontal axis as seen in DS9
 src_pos_type    gaussian    # Determine source position when not given in header (Options: header, gaussian, weighted, max, or hst)
 record_ypos     True        # Option to record the y position and width for each integration (only records if src_pos_type is gaussian)
+dqmask          False       # Mask pixels with an odd entry in the DQ array
+
+# Outlier rejection along time axis
+ff_outlier      False       # Set True to use full frame; set False to use only background region
+ff_thresh       [5,5]       # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
+bg_thresh       [5,5]       # Background region double-iteration X-sigma threshold for outlier rejection along time axis
 
 # Background parameters
 bg_hw           8           # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
-bg_deg          1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
+bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
 
 # Spectral extraction parameters
@@ -27,6 +32,9 @@ window_len      13          # Smoothing window length, for median frame or when 
 prof_deg        3           # Polynomial degree, when fittype = poly
 p5thresh        10          # X-sigma threshold for outlier rejection while constructing spatial profile
 p7thresh        10          # X-sigma threshold for outlier rejection during optimal spectral extraction
+
+# Curvature treatment
+curvature       None        # How to manage the curved trace on the detector (Options: None, correct). Use correct for NIRSpec/G395.
 
 # Diagnostics
 isplots_S3      3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -15,9 +15,9 @@ record_ypos     True        # Option to record the y position and width for each
 dqmask          False       # Mask pixels with an odd entry in the DQ array
 
 # Outlier rejection along time axis
-ff_outlier      False       # Set True to use full frame; set False to use only background region
-ff_thresh       [5,5]       # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
-bg_thresh       [5,5]       # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+ff_outlier      False       # Set False to use only background region (recommended for deep transits)
+                            # Set True to use full frame (works well for shallow transits/eclipses)
+bg_thresh       [4,4]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 
 # Background parameters
 bg_hw           8           # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -15,9 +15,9 @@ record_ypos     True        # Option to record the y position and width for each
 dqmask          True        # Mask pixels with an odd entry in the DQ array
 
 # Outlier rejection along time axis
-ff_outlier      True        # Set True to use full frame; set False to use only background region
-ff_thresh       [4,4]       # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
-bg_thresh       [4,4]       # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+ff_outlier      False       # Set False to use only background region (recommended for deep transits)
+                            # Set True to use full frame (works well for shallow transits/eclipses)
+bg_thresh       [4,4]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 
 # Background parameters
 bg_hw           7           # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -21,7 +21,7 @@ bg_thresh       [4,4]       # Background region double-iteration X-sigma thresho
 
 # Background parameters
 bg_hw           7           # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_deg          1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
+bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh        10          # X-sigma threshold for outlier rejection during background subtraction
 
 # Spectral extraction parameters

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -14,9 +14,13 @@ src_pos_type    gaussian    # Determine source position when not given in header
 record_ypos     True        # Option to record the y position and width for each integration (only records if src_pos_type is gaussian)
 dqmask          True        # Mask pixels with an odd entry in the DQ array
 
+# Outlier rejection along time axis
+ff_outlier      True        # Set True to use full frame; set False to use only background region
+ff_thresh       [4,4]       # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
+bg_thresh       [4,4]       # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+
 # Background parameters
 bg_hw           7           # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh       [10,10]     # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg          1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh        10          # X-sigma threshold for outlier rejection during background subtraction
 

--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -9,6 +9,9 @@ wave_min        1.5         # Minimum wavelength. Set to None to use the shortes
 wave_max        4.5         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
 allapers        False       # Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
+# Mannualy mask pixel columns by index number
+# mask_columns    []
+
 # Parameters for drift correction of 1D spectra
 recordDrift     False    # Set True to record drift/jitter in 1D spectra (always recorded if correctDrift is True)
 correctDrift    False   # Set True to correct drift/jitter in 1D spectra (not recommended for simulated data)

--- a/demos/JWST/S5_template.ecf
+++ b/demos/JWST/S5_template.ecf
@@ -24,7 +24,7 @@ ld_file_white    None  # Fully qualified path to the location of a limb darkenin
 old_fitparams   None # filename relative to topdir that points to a fitparams csv to resume where you left off (set to None to start from scratch)
 
 #lsq
-lsq_method      'Nelder-Mead' # The scipy.optimize.minimize optimization method to use
+lsq_method      'Powell' # The scipy.optimize.minimize optimization method to use
 lsq_tol         1e-6    # The tolerance for the scipy.optimize.minimize optimization method
 lsq_maxiter     None    # Maximum number of iterations to perform. Depending on the method each iteration may use several function evaluations. Set to None to use the default value
 

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -362,11 +362,15 @@ The plot below shows you which parts will be used for the background calculation
 
 .. image:: ../media/bg_hw.png
 
+ff_outlier
+'''''''''
+Set False to use only the background region when searching for outliers along the time axis (recommended for deep transits).  Set True to apply the outlier rejection routine to the full frame (works well for shallow transits/eclipses).  Be sure to check the percentage of pixels that were flagged while ``ff_outlier = True``; the value should be << 1% when ``bg_thresh = [5,5]``.  
+
 bg_thresh
 '''''''''
 Double-iteration X-sigma threshold for outlier rejection along time axis.
-The flux of every background pixel will be considered over time for the current data segment.
-e.g: ``bg_thresh = [5,5]``: Two iterations of 5-sigma clipping will be performed in time for every background pixel. Outliers will be masked and not considered in the background flux calculation.
+The flux of every full-frame or background pixel will be considered over time for the current data segment.
+e.g: ``bg_thresh = [5,5]``: Two iterations of 5-sigma clipping will be performed in time for every full-frame or background pixel. Outliers will be masked and not considered in the flux calculation.
 
 bg_deg
 ''''''

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -276,7 +276,6 @@ def flag_ff(data, meta, log):
     data : Xarray Dataset
         The updated Dataset object with outlier pixels flagged.
     '''
-    
     return nircam.flag_ff(data, meta, log)
 
 

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -257,6 +257,29 @@ def flag_bg(data, meta, log):
     return nircam.flag_bg(data, meta, log)
 
 
+def flag_ff(data, meta, log):
+    '''Outlier rejection of full frame along time axis.
+    For data with deep transits, there is a risk of masking good transit data.
+    Proceed with caution.
+
+    Parameters
+    ----------
+    data : Xarray Dataset
+        The Dataset object.
+    meta : eureka.lib.readECF.MetaClass
+        The metadata object.
+    log : logedit.Logedit
+        The current log.
+
+    Returns
+    -------
+    data : Xarray Dataset
+        The updated Dataset object with outlier pixels flagged.
+    '''
+    
+    return nircam.flag_ff(data, meta, log)
+
+
 def fit_bg(dataim, datamask, n, meta, isplots=0):
     """Fit for a non-uniform background.
 

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -206,7 +206,7 @@ def flag_ff(data, meta, log):
     prev_count = data.mask.values.sum()
 
     # Compute new pixel mask
-    data['mask'] = sigrej.sigrej(data.flux, meta.ff_thresh, data.mask, None)
+    data['mask'] = sigrej.sigrej(data.flux, meta.bg_thresh, data.mask, None)
 
     # Count difference in number of good pixels
     new_count = data.mask.values.sum()

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -213,8 +213,8 @@ def flag_ff(data, meta, log):
     diff_count = prev_count - new_count
     perc_rej = 100*(diff_count/size)
     log.writelog(f'    Flagged {perc_rej:.6f}% of pixels as bad.',
-                    mute=(not meta.verbose))
-    
+                 mute=(not meta.verbose))
+
     return data
 
 

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -160,15 +160,10 @@ def flag_bg(data, meta, log):
     log.writelog('  Performing background outlier rejection...',
                  mute=(not meta.verbose))
 
-    meta.bg_y2 = meta.src_ypos + meta.bg_hw
-    meta.bg_y1 = meta.src_ypos - meta.bg_hw
-
     bgdata1 = data.flux[:, :meta.bg_y1]
     bgmask1 = data.mask[:, :meta.bg_y1]
     bgdata2 = data.flux[:, meta.bg_y2:]
     bgmask2 = data.mask[:, meta.bg_y2:]
-    # FINDME: KBS removed estsig from inputs to speed up outlier detection.
-    # Need to test performance with and without estsig on real data.
     if hasattr(meta, 'use_estsig') and meta.use_estsig:
         bgerr1 = np.median(data.err[:, :meta.bg_y1])
         bgerr2 = np.median(data.err[:, meta.bg_y2:])
@@ -182,6 +177,44 @@ def flag_bg(data, meta, log):
     data['mask'][:, meta.bg_y2:] = sigrej.sigrej(bgdata2, meta.bg_thresh,
                                                  bgmask2, estsig2)
 
+    return data
+
+
+def flag_ff(data, meta, log):
+    '''Outlier rejection of full frame along time axis.
+    For data with deep transits, there is a risk of masking good transit data.
+    Proceed with caution.
+
+    Parameters
+    ----------
+    data : Xarray Dataset
+        The Dataset object.
+    meta : eureka.lib.readECF.MetaClass
+        The metadata object.
+    log : logedit.Logedit
+        The current log.
+
+    Returns
+    -------
+    data : Xarray Dataset
+        The updated Dataset object with outlier pixels flagged.
+    '''
+    log.writelog('  Performing full frame outlier rejection...',
+                 mute=(not meta.verbose))
+
+    size = data.mask.size
+    prev_count = data.mask.values.sum()
+
+    # Compute new pixel mask
+    data['mask'] = sigrej.sigrej(data.flux, meta.ff_thresh, data.mask, None)
+
+    # Count difference in number of good pixels
+    new_count = data.mask.values.sum()
+    diff_count = prev_count - new_count
+    perc_rej = 100*(diff_count/size)
+    log.writelog(f'    Flagged {perc_rej:.6f}% of pixels as bad.',
+                    mute=(not meta.verbose))
+    
     return data
 
 

--- a/src/eureka/S3_data_reduction/nirspec.py
+++ b/src/eureka/S3_data_reduction/nirspec.py
@@ -157,23 +157,7 @@ def flag_ff(data, meta, log):
     data : Xarray Dataset
         The updated Dataset object with outlier pixels flagged.
     '''
-    log.writelog('  Performing full frame outlier rejection...',
-                 mute=(not meta.verbose))
-
-    size = data.mask.size
-    prev_count = data.mask.values.sum()
-
-    # Compute new pixel mask
-    data['mask'] = sigrej.sigrej(data.flux, meta.ff_thresh, data.mask, None)
-
-    # Count difference in number of good pixels
-    new_count = data.mask.values.sum()
-    diff_count = prev_count - new_count
-    perc_rej = 100*(diff_count/size)
-    log.writelog(f'    Flagged {perc_rej:.6f}% of pixels as bad.',
-                 mute=(not meta.verbose))
-    
-    return data
+    return nircam.flag_ff(data, meta, log)
 
 
 def fit_bg(dataim, datamask, n, meta, isplots=0):

--- a/src/eureka/S3_data_reduction/nirspec.py
+++ b/src/eureka/S3_data_reduction/nirspec.py
@@ -171,7 +171,7 @@ def flag_ff(data, meta, log):
     diff_count = prev_count - new_count
     perc_rej = 100*(diff_count/size)
     log.writelog(f'    Flagged {perc_rej:.6f}% of pixels as bad.',
-                    mute=(not meta.verbose))
+                 mute=(not meta.verbose))
     
     return data
 

--- a/src/eureka/S3_data_reduction/nirspec.py
+++ b/src/eureka/S3_data_reduction/nirspec.py
@@ -121,8 +121,6 @@ def flag_bg(data, meta, log):
     bgmask1 = data.mask[:, :meta.bg_y1]
     bgdata2 = data.flux[:, meta.bg_y2:]
     bgmask2 = data.mask[:, meta.bg_y2:]
-    # FINDME: KBS removed estsig from inputs to speed up outlier detection.
-    # Need to test performance with and without estsig on real data.
     if hasattr(meta, 'use_estsig') and meta.use_estsig:
         # This might not be necessary for real data
         bgerr1 = np.ma.median(np.ma.masked_equal(data.err[:, :meta.bg_y1], 0))

--- a/src/eureka/S3_data_reduction/optspex.py
+++ b/src/eureka/S3_data_reduction/optspex.py
@@ -528,7 +528,7 @@ def clean_median_flux(data, meta, log, m):
         goodrow = medflux[j][~np.ma.getmaskarray(medflux[j])]
         if len(goodrow) > 0:
             f = spi.interp1d(x1, goodrow, 'linear',
-                            fill_value='extrapolate')
+                             fill_value='extrapolate')
             # f = spi.UnivariateSpline(x1, goodmed, k=1, s=None)
             interp_med[j] = f(xx)
         else:

--- a/src/eureka/S3_data_reduction/optspex.py
+++ b/src/eureka/S3_data_reduction/optspex.py
@@ -526,10 +526,14 @@ def clean_median_flux(data, meta, log, m):
     for j in range(ny):
         x1 = xx[~np.ma.getmaskarray(medflux[j])]
         goodrow = medflux[j][~np.ma.getmaskarray(medflux[j])]
-        f = spi.interp1d(x1, goodrow, 'linear',
-                         fill_value='extrapolate')
-        # f = spi.UnivariateSpline(x1, goodmed, k=1, s=None)
-        interp_med[j] = f(xx)
+        if len(goodrow) > 0:
+            f = spi.interp1d(x1, goodrow, 'linear',
+                            fill_value='extrapolate')
+            # f = spi.UnivariateSpline(x1, goodmed, k=1, s=None)
+            interp_med[j] = f(xx)
+        else:
+            log.writelog(f'    Row {j}: Interpolation failed. No good pixels.')
+            interp_med[j] = medflux[j]
 
     if meta.window_len > 1:
         # Apply smoothing filter along dispersion direction

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -332,7 +332,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
 
                 if not meta.photometry:
                     # Perform outlier rejection of
-                    # spectral region along time axis
+                    # full frame along time axis
                     if hasattr(meta, 'ff_outlier') and meta.ff_outlier:
                         data = inst.flag_ff(data, meta, log)
 

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -331,6 +331,11 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 data, meta = b2f.convert_to_e(data, meta, log)
 
                 if not meta.photometry:
+                    # Perform outlier rejection of
+                    # spectral region along time axis
+                    if hasattr(meta, 'ff_outlier') and meta.ff_outlier:
+                        data = inst.flag_ff(data, meta, log)
+
                     # Compute clean median frame
                     data = optspex.clean_median_flux(data, meta, log, m)
 
@@ -342,7 +347,11 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
 
                     # Perform outlier rejection of
                     # sky background along time axis
-                    data = inst.flag_bg(data, meta, log)
+                    meta.bg_y2 = meta.src_ypos + meta.bg_hw
+                    meta.bg_y1 = meta.src_ypos - meta.bg_hw
+                    if (not hasattr(meta, 'ff_outlier')
+                            or meta.ff_outlier == False):
+                        data = inst.flag_bg(data, meta, log)
 
                     # Do the background subtraction
                     data = bg.BGsubtraction(data, meta, log, 

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -350,7 +350,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                     meta.bg_y2 = meta.src_ypos + meta.bg_hw
                     meta.bg_y1 = meta.src_ypos - meta.bg_hw
                     if (not hasattr(meta, 'ff_outlier')
-                            or meta.ff_outlier == False):
+                            or meta.ff_outlier is False):
                         data = inst.flag_bg(data, meta, log)
 
                     # Do the background subtraction

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -350,7 +350,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                     meta.bg_y2 = meta.src_ypos + meta.bg_hw
                     meta.bg_y1 = meta.src_ypos - meta.bg_hw
                     if (not hasattr(meta, 'ff_outlier')
-                            or meta.ff_outlier is False):
+                            or not meta.ff_outlier):
                         data = inst.flag_bg(data, meta, log)
 
                     # Do the background subtraction

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -603,7 +603,7 @@ def manmask(data, meta, log):
                  mute=(not meta.verbose))
     for i in range(len(meta.manmask)):
         colstart, colend, rowstart, rowend = meta.manmask[i]
-        data['mask'][rowstart:rowend, colstart:colend] = 0
+        data['mask'][:, rowstart:rowend, colstart:colend] = 0
 
     return data
 

--- a/tests/MIRI_ecfs/S3_MIRI.ecf
+++ b/tests/MIRI_ecfs/S3_MIRI.ecf
@@ -12,9 +12,13 @@ src_pos_type gaussian   # Determine source position when not given in header (Op
 record_ypos  True        # Option to record the y position and width for each integration (only records if src_pos_type is gaussian)
 dqmask       True        # Mask pixels with an odd entry in the DQ array
 
+# Outlier rejection along time axis
+# ff_outlier      False # Set True to use full frame; set False to use only background region
+ff_thresh       [5,5]   # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
+bg_thresh       [5,5]   # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+
 # Background parameters
 bg_hw           10          # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
 

--- a/tests/MIRI_ecfs/S3_MIRI.ecf
+++ b/tests/MIRI_ecfs/S3_MIRI.ecf
@@ -13,9 +13,9 @@ record_ypos  True        # Option to record the y position and width for each in
 dqmask       True        # Mask pixels with an odd entry in the DQ array
 
 # Outlier rejection along time axis
-# ff_outlier      False # Set True to use full frame; set False to use only background region
-ff_thresh       [5,5]   # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
-bg_thresh       [5,5]   # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+ff_outlier      False       # Set False to use only background region (recommended for deep transits)
+                            # Set True to use full frame (works well for shallow transits/eclipses)
+bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 
 # Background parameters
 bg_hw           10          # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/tests/NIRCam_ecfs/S3_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S3_NIRCam.ecf
@@ -12,9 +12,13 @@ src_pos_type gaussian   # Determine source position when not given in header (Op
 record_ypos True        # Option to record the y position and width for each integration (only records if src_pos_type is gaussian)
 dqmask      True        # Mask pixels with an odd entry in the DQ array
 
+# Outlier rejection along time axis
+ff_outlier      True    # Set True to use full frame; set False to use only background region
+ff_thresh       [5,5]   # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
+bg_thresh       [5,5]   # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+
 # Background parameters
 bg_hw       12          # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh   [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
 

--- a/tests/NIRCam_ecfs/S3_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S3_NIRCam.ecf
@@ -13,9 +13,9 @@ record_ypos True        # Option to record the y position and width for each int
 dqmask      True        # Mask pixels with an odd entry in the DQ array
 
 # Outlier rejection along time axis
-ff_outlier      True    # Set True to use full frame; set False to use only background region
-ff_thresh       [5,5]   # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
-bg_thresh       [5,5]   # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+ff_outlier      True        # Set False to use only background region (recommended for deep transits)
+                            # Set True to use full frame (works well for shallow transits/eclipses)
+bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 
 # Background parameters
 bg_hw       12          # Half-width of exclusion region for BG subtraction (relative to source position)

--- a/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
+++ b/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
@@ -12,9 +12,13 @@ src_pos_type gaussian   # Determine source position when not given in header (Op
 record_ypos True        # Option to record the y position and width for each integration (only records if src_pos_type is gaussian)
 dqmask      True        # Mask pixels with an odd entry in the DQ array
 
+# Outlier rejection along time axis
+ff_outlier      False   # Set True to use full frame; set False to use only background region
+ff_thresh       [5,5]   # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
+bg_thresh       [15,15] # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+
 # Background parameters
 bg_hw       10         # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_thresh   [15,15]    # Double-iteration X-sigma threshold for outlier rejection along time axis
 bg_deg      0          # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh    2          # X-sigma threshold for outlier rejection during background subtraction
 

--- a/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
+++ b/tests/NIRSpec_ecfs/S3_NIRSpec.ecf
@@ -13,9 +13,9 @@ record_ypos True        # Option to record the y position and width for each int
 dqmask      True        # Mask pixels with an odd entry in the DQ array
 
 # Outlier rejection along time axis
-ff_outlier      False   # Set True to use full frame; set False to use only background region
-ff_thresh       [5,5]   # Full Frame double-iteration X-sigma threshold for outlier rejection along time axis
-bg_thresh       [15,15] # Background region double-iteration X-sigma threshold for outlier rejection along time axis
+ff_outlier      False       # Set False to use only background region (recommended for deep transits)
+                            # Set True to use full frame (works well for shallow transits/eclipses)
+bg_thresh       [15,15]     # Double-iteration X-sigma threshold for outlier rejection along time axis
 
 # Background parameters
 bg_hw       10         # Half-width of exclusion region for BG subtraction (relative to source position)


### PR DESCRIPTION
Instead of only performing outlier rejection along the time axis within the BG region, this added functionality allows the user to perform outlier rejection on the entire frame.  This step (when enabled) takes place before computing the median frame, so has the potential to yield a more reliable median frame.  The risk is that, for deep transits, this routine could flag in-transit points as bad. So, this method should be used with caution.

I have updated the demos and test directories, but not the html file.