### PR TITLE
Bug patches after latest PR

### DIFF
--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -140,13 +140,15 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None, input_meta=None):
             # (or someone is putting weird files into Eureka!)
             pipeline = EurekaSpec2Pipeline()
 
-            # By default pipeline can trim the dispersion axis,
-            # override the function that does this with specific 
-            # wavelength range that you want to trim to.
-            jwst.assign_wcs.nirspec.nrs_wcs_set_input = \
-                partial(jwst.assign_wcs.nirspec.nrs_wcs_set_input, 
-                        wavelength_range=[meta.waverange_start,
-                                          meta.waverange_end])
+            if (meta.waverange_start is not None or
+                    meta.waverange_end is not None):
+                # By default pipeline can trim the dispersion axis,
+                # override the function that does this with specific 
+                # wavelength range that you want to trim to.
+                jwst.assign_wcs.nirspec.nrs_wcs_set_input = \
+                    partial(jwst.assign_wcs.nirspec.nrs_wcs_set_input, 
+                            wavelength_range=[meta.waverange_start,
+                                              meta.waverange_end])
     elif telescope == 'HST':
         log.writelog('There is no Stage 2 for HST - skipping.')
         # Clean up temporary folder

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -138,7 +138,7 @@ def straighten_trace(data, meta, log, m):
     shifts, new_center = find_column_median_shifts(data.medflux, meta, m)
 
     # Correct wavelength (only one frame)
