### PR TITLE
Bias Correction

### DIFF
--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -47,15 +47,16 @@ bg_y2 				26
 bg_deg 				0 
 p3thresh			5
 verbose				True
-isplots 			1
-hide_plots    True
+isplots_S1 			3
+nplots              5
+hide_plots          True
 
 #mask curved traces
 masktrace           True
 window_len          11
 expand_mask         8
 ignore_low          600
-ignore_hi						None
+ignore_hi			None
 
 #manual reference pixel correction for PRISM
 refpix_corr      False

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -25,9 +25,12 @@ skip_gain_scale     False
 #Pipeline stages parameters
 jump_rejection_threshold  4.0 #float, default is 4.0, CR sigma rejection threshold
 
-#Custom bias frames
+#Bias
+bias_correction     None    # Bias correction options: [mean, group_level, smooth, None]
+bias_group          1       # Group number options: [1, 2, ..., each]
+bias_smooth_length  201     # Window length when using 'smooth' bias correction
 custom_bias         False
-superbias_file	   /path/to/custom/superbias/fits/file
+superbias_file	    /path/to/custom/superbias/fits/file
 
 #Saturation
 update_sat_flags    False   #Wheter to update the saturation flags more aggressively

--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -9,6 +9,9 @@ wave_min        1.5         # Minimum wavelength. Set to None to use the shortes
 wave_max        4.5         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
 allapers        False       # Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
+# Mannualy mask pixel columns by index number
+# mask_columns  []
+
 # Parameters for drift correction of 1D spectra
 recordDrift     False    # Set True to record drift/jitter in 1D spectra (always recorded if correctDrift is True)
 correctDrift    False   # Set True to correct drift/jitter in 1D spectra (not recommended for simulated data)

--- a/docs/media/S1_template.ecf
+++ b/docs/media/S1_template.ecf
@@ -25,6 +25,43 @@ skip_gain_scale     False
 #Pipeline stages parameters
 jump_rejection_threshold  4.0 #float, default is 4.0, CR sigma rejection threshold
 
+#Bias
+bias_correction     None    # Bias correction options: [mean, group_level, smooth, None]
+bias_group          1       # Group number options: [1, 2, ..., each]
+bias_smooth_length  201     # Window length when using 'smooth' bias correction
+custom_bias         False
+superbias_file	    /path/to/custom/superbias/fits/file
+
+#Saturation
+update_sat_flags    False   #Wheter to update the saturation flags more aggressively
+expand_prev_group   False   #Expand saturation flags to previous group
+dq_sat_mode         percentile # options: [percentile, min, defined]
+dq_sat_percentile   50      # percentile of the entire time series to use to define the saturation mask (50=median)
+dq_sat_columns	    [[0, 0], [0,0], [0,0], [0,0], [0,0]]  #for dq_sat_mode = defined, user defined saturated columns 
+
+#Background subtraction
+grouplevel_bg 		True
+ncpu				6
+bg_y1 				6
+bg_y2 				26
+bg_deg 				0 
+p3thresh			5
+verbose				True
+isplots 			1
+hide_plots    True
+
+#mask curved traces
+masktrace           True
+window_len          11
+expand_mask         8
+ignore_low          600
+ignore_hi						None
+
+#manual reference pixel correction for PRISM
+refpix_corr      False
+npix_top         8
+npix_bot         8
+
 # Project directory
 topdir              /home/User/Data/JWST-Sim/NIRSpec/
 

--- a/docs/media/S4_template.ecf
+++ b/docs/media/S4_template.ecf
@@ -9,6 +9,9 @@ wave_min        1.5         # Minimum wavelength. Set to None to use the shortes
 wave_max        4.5         # Maximum wavelength. Set to None to use the longest extracted wavelength from Stage 3.
 allapers        False       # Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
