### PR TITLE
Added NIRCam Photometry citation (Schlawin+ 2023)

### DIFF
--- a/src/eureka/lib/citations.py
+++ b/src/eureka/lib/citations.py
@@ -277,10 +277,23 @@ CITATIONS = {
         }"""],
     "nircam_photometry":
         [r"""@ARTICLE{schlawin2023,
-            author = {{Schlawin}, Everett and {Beatty}, Thomas and {Brooks}, Brian and {Nikolov}, Nikolay K. and {Greene}, Thomas P. and {Espinoza}, N{\'e}stor and {Glidic}, Kayli and {Baka}, Keith and {Egami}, Eiichi and {Stansberry}, John and {Boyer}, Martha and {Gennaro}, Mario and {Leisenring}, Jarron and {Hilbert}, Bryan and {Misselt}, Karl and {Kelly}, Doug and {Canipe}, Alicia and {Beichman}, Charles and {Correnti}, Matteo and {Knight}, J. Scott and {Jurling}, Alden and {Perrin}, Marshall D. and {Feinberg}, Lee D. and {McElwain}, Michael W. and {Bond}, Nicholas and {Ciardi}, David and {Kendrew}, Sarah and {Rieke}, Marcia},
-                title = "{JWST NIRCam Defocused Imaging: Photometric Stability Performance and How It Can Sense Mirror Tilts}",
+            author = {{Schlawin}, Everett and {Beatty}, Thomas and {Brooks}, 
+            Brian and {Nikolov}, Nikolay K. and {Greene}, Thomas P. and 
+            {Espinoza}, N{\'e}stor and {Glidic}, Kayli and {Baka}, Keith and 
+            {Egami}, Eiichi and {Stansberry}, John and {Boyer}, Martha and 
+            {Gennaro}, Mario and {Leisenring}, Jarron and {Hilbert}, Bryan and 
+            {Misselt}, Karl and {Kelly}, Doug and {Canipe}, Alicia and 
+            {Beichman}, Charles and {Correnti}, Matteo and {Knight}, J. Scott 
+            and {Jurling}, Alden and {Perrin}, Marshall D. and {Feinberg}, 
+            Lee D. and {McElwain}, Michael W. and {Bond}, Nicholas and 
+            {Ciardi}, David and {Kendrew}, Sarah and {Rieke}, Marcia},
+                title = "{JWST NIRCam Defocused Imaging: Photometric Stability 
+                Performance and How It Can Sense Mirror Tilts}",
             journal = {\pasp},
-            keywords = {Exoplanet atmospheres, Space vehicle instruments, Time series analysis, Multiple mirror telescopes, 487, 1548, 1916, 1080, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Earth and Planetary Astrophysics},
+            keywords = {Exoplanet atmospheres, Space vehicle instruments, 
+            Time series analysis, Multiple mirror telescopes, 487, 1548, 
+            1916, 1080, Astrophysics - Instrumentation and Methods for 
+            Astrophysics, Astrophysics - Earth and Planetary Astrophysics},
                 year = 2023,
                 month = jan,
             volume = {135},

--- a/src/eureka/lib/citations.py
+++ b/src/eureka/lib/citations.py
@@ -275,6 +275,25 @@ CITATIONS = {
             adsurl = {https://ui.adsabs.harvard.edu/abs/2017JATIS...3c5001G},
             adsnote = {Provided by the SAO/NASA Astrophysics Data System}
         }"""],
+    "nircam_photometry":
+        [r"""@ARTICLE{schlawin2023,
+            author = {{Schlawin}, Everett and {Beatty}, Thomas and {Brooks}, Brian and {Nikolov}, Nikolay K. and {Greene}, Thomas P. and {Espinoza}, N{\'e}stor and {Glidic}, Kayli and {Baka}, Keith and {Egami}, Eiichi and {Stansberry}, John and {Boyer}, Martha and {Gennaro}, Mario and {Leisenring}, Jarron and {Hilbert}, Bryan and {Misselt}, Karl and {Kelly}, Doug and {Canipe}, Alicia and {Beichman}, Charles and {Correnti}, Matteo and {Knight}, J. Scott and {Jurling}, Alden and {Perrin}, Marshall D. and {Feinberg}, Lee D. and {McElwain}, Michael W. and {Bond}, Nicholas and {Ciardi}, David and {Kendrew}, Sarah and {Rieke}, Marcia},
+                title = "{JWST NIRCam Defocused Imaging: Photometric Stability Performance and How It Can Sense Mirror Tilts}",
+            journal = {\pasp},
+            keywords = {Exoplanet atmospheres, Space vehicle instruments, Time series analysis, Multiple mirror telescopes, 487, 1548, 1916, 1080, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Earth and Planetary Astrophysics},
+                year = 2023,
+                month = jan,
+            volume = {135},
+            number = {1043},
+                eid = {018001},
+                pages = {018001},
+                doi = {10.1088/1538-3873/aca718},
+        archivePrefix = {arXiv},
+            eprint = {2211.16727},
+        primaryClass = {astro-ph.IM},
+            adsurl = {https://ui.adsabs.harvard.edu/abs/2023PASP..135a8001S},
+            adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+        }"""],
     "niriss": 
         [r"""@ARTICLE{willott2022,
             author = {{Willott}, Chris J. and {Doyon}, Ren{\'e} and {Albert}, 

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -718,8 +718,8 @@ def make_citations(meta, stage=None):
     # check for nircam photometry in S3
     if stage == 3:
         if hasattr(meta, 'inst') and hasattr(meta, "photometry"):
-                if meta.photometry and meta.inst == "nircam":
-                        other_cites = other_cites + ["nircam_photometry"]
+            if meta.photometry and meta.inst == "nircam":
+                other_cites = other_cites + ["nircam_photometry"]
 
     if stage == 5:
         # concat non-lsq fit methods (emcee/dynesty) to the citation list

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -715,6 +715,12 @@ def make_citations(meta, stage=None):
     # in S5, extract fitting methods/myfuncs to grab citations
     other_cites = []
     
+    # check for nircam photometry in S3
+    if stage == 3:
+        if hasattr(meta, 'inst') and hasattr(meta, "photometry"):
+                if meta.photometry and meta.inst == "nircam":
+                        other_cites = other_cites + ["nircam_photometry"]
+
     if stage == 5:
         # concat non-lsq fit methods (emcee/dynesty) to the citation list
         if "emcee" in meta.fit_method:

--- a/tests/test_Photometry_NIRCam.py
+++ b/tests/test_Photometry_NIRCam.py
@@ -1,13 +1,15 @@
-# Last Updated: 2022-08-16
+# Last Updated: 2023-03-04
 
 import sys
 import os
 from importlib import reload
 import time as time_pkg
 
+import numpy as np
+
 sys.path.insert(0, '..'+os.sep+'src'+os.sep)
 from eureka.lib.readECF import MetaClass
-from eureka.lib.util import pathdirectory
+from eureka.lib.util import COMMON_IMPORTS, pathdirectory
 import eureka.lib.plots
 # try:
 #     from eureka.S2_calibrations import s2_calibrate as s2
@@ -51,12 +53,18 @@ def test_NIRCam(capsys):
     assert os.path.exists(name)
     assert os.path.exists(name+os.sep+'figs')
 
+    s3_cites = np.union1d(COMMON_IMPORTS[2], ["nircam", "nircam_photometry"])
+    assert np.array_equal(s3_meta.citations, s3_cites)
+
     # run assertions for S4
     meta.outputdir_raw = (f'data{os.sep}Photometry{os.sep}NIRCam{os.sep}'
                           f'Stage4{os.sep}')
     name = pathdirectory(meta, 'S4', 1, ap=60, bg='70_90')
     assert os.path.exists(name)
     assert os.path.exists(name+os.sep+'figs')
+
+    s4_cites = np.union1d(s3_cites, COMMON_IMPORTS[3])
+    assert np.array_equal(s4_meta.citations, s4_cites)
 
     # remove temporary files
     os.system(f"rm -r data{os.sep}JWST-Sim{os.sep}NIRCam{os.sep}Stage3")


### PR DESCRIPTION
Added citation to Schlawin+ (2023) describing NIRCam Photometry (https://ui.adsabs.harvard.edu/abs/2023PASP..135a8001S). Added citation checking to test_Photometry_NIRCam.