-    log.writelog('  Correcting the wavelength solution...',
+    log.writelog('    Correcting the wavelength solution...',
                  mute=(not meta.verbose))
     # broadcast to (1, detector.shape) which is the expected shape of
     # the function
@@ -148,7 +148,7 @@ def straighten_trace(data, meta, log, m):
     data.wave_2d.values = roll_columns(wave_data, single_shift)[0]
     data.wave_1d.values = data.wave_2d[new_center].values
 
-    log.writelog('  Correcting the curvature over all integrations...',
+    log.writelog('    Correcting the curvature over all integrations...',
                  mute=(not meta.verbose))
     # broadcast the shifts to the number of integrations
     shifts = np.reshape(np.repeat(shifts, data.flux.shape[0]),
@@ -164,7 +164,7 @@ def straighten_trace(data, meta, log, m):
                                        axis=0), shifts).squeeze()
 
     # update the new src_ypos
-    log.writelog(f'  Updating src_ypos to new center, row {new_center}...',
+    log.writelog(f'    Updating src_ypos to new center, row {new_center}...',
                  mute=(not meta.verbose))
     meta.src_ypos = new_center
 

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -37,7 +37,8 @@ def find_column_median_shifts(data, meta, m):
     # Smooth CoM values to get rid of outliers
     smooth_coms = smooth.medfilt(column_coms, 11)
     # if a value in smooth coms is nan, set it to the last non-nan value
-    smooth_coms[np.isnan(smooth_coms)] = smooth_coms[~np.isnan(smooth_coms)][-1]
+    smooth_coms[np.isnan(smooth_coms)] = \
+        smooth_coms[~np.isnan(smooth_coms)][-1]
 
     # Convert to interget pixels
     int_coms = np.around(smooth_coms).astype(int)

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/CentroidModel.py
@@ -97,9 +97,13 @@ class CentroidModel(PyMC3Model):
         
         centroid_flux = lib.zeros(0)
         for c in range(nchan):
+            if self.nchannel_fitted > 1:
+                chan = channels[c]
+            else:
+                chan = 0
+
             centroid = self.centroid_local
             if self.multwhite:
-                chan = channels[c]
                 # Split the arrays that have lengths of the original time axis
                 centroid = split([centroid, ], self.nints, chan)[0]
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/ExpRampModel.py
@@ -91,6 +91,7 @@ class ExpRampModel(PyMC3Model):
                 chan = channels[c]
             else:
                 chan = 0
+
             for i in range(12):
                 try:
                     if chan == 0:
@@ -103,9 +104,13 @@ class ExpRampModel(PyMC3Model):
 
         ramp_flux = lib.zeros(0)
         for c in range(nchan):
+            if self.nchannel_fitted > 1:
+                chan = channels[c]
+            else:
+                chan = 0
+
             time = self.time_local
             if self.multwhite:
-                chan = channels[c]
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PolynomialModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PolynomialModel.py
@@ -103,9 +103,13 @@ class PolynomialModel(PyMC3Model):
 
         poly_flux = lib.zeros(0)
         for c in range(nchan):
+            if self.nchannel_fitted > 1:
+                chan = channels[c]
+            else:
+                chan = 0
+
             time = self.time_local
             if self.multwhite:
-                chan = channels[c]
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/SinusoidPhaseCurve.py
@@ -129,9 +129,13 @@ class SinusoidPhaseCurveModel(PyMC3Model):
 
         lcfinal = lib.zeros(0)
         for c in range(nchan):
+            if self.nchannel_fitted > 1:
+                chan = channels[c]
+            else:
+                chan = 0
+
             time = self.time
             if self.multwhite:
-                chan = channels[c]
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
@@ -227,16 +227,16 @@ class StarryModel(PyMC3Model):
 
         phys_flux = lib.zeros(0)
         for c in range(nchan):
-            time = self.time
-            if self.multwhite:
-                chan = channels[c]
-                # Split the arrays that have lengths of the original time axis
-                time = split([time, ], self.nints, chan)[0]
-
             if self.nchannel_fitted > 1:
                 chan = channels[c]
             else:
                 chan = 0
+
+            time = self.time
+            if self.multwhite:
+                # Split the arrays that have lengths of the original time axis
+                time = split([time, ], self.nints, chan)[0]
+
             lcpiece = systems[chan].flux(time)
             if eval:
                 lcpiece = lcpiece.eval()

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StepModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StepModel.py
@@ -70,6 +70,7 @@ class StepModel(PyMC3Model):
                 chan = channels[c]
             else:
                 chan = 0
+
             for i in range(10):
                 try:
                     if chan == 0:
@@ -84,9 +85,13 @@ class StepModel(PyMC3Model):
 
         poly_flux = lib.zeros(0)
         for c in range(nchan):
+            if self.nchannel_fitted > 1:
+                chan = channels[c]
+            else:
+                chan = 0
+
             time = self.time
             if self.multwhite:
-                chan = channels[c]
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 

--- a/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
@@ -95,16 +95,16 @@ class BatmanTransitModel(Model):
         # Set all parameters
         lcfinal = np.array([])
         for c in range(nchan):
-            time = self.time
-            if self.multwhite:
-                chan = channels[c]
-                # Split the arrays that have lengths of the original time axis
-                time = split([time, ], self.nints, chan)[0]
-
             if self.nchannel_fitted > 1:
                 chan = channels[c]
             else:
                 chan = 0
+
+            time = self.time
+            if self.multwhite:
+                # Split the arrays that have lengths of the original time axis
+                time = split([time, ], self.nints, chan)[0]
+
             # Set all parameters
             for index, item in enumerate(self.longparamlist[chan]):
                 setattr(bm_params, self.paramtitles[index],
@@ -248,7 +248,11 @@ class BatmanEclipseModel(Model):
         # Set all parameters
         lcfinal = np.array([])
         for c in range(nchan):
-            chan = channels[c]
+            if self.nchannel_fitted > 1:
+                chan = channels[c]
+            else:
+                chan = 0
+
             time = self.time
             if self.multwhite:
                 # Split the arrays that have lengths of the original time axis

--- a/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
@@ -91,16 +91,16 @@ class CentroidModel(Model):
         # Create the centroid model for each wavelength
         lcfinal = np.array([])
         for c in range(nchan):
-            centroid = self.centroid_local
-            if self.multwhite:
-                chan = channels[c]
-                # Split the arrays that have lengths of the original time axis
-                centroid = split([centroid, ], self.nints, chan)[0]
-
             if self.nchannel_fitted > 1:
                 chan = channels[c]
             else:
                 chan = 0
+
+            centroid = self.centroid_local
+            if self.multwhite:
+                # Split the arrays that have lengths of the original time axis
+                centroid = split([centroid, ], self.nints, chan)[0]
+
             coeff = getattr(self.parameters, self.coeff_keys[chan]).value
             lcpiece = 1 + centroid*coeff
             lcfinal = np.append(lcfinal, lcpiece)

--- a/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
@@ -74,6 +74,7 @@ class ExpRampModel(Model):
                 chan = self.fitted_channels[c]
             else:
                 chan = 0
+
             for i in range(6):
                 try:
                     if chan == 0:
@@ -113,16 +114,16 @@ class ExpRampModel(Model):
         # Create the ramp from the coeffs
         lcfinal = np.array([])
         for c in range(nchan):
-            time = self.time_local
-            if self.multwhite:
-                chan = channels[c]
-                # Split the arrays that have lengths of the original time axis
-                time = split([time, ], self.nints, chan)[0]
-
             if self.nchannel_fitted > 1:
                 chan = channels[c]
             else:
                 chan = 0
+
+            time = self.time_local
+            if self.multwhite:
+                # Split the arrays that have lengths of the original time axis
+                time = split([time, ], self.nints, chan)[0]
+
             r0, r1, r2, r3, r4, r5 = self.coeffs[c]
             lcpiece = (1+r0*np.exp(-r1*time + r2)
                        + r3*np.exp(-r4*time + r5))

--- a/src/eureka/S5_lightcurve_fitting/models/PolynomialModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/PolynomialModel.py
@@ -74,6 +74,7 @@ class PolynomialModel(Model):
                 chan = self.fitted_channels[c]
             else:
                 chan = 0
+
             for i in range(9, -1, -1):
                 try:
                     if chan == 0:
@@ -117,16 +118,16 @@ class PolynomialModel(Model):
         # Create the polynomial from the coeffs
         lcfinal = np.array([])
         for c in range(nchan):
-            time = self.time_local
-            if self.multwhite:
-                chan = channels[c]
-                # Split the arrays that have lengths of the original time axis
-                time = split([time, ], self.nints, chan)[0]
-            
             if self.nchannel_fitted > 1:
                 chan = channels[c]
             else:
                 chan = 0
+
+            time = self.time_local
+            if self.multwhite:
+                # Split the arrays that have lengths of the original time axis
+                time = split([time, ], self.nints, chan)[0]
+            
             poly = np.poly1d(self.coeffs[chan])
             lcpiece = np.polyval(poly, time)
             lcfinal = np.append(lcfinal, lcpiece)

--- a/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
@@ -144,7 +144,6 @@ class SinusoidPhaseCurveModel(Model):
 
             time = self.time
             if self.multwhite:
-                chan = channels[c]
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 

--- a/src/eureka/S5_lightcurve_fitting/models/StepModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/StepModel.py
@@ -108,9 +108,13 @@ class StepModel(Model):
         # Create the ramp from the coeffs
         lcfinal = np.ones((nchan, len(self.time)))
         for c in range(nchan):
+            if self.nchannel_fitted > 1:
+                chan = channels[c]
+            else:
+                chan = 0
+
             time = self.time
             if self.multwhite:
-                chan = channels[c]
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -225,7 +225,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
                 else:
                     centroid_param_list.append(
                         np.zeros_like(lc.time.values))
-            xpos, ypos, xwidth, ywidth = centroid_param_list
+            xpos, xwidth, ypos, ywidth = centroid_param_list
 
             # make citations for current stage
             util.make_citations(meta, 5)

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -125,7 +125,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
 
             # Get the number of integrations in this lightcurve so
             # that we know how to split the flattened arrays
-            meta.nints = [len(lc.time.values)]
+            meta.nints = [len(lc.time.values), ]
             
             if meta.multwhite:
                 # Need to normalize each one if doing a joint fit

--- a/src/eureka/lib/split_channels.py
+++ b/src/eureka/lib/split_channels.py
@@ -19,8 +19,12 @@ def get_trim(nints, channel):
     trim2 : int
         The second index to use when slicing an array.
     """
-    trim1 = int(np.nansum(nints[:channel]))
-    trim2 = trim1 + int(nints[channel])
+    if len(nints) == 1:
+        trim1 = 0
+        trim2 = nints[0]
+    else:
+        trim1 = int(np.nansum(nints[:channel]))
+        trim2 = trim1 + int(nints[channel])
     return trim1, trim2
 
 


### PR DESCRIPTION
The latest PR unfortunately introduced some glaring bugs which I didn't catch myself nor did the automated tests.

1. Because of the way I implemented the new `meta.nints` code, unshared fits would break after fitting for the first lightcurve.
2. SinusoidalPhaseCurve fits would break with the PyMC3 version of the code as `chan` was always used but not always defined.
3. Also, at present, setting waverange_start and waverange_end to None causes a crash for NIRSpec spectra which shouldn't happen. Users should be able to use the default extraction if they want (or need).

Aside from resolving these bugs, I added a bit nicer formatting for the log statements inside straighten.py.