+# Mannualy mask pixel columns by index number
+# mask_columns  []
+
 # Parameters for drift correction of 1D spectra
 recordDrift     False    # Set True to record drift/jitter in 1D spectra (always recorded if correctDrift is True)
 correctDrift    False   # Set True to correct drift/jitter in 1D spectra (not recommended for simulated data)

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -37,15 +37,15 @@ If True, skip the named step.
 
 bias_correction
 '''''''''''''''''
-Method applied to correct the superbias using a scale factor (SF).  Here, SF = (median of group)/(median of superbias), using a background region that is ``expand_mask`` pixels from the measured trace.  The option ``None`` applies no correction; ``group_level`` computes SF for every integration in ``bias_group``; ``smooth`` applies a smoothing filter of length ``bias_smooth_length`` to the ``group_level`` SF values; and ``mean`` uses the mean SF over all integrations.  We currently recommend using ``smooth`` with a ``bias_smooth_length`` that is ~15 minutes.
+Method applied to correct the superbias using a scale factor (SF) when no bias pixels are available (i.e., with NIRSpec).  Here, SF = (median of group)/(median of superbias), using a background region that is ``expand_mask`` pixels from the measured trace.  The default option ``None`` applies no correction; ``group_level`` computes SF for every integration in ``bias_group``; ``smooth`` applies a smoothing filter of length ``bias_smooth_length`` to the ``group_level`` SF values; and ``mean`` uses the mean SF over all integrations.  For NIRSpec, we currently recommend using ``smooth`` with a ``bias_smooth_length`` that is ~15 minutes.
 
 bias_group
 '''''''''''''''''
-Integer or string.  Specifies which group number should be used when applying the bias correction.  We currently recommend using the first group (``bias_group`` = 1).  There is no group 0.  Users can also specify ``each``, which computes a unique bias correction for each group.
+Integer or string.  Specifies which group number should be used when applying the bias correction.  For NIRSpec, we currently recommend using the first group (``bias_group`` = 1).  There is no group 0.  Users can also specify ``each``, which computes a unique bias correction for each group.
 
 bias_smooth_length
 '''''''''''''''''
-Integer. When ``bias_correction = smooth``, this value is used as the window length during smoothing.
+Integer. When ``bias_correction = smooth``, this value is used as the window length during smoothing across integrations.
 
 custom_bias
 '''''''''''''''''

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -35,6 +35,18 @@ If True, skip the named step.
 .. note::
    Note that some instruments and observing modes might skip a step either way! See the `calwebb_detector1 docs <https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_detector1.html>`__ for the list of steps run for each instrument/mode by the STScI's JWST pipeline.
 
+bias_correction
+'''''''''''''''''
+Method applied to correct the superbias using a scale factor (SF).  Here, SF = (median of group)/(median of superbias), using a background region that is ``expand_mask`` pixels from the measured trace.  The option ``None`` applies no correction; ``group_level`` computes SF for every integration in ``bias_group``; ``smooth`` applies a smoothing filter of length ``bias_smooth_length`` to the ``group_level`` SF values; and ``mean`` uses the mean SF over all integrations.  We currently recommend using ``smooth`` with a ``bias_smooth_length`` that is ~15 minutes.
+
+bias_group
+'''''''''''''''''
+Integer or string.  Specifies which group number should be used when applying the bias correction.  We currently recommend using the first group (``bias_group`` = 1).  There is no group 0.  Users can also specify ``each``, which computes a unique bias correction for each group.
+
+bias_smooth_length
+'''''''''''''''''
+Integer. When ``bias_correction = smooth``, this value is used as the window length during smoothing.
+
 custom_bias
 '''''''''''''''''
 Boolean, allows user to supply a custom bias file and overwrite the default file
@@ -91,7 +103,11 @@ verbose
 '''''''''''''''''
 See Stage 3 inputs
 
-isplots
+isplots_S1
+'''''''''''''''''
+Sets how many plots should be saved when running Stage 1. A full description of these outputs is available here: :ref:`Stage 3 Output <s3-out>`
+
+nplots
 '''''''''''''''''
 See Stage 3 inputs
 
@@ -109,7 +125,7 @@ Smoothing length for the trace location
 
 expand_mask
 '''''''''''''''''
