### PR TITLE
Enable Binned LC Plots

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
         - crds
         - exotic-ld
         - image_registration @ git+https://github.com/keflavich/image_registration.git@master#egg=image_registration
-        - jwst==1.8.0
+        - jwst==1.8.2
         - myst-parser # Needed for documentation
         - setuptools_scm # Needed for version number
         - sphinx-rtd-theme # Needed for documentation

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -36,7 +36,7 @@ dependencies:
         - exotic-ld
         - exoplanet
         - image_registration==0.2.6
-        - jwst==1.8.0
+        - jwst==1.8.2
         - myst-parser # Needed for documentation
         - pymc3
         - setuptools_scm # Needed for version number

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ where = src
 
 [options.extras_require]
 jwst =
-    jwst==1.8.0
+    jwst==1.8.2
     stcal >= 1.0.0 # Needed for our create_integration_model function
     asdf
 hst =

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -252,7 +252,7 @@ class PyMC3Model:
             # Split the arrays that have lengths of the original time axis
             time = split([time, ], self.nints, chan)[0]
 
-        ax.plot(time, model, '.', ls='', ms=2, label=label,
+        ax.plot(time, model, '.', ls='', ms=1, label=label,
                 color=color, zorder=zorder)
 
         if components and self.components is not None:

--- a/src/eureka/S5_lightcurve_fitting/gradient_fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/gradient_fitters.py
@@ -117,7 +117,8 @@ def exoplanetfitter(lc, model, meta, log, calling_function='exoplanet',
     #     plots.plot_GP_components(lc, model, meta, fitter=calling_function)
 
     # Zoom in on phase variations
-    if meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames):
+    if (meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames or
+                                  'sinusoid_pc' in meta.run_myfuncs)):
         plots.plot_phase_variations(lc, model, meta, fitter=calling_function)
 
     # Plot Allan plot
@@ -266,7 +267,8 @@ def nutsfitter(lc, model, meta, log, **kwargs):
     #     plots.plot_GP_components(lc, model, meta, fitter='nuts')
 
     # Zoom in on phase variations
-    if meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames):
+    if (meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames or
+                                  'sinusoid_pc' in meta.run_myfuncs)):
         plots.plot_phase_variations(lc, model, meta, fitter='nuts')
 
     # Plot Allan plot

--- a/src/eureka/S5_lightcurve_fitting/lightcurve.py
+++ b/src/eureka/S5_lightcurve_fitting/lightcurve.py
@@ -6,7 +6,7 @@ from . import models as m
 from . import fitters
 from . import gradient_fitters
 from .utils import COLORS, color_gen
-from ..lib import plots
+from ..lib import plots, util
 
 
 class LightCurve(m.Model):
@@ -180,12 +180,22 @@ class LightCurve(m.Model):
                 flux = flux[channel*len(self.time):(channel+1)*len(self.time)]
                 unc = unc[channel*len(self.time):(channel+1)*len(self.time)]
 
+            # Get binned data and times
+            if not hasattr(meta, 'nbin_plot') or meta.nbin_plot is None or \
+               meta.nbin_plot > len(self.time):
+                nbin_plot = len(self.time)
+            else:
+                nbin_plot = meta.nbin_plot
+            binned_time = util.binData(self.time, nbin_plot)
+            binned_flux = util.binData(flux, nbin_plot)
+            binned_unc = util.binData(unc, nbin_plot, err=True)
+
             fig = plt.figure(5103, figsize=(8, 6))
             fig.clf()
             # Draw the data
             ax = fig.gca()
-            ax.errorbar(self.time, flux, unc, fmt='.', color=self.colors[i],
-                        zorder=0)
+            ax.errorbar(binned_time, binned_flux, binned_unc, fmt='.',
+                        color=self.colors[i], zorder=0)
 
             # Make a new color generator for the models
             plot_COLORS = color_gen("Greys", 6)

--- a/src/eureka/S5_lightcurve_fitting/lightcurve.py
+++ b/src/eureka/S5_lightcurve_fitting/lightcurve.py
@@ -202,11 +202,11 @@ class LightCurve(m.Model):
 
             # Get binned data and times
             if not hasattr(meta, 'nbin_plot') or meta.nbin_plot is None or \
-               meta.nbin_plot > len(self.time):
-                nbin_plot = len(self.time)
+               meta.nbin_plot > len(time):
+                nbin_plot = len(time)
             else:
                 nbin_plot = meta.nbin_plot
-            binned_time = util.binData(self.time, nbin_plot)
+            binned_time = util.binData(time, nbin_plot)
             binned_flux = util.binData(flux, nbin_plot)
             binned_unc = util.binData(unc, nbin_plot, err=True)
 

--- a/src/eureka/S5_lightcurve_fitting/likelihood.py
+++ b/src/eureka/S5_lightcurve_fitting/likelihood.py
@@ -328,7 +328,7 @@ def computeRMS(data, maxnbins=None, binstep=1, isrmserr=False):
         Moved code to separate file, added documentation.
     """
     data = np.ma.masked_invalid(np.ma.copy(data))
-    
+
     # bin data into multiple bin sizes
     npts = data.size
     if maxnbins is None:

--- a/src/eureka/S5_lightcurve_fitting/models/Model.py
+++ b/src/eureka/S5_lightcurve_fitting/models/Model.py
@@ -227,7 +227,7 @@ class Model:
             # Split the arrays that have lengths of the original time axis
             time = split([time, ], self.nints, chan)[0]
 
-        ax.plot(time, model, '.', ls='', ms=2, label=label, color=color,
+        ax.plot(time, model, '.', ls='', ms=1, label=label, color=color,
                 zorder=zorder)
 
         if components and self.components is not None:

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -105,7 +105,7 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
         ax = fig.subplots(3, 1)
         ax[0].errorbar(binned_time, binned_flux, yerr=binned_unc, fmt='.',
                        color='w', ecolor=color, mec=color)
-        ax[0].plot(time, model, '.', ls='', ms=2, color='0.3', zorder=10)
+        ax[0].plot(time, model, '.', ls='', ms=1, color='0.3', zorder=10)
         if isTitle:
             ax[0].set_title(f'{meta.eventlabel} - Channel {channel} - '
                             f'{fitter}')

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -89,11 +89,11 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
 
         # Get binned data and times
         if not hasattr(meta, 'nbin_plot') or meta.nbin_plot is None or \
-           meta.nbin_plot > len(lc.time):
-            nbin_plot = len(lc.time)
+           meta.nbin_plot > len(time):
+            nbin_plot = len(time)
         else:
             nbin_plot = meta.nbin_plot
-        binned_time = util.binData(lc.time, nbin_plot)
+        binned_time = util.binData(time, nbin_plot)
         binned_flux = util.binData(flux, nbin_plot)
         binned_unc = util.binData(unc, nbin_plot, err=True)
         binned_normflux = util.binData(flux/model_sys, nbin_plot)

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -262,7 +262,7 @@ def plot_phase_variations(lc, model, meta, fitter, isTitle=True):
 
         if meta.isplots_S5 >= 3:
             # Setup the figure
-            fig = plt.figure(5104, figsize=(8, 6))
+            fig = plt.figure(5304, figsize=(8, 6))
             plt.clf()
             ax = fig.gca()
             if isTitle:


### PR DESCRIPTION
Working with datasets that have many integrations makes it difficult to see what's going on in the light curve plots.  So, when `meta.nbin_plot` is given, the light curves in all figures are now binned to the desired time resolution.  Before, only some plots were binned.

I also updated the `jwst` version to 1.8.2.  Version 1.9 appears to still be buggy.