-Aperture around the trace to mask
+Aperture (in pixels) around the trace to mask
 
 ignore_low
 '''''''''''''''''
@@ -551,6 +567,11 @@ Start and End of the wavelength range being considered. Set to None to use the s
 allapers
 ''''''''
 If True, run S4 on all of the apertures considered in S3. Otherwise the code will use the only or newest S3 outputs found in the inputdir. To specify a particular S3 save file, ensure that "inputdir" points to the procedurally generated folder containing that save file (e.g. set inputdir to /Data/JWST-Sim/NIRCam/Stage3/S3_2021-11-08_nircam_wfss_ap10_bg10_run1/).
+
+
+mask_columns
+''''''''
+List of pixel columns that should not be used when constructing a light curve.  Absolute (not relative) pixel columns should be used. Figure 3102 is very helpful for identifying bad pixel columns.
 
 
 recordDrift

--- a/src/eureka/S1_detector_processing/bias_sub.py
+++ b/src/eureka/S1_detector_processing/bias_sub.py
@@ -1,0 +1,131 @@
+#
+#  Module for subtracting a super-bias image from science data sets
+#
+
+import numpy as np
+import logging
+from jwst.lib import reffile_utils
+from .group_level import mask_trace
+from ..lib.astropytable import savetable_S1
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+def do_correction(input_model, bias_model, meta, log):
+    """
+    Short Summary
+    -------------
+    Execute all tasks for Super-Bias Subtraction
+
+    Parameters
+    ----------
+    input_model: data model object
+        science data to be corrected
+
+    bias_model: super-bias model object
+        bias data
+
+    Returns
+    -------
+    output_model: data model object
+        bias-subtracted science data
+
+    """
+    log.writelog('  Subtracting bias using scaled superbias.')
+
+    # Check for subarray mode and extract subarray from the
+    # bias reference data if necessary
+    if not reffile_utils.ref_matches_sci(input_model, bias_model):
+        bias_model = reffile_utils.get_subarray_model(input_model, bias_model)
+
+    # Compute trace mask, where ones are good background regions
+    input_model = mask_trace(input_model, log, meta)
+    trace_mask = input_model.trace_mask
+
+    # Compute median of bias frame outside of trace
+    bias_median = np.nanmedian(bias_model.data[np.where(trace_mask)])
+
+    # Compute median of each integration/group outside of trace
+    # Using double-for loop to avoid heavy memory usage
+    nint, ngroup, nrow, ncol = input_model.data.shape
+    scale_factor = np.zeros((nint, ngroup))
+    for ii in range(nint):
+        data = input_model.data[ii]
+        for jj in range(ngroup):
+            data_median = np.nanmedian(data[jj][np.where(trace_mask)])
+            scale_factor[ii, jj] = data_median/bias_median
+    mean_scale_factor = np.mean(scale_factor)
+    log.writelog(f'  Mean bias scale factor: {mean_scale_factor}')
+    
+    # Replace NaN's in the superbias with zeros
+    bias_model.data[np.isnan(bias_model.data)] = 0.0
+
+    # Scale superbias frame (used for zeroframe)
+    bias_model.data *= mean_scale_factor
+
+    # Create 4D bias array for each integration/group and apply scale factor 
+    bias_data = np.ones((nint, ngroup, nrow, ncol)) * \
+        bias_model.data[np.newaxis, np.newaxis, :, :]
+    bias_data *= scale_factor[:, :, np.newaxis, np.newaxis]
+
+    # Get segment number
+    segment = str(input_model.meta.exposure.segment_number).zfill(3)
+
+    # Save scale factor to ECSV file
+    fname = meta.outputdir+"S1_seg"+segment+"_BiasScaleFactor.ecsv"
+    savetable_S1(fname, scale_factor)
+    
+    # Subtract the bias data from the science data
+    output_model = subtract_bias(input_model, bias_model, bias_data)
+
+    output_model.meta.cal_step.superbias = 'COMPLETE'
+
+    return output_model
+
+
+def subtract_bias(input, bias, bias_data=None):
+    """
+    Subtracts a superbias image from a science data set, subtracting the
+    superbias from each group of each integration in the science data.
+    The DQ flags in the bias reference image are propagated into the science
+    data pixeldq array. The error array is unchanged.
+
+    Parameters
+    ----------
+    input: data model object
+        the input science data
+
+    bias: superbias model object
+        the superbias image data
+
+    Returns
+    -------
+    output: data model object
+        bias-subtracted science data
+
+    """
+
+    # Create output as a copy of the input science data model
+    output = input.copy()
+
+    # combine the science and superbias DQ arrays
+    output.pixeldq = np.bitwise_or(input.pixeldq, bias.dq)
+
+    # Subtract the superbias image from all groups and integrations
+    # of the science data
+    if bias_data is None:
+        # Same bias frame for all groups/integrations
+        output.data -= bias.data
+    else:
+        # Different bias frames for each group/integration
+        output.data -= bias_data
+
+    # If ZEROFRAME is present, subtract the super bias.  Zero values
+    # indicate bad data, so should be kept zero.
+    if input.meta.exposure.zero_frame:
+        wh_zero = np.where(output.zeroframe == 0.)
+        output.zeroframe -= bias.data
+        output.zeroframe[wh_zero] = 0.  # Zero values indicate unusable data
+
+    return output

--- a/src/eureka/S1_detector_processing/bias_sub.py
+++ b/src/eureka/S1_detector_processing/bias_sub.py
@@ -86,12 +86,12 @@ def do_correction(input_model, bias_model, meta, log):
             if isinstance(meta.bias_group, int):
                 # Scale superbias frame using single value for all groups
                 jj = meta.bias_group
-                assert jj >= 0, f"Number of groups should be >=0, got: {jj}"
-                assert jj < ngroup, f"Number of groups should be <{ngroup}" + \
+                assert jj > 0, f"Group number should be >0, got: {jj}"
+                assert jj <= ngroup, f"Group number should be <={ngroup}" + \
                     ", got: {jj}"
                 log.writelog('  Applying mean bias correction using ' +
                              f'group {jj}.')
-                bias_model.data *= mean_scale_factor[jj]
+                bias_model.data *= mean_scale_factor[jj-1]
             elif meta.bias_group == "each":
                 # Scale superbias frame using means values for each group
                 log.writelog('  Applying mean bias correction to each group.')
@@ -101,7 +101,7 @@ def do_correction(input_model, bias_model, meta, log):
             else:
                 raise ValueError('Incorrect meta.bias_group value: ' + 
                                  f'{meta.bias_group}. Should be ' +
-                                 '[0, 1, 2, ..., each].')
+                                 '[1, 2, ..., each].')
         elif (meta.bias_correction == "group_level") or \
              (meta.bias_correction == "smooth"):
             # Apply correction for zeroframe
@@ -109,12 +109,12 @@ def do_correction(input_model, bias_model, meta, log):
             if isinstance(meta.bias_group, int):
                 # Scale superbias frame using values from one group
                 jj = meta.bias_group
-                assert jj >= 0, f"Number of groups should be >=0, got: {jj}"
-                assert jj < ngroup, f"Number of groups should be <{ngroup}" + \
+                assert jj > 0, f"Group number should be >0, got: {jj}"
+                assert jj <= ngroup, f"Group number should be <={ngroup}" + \
                     ", got: {jj}"
                 log.writelog('  Applying group-level bias correction using ' +
                              f'group {jj}.')
-                bias_data *= scale_factor[:, jj, np.newaxis, 
+                bias_data *= scale_factor[:, jj-1, np.newaxis, 
                                           np.newaxis, np.newaxis]
             elif meta.bias_group == "each":
                 # Scale superbias frame using values from each group
@@ -124,7 +124,7 @@ def do_correction(input_model, bias_model, meta, log):
             else:
                 raise ValueError('Incorrect meta.bias_group value: ' + 
                                  f'{meta.bias_group}. Should be ' +
-                                 '[0, 1, 2, ..., each].')
+                                 '[1, 2, ..., each].')
         else:
             log.writelog('  No bias correction applied.')
             bias_data = None

--- a/src/eureka/S1_detector_processing/bias_sub.py
+++ b/src/eureka/S1_detector_processing/bias_sub.py
@@ -1,6 +1,6 @@
-#
-#  Module for subtracting a super-bias image from science data sets
-#
+# Module for subtracting a super-bias image from science data sets
+# This is based on the superbias_step from the JWST pipeline v1.8.0
+# adapted by Kevin Stevenson, Feb 2023
 
 import numpy as np
 import logging

--- a/src/eureka/S1_detector_processing/bias_sub.py
+++ b/src/eureka/S1_detector_processing/bias_sub.py
@@ -15,8 +15,6 @@ log.setLevel(logging.DEBUG)
 
 def do_correction(input_model, bias_model, meta, log):
     """
-    Short Summary
-    -------------
     Execute all tasks for Super-Bias Subtraction
 
     Parameters
@@ -130,7 +128,7 @@ def do_correction(input_model, bias_model, meta, log):
             bias_data = None
     except Exception as error:
         log.writelog(repr(error))
-        return None
+        raise error
 
     # Subtract the bias data from the science data
     output_model = subtract_bias(input_model, bias_model, bias_data)

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -7,6 +7,7 @@ from astropy.io import fits
 from jwst.pipeline.calwebb_detector1 import Detector1Pipeline
 
 from eureka.S1_detector_processing.ramp_fitting import Eureka_RampFitStep
+from eureka.S1_detector_processing.superbias import Eureka_SuperBiasStep
 
 from ..lib import logedit, util
 from ..lib import manageevent as me
@@ -196,6 +197,11 @@ class EurekaS1Pipeline(Detector1Pipeline):
             self.lastframe.skip = meta.skip_lastframe
             self.rscd.skip = meta.skip_rscd
 
+        # Define superbias offset procedure
+        self.superbias = Eureka_SuperBiasStep()
+        self.superbias.s1_meta = meta
+        self.superbias.s1_log = log
+        
         # Define ramp fitting procedure
         self.ramp_fit = Eureka_RampFitStep()
         self.ramp_fit.algorithm = meta.ramp_fit_algorithm

--- a/src/eureka/S1_detector_processing/superbias.py
+++ b/src/eureka/S1_detector_processing/superbias.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 # This is based on the superbias_step from the JWST pipeline v1.8.0
-# adapted by Kevin Stevenson, Feb 2021
+# adapted by Kevin Stevenson, Feb 2023
 
 
 from jwst.stpipe import Step

--- a/src/eureka/S1_detector_processing/superbias.py
+++ b/src/eureka/S1_detector_processing/superbias.py
@@ -1,0 +1,64 @@
+#! /usr/bin/env python
+
+# This is based on the superbias_step from the JWST pipeline v1.8.0
+# adapted by Kevin Stevenson, Feb 2021
+
+
+from jwst.stpipe import Step
+from jwst import datamodels
+# from jwst.superbias import bias_sub
+from . import bias_sub
+# import numpy as np
+# from functools import partial
+# import warnings
+import logging
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+__all__ = ["Eureka_SuperBiasStep"]
+
+
+class Eureka_SuperBiasStep(Step):
+    """This step is an alternative to the jwst pipeline superbias. 
+    Performs super-bias subtraction by subtracting scaled super-bias 
+    reference data from the input science data model at the group level.
+    """
+
+    class_alias = "superbias"
+
+    spec = """
+
+    """
+
+    reference_file_types = ['superbias']
+
+    def process(self, input):
+
+        # Open the input data model
+        with datamodels.RampModel(input) as input_model:
+
+            # Get the name of the superbias reference file to use
+            self.bias_name = self.get_reference_file(input_model, 'superbias')
+            self.log.info('Using SUPERBIAS reference file %s', self.bias_name)
+
+            # Check for a valid reference file
+            if self.bias_name == 'N/A':
+                self.log.warning('No SUPERBIAS reference file found')
+                self.log.warning('Superbias step will be skipped')
+                result = input_model.copy()
+                result.meta.cal_step.superbias = 'SKIPPED'
+                return result
+
+            # Open the superbias ref file data model
+            bias_model = datamodels.SuperBiasModel(self.bias_name)
+
+            # Do the bias subtraction
+            result = bias_sub.do_correction(input_model, bias_model, 
+                                            self.s1_meta, self.s1_log)
+
+            # Close the superbias reference file model and
+            # set the step status to complete
+            bias_model.close()
+            result.meta.cal_step.superbias = 'COMPLETE'
+
+        return result

--- a/src/eureka/lib/astropytable.py
+++ b/src/eureka/lib/astropytable.py
@@ -3,6 +3,34 @@ from astropy.io import ascii
 import numpy as np
 
 
+def savetable_S1(filename, scale_factor):
+    """Save the scale factor from Stage 1 as an ECSV.
+
+    Parameters
+    ----------
+    filename : str
+        The fully qualified filename that the results will be stored in.
+    scale_factor : ndarray (2D)
+        The bias scale factor of dimension nints by ngroup
+
+    Raises
+    ------
+    ValueError
+        There was a shape mismatch between your arrays
+    """
+    nint, ngroup = scale_factor.shape
+
+    names = []
+    for ii in range(1,ngroup+1):
+        names.append(f'group{ii}')
+    names = tuple(names)
+
+    table = QTable(scale_factor, names=names)
+    ascii.write(table, filename, format='ecsv', overwrite=True,
+                fast_writer=True)
+    return
+
+
 def savetable_S5(filename, time, wavelength, bin_width, lcdata, lcerr,
                  individual_models, model, residuals):
     """Save the results from Stage 5 as an ECSV file.

--- a/src/eureka/lib/astropytable.py
+++ b/src/eureka/lib/astropytable.py
@@ -21,7 +21,7 @@ def savetable_S1(filename, scale_factor):
     nint, ngroup = scale_factor.shape
 
     names = []
-    for ii in range(1,ngroup+1):
+    for ii in range(1, ngroup+1):
         names.append(f'group{ii}')
     names = tuple(names)
 


### PR DESCRIPTION
This PR modifies/overrides the JWST pipeline's superbias step (within Stage 1) to apply a scale factor correction.  There are numerous options available in the ECF that can be applied, but the general procedure is the same.  The code always computes a scale factor (SF) correction as follows: SF = (median of group)/(median of superbias), using a background region that is `meta.expand_mask`  pixels from the measured trace.  Depending on `meta.bias_correction` (options include: mean, group_level, smooth, None) `and meta.bias_group` (options include: 1, 2, ..., each), the code applies various corrections to the superbias before subtracting from the data.