### PR TITLE
Skip masking trace, etc when bias_correction is None; enable row-by-row BG subtraction; edit NIRCam extraction height

### DIFF
--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -48,12 +48,15 @@ grouplevel_bg       True
 ncpu                6
 bg_y1               6
 bg_y2               26
-bg_deg              0 
+bg_deg              0
 p3thresh            5
 verbose             True
 isplots_S1          3
 nplots              5
 hide_plots          True
+bg_disp             False   # Row-by-row BG subtraction (only useful for NIRCam)
+bg_x1               640     # Left edge of exclusion region for row-by-row BG subtraction
+bg_x2               2048    # Right edge of exclusion region for row-by-row BG subtraction
 
 # Mask curved traces
 masktrace           True

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -55,8 +55,8 @@ isplots_S1          3
 nplots              5
 hide_plots          True
 bg_disp             False   # Row-by-row BG subtraction (only useful for NIRCam)
-bg_x1               640     # Left edge of exclusion region for row-by-row BG subtraction
-bg_x2               2048    # Right edge of exclusion region for row-by-row BG subtraction
+bg_x1               None    # Left edge of exclusion region for row-by-row BG subtraction
+bg_x2               None    # Right edge of exclusion region for row-by-row BG subtraction
 
 # Mask curved traces
 masktrace           True

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -30,7 +30,7 @@ custom_linearity    False
 linearity_file      /path/to/custom/linearity/fits/file
 
 # Custom bias
-bias_correction     None    # Bias correction options: [mean, group_level, smooth, None]
+bias_correction     None    # Bias correction options: [mean, group_level, smooth, None], requires masktrace=True
 bias_group          1       # Group number options: [1, 2, ..., each]
 bias_smooth_length  201     # Window length when using 'smooth' bias correction
 custom_bias         False

--- a/demos/JWST/S2_nircam_wfss_template.ecf
+++ b/demos/JWST/S2_nircam_wfss_template.ecf
@@ -5,8 +5,7 @@
 suffix                  rateints     # Data file suffix
 
 # Controls the cross-dispersion extraction
-slit_y_low              None    # Use None to rely on the default parameters
-slit_y_high             None    # Use None to rely on the default parameters
+tsgrism_extract_height  None    # Use None to rely on the default parameters
 
 # Modify the existing file to change the dispersion extraction - FIX: DOES NOT WORK CURRENTLY
 waverange_start         None    # Use None to rely on the default parameters

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -26,8 +26,8 @@ bg_hw           8           # Half-width of exclusion region for BG subtraction 
 bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
 bg_disp         False       # Row-by-row BG subtraction (only useful for NIRCam)
-bg_x1           640         # Left edge of exclusion region for row-by-row BG subtraction
-bg_x2           2048        # Right edge of exclusion region for row-by-row BG subtraction
+bg_x1           None        # Left edge of exclusion region for row-by-row BG subtraction
+bg_x2           None        # Right edge of exclusion region for row-by-row BG subtraction
 
 # Spectral extraction parameters
 spec_hw         8           # Half-width of aperture region for spectral extraction (relative to source position)

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -25,6 +25,9 @@ bg_thresh       [4,4]       # Double-iteration X-sigma threshold for outlier rej
 bg_hw           8           # Half-width of exclusion region for BG subtraction (relative to source position)
 bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
+bg_disp         False       # Row-by-row BG subtraction (only useful for NIRCam)
+bg_x1           640         # Left edge of exclusion region for row-by-row BG subtraction
+bg_x2           2048        # Right edge of exclusion region for row-by-row BG subtraction
 
 # Spectral extraction parameters
 spec_hw         8           # Half-width of aperture region for spectral extraction (relative to source position)

--- a/src/eureka/S1_detector_processing/bias_sub.py
+++ b/src/eureka/S1_detector_processing/bias_sub.py
@@ -35,7 +35,7 @@ def do_correction(input_model, bias_model, meta, log):
     if not reffile_utils.ref_matches_sci(input_model, bias_model):
         bias_model = reffile_utils.get_subarray_model(input_model, bias_model)
 
-    if meta.bias_correction is not None:
+    if meta.bias_correction is not None and meta.masktrace:
         # Compute trace mask, where ones are good background regions
         input_model = mask_trace(input_model, log, meta)
         trace_mask = input_model.trace_mask

--- a/src/eureka/S1_detector_processing/bias_sub.py
+++ b/src/eureka/S1_detector_processing/bias_sub.py
@@ -35,51 +35,54 @@ def do_correction(input_model, bias_model, meta, log):
     if not reffile_utils.ref_matches_sci(input_model, bias_model):
         bias_model = reffile_utils.get_subarray_model(input_model, bias_model)
 
-    # Compute trace mask, where ones are good background regions
-    input_model = mask_trace(input_model, log, meta)
-    trace_mask = input_model.trace_mask
+    if meta.bias_correction is not None:
+        # Compute trace mask, where ones are good background regions
+        input_model = mask_trace(input_model, log, meta)
+        trace_mask = input_model.trace_mask
 
-    # Compute median of bias frame outside of trace
-    bias_median = np.nanmedian(bias_model.data[np.where(trace_mask)])
+        # Compute median of bias frame outside of trace
+        bias_median = np.nanmedian(bias_model.data[np.where(trace_mask)])
 
-    log.writelog('  Computing scale factor for superbias correction.')
-    # Compute median of each integration/group outside of trace
-    # Using double-for loop to avoid heavy memory usage
-    nint, ngroup, nrow, ncol = input_model.data.shape
-    scale_factor = np.zeros((nint, ngroup))
-    for ii in range(nint):
-        data = input_model.data[ii]
-        for jj in range(ngroup):
-            data_median = np.nanmedian(data[jj][np.where(trace_mask)])
-            scale_factor[ii, jj] = data_median/bias_median
-    mean_scale_factor = np.nanmean(scale_factor, axis=0)
-    log.writelog(f'  Mean bias scale factors (by group): {mean_scale_factor}')
-    
-    # Get segment number
-    segment = str(input_model.meta.exposure.segment_number).zfill(3)
+        log.writelog('  Computing scale factor for superbias correction.')
+        # Compute median of each integration/group outside of trace
+        # Using double-for loop to avoid heavy memory usage
+        nint, ngroup, nrow, ncol = input_model.data.shape
+        scale_factor = np.zeros((nint, ngroup))
+        for ii in range(nint):
+            data = input_model.data[ii]
+            for jj in range(ngroup):
+                data_median = np.nanmedian(data[jj][np.where(trace_mask)])
+                scale_factor[ii, jj] = data_median/bias_median
+        mean_scale_factor = np.nanmean(scale_factor, axis=0)
+        log.writelog('  Mean bias scale factors (by group): ' +
+                     f'{mean_scale_factor}')
 
-    # Save scale factor to ECSV file
-    fname = meta.outputdir+"S1_seg"+segment+"_BiasScaleFactor.ecsv"
-    savetable_S1(fname, scale_factor)
+        # Get segment number
+        segment = str(input_model.meta.exposure.segment_number).zfill(3)
 
-    # Smooth scale factor
-    if meta.bias_correction == "smooth":
-        for jj in range(ngroup):
-            scale_factor[:, jj] = smooth(scale_factor[:, jj], 
-                                         meta.bias_smooth_length)
-        # Save smoothed scale factor to ECSV file
-        fname = meta.outputdir+"S1_seg"+segment+"_BiasSmoothedScaleFactor.ecsv"
+        # Save scale factor to ECSV file
+        fname = meta.outputdir+"S1_seg"+segment+"_BiasScaleFactor.ecsv"
         savetable_S1(fname, scale_factor)
+
+        # Smooth scale factor
+        if meta.bias_correction == "smooth":
+            for jj in range(ngroup):
+                scale_factor[:, jj] = smooth(scale_factor[:, jj],
+                                             meta.bias_smooth_length)
+            # Save smoothed scale factor to ECSV file
+            fname = meta.outputdir + "S1_seg" + segment + \
+                                     "_BiasSmoothedScaleFactor.ecsv"
+            savetable_S1(fname, scale_factor)
 
     # Replace NaN's in the superbias with zeros
     bias_model.data[np.isnan(bias_model.data)] = 0.0
 
-    # Create 4D bias array for each integration/group and apply scale factor 
-    bias_data = np.ones((nint, ngroup, nrow, ncol)) * \
-        bias_model.data[np.newaxis, np.newaxis, :, :]
-    
     try:
         if meta.bias_correction == "mean":
+            # Create 4D bias array for each integration/group and
+            # apply scale factor
+            bias_data = np.ones((nint, ngroup, nrow, ncol)) * \
+                bias_model.data[np.newaxis, np.newaxis, :, :]
             if isinstance(meta.bias_group, int):
                 # Scale superbias frame using single value for all groups
                 jj = meta.bias_group
@@ -94,14 +97,18 @@ def do_correction(input_model, bias_model, meta, log):
                 # Scale superbias frame using means values for each group
                 log.writelog('  Applying mean bias correction to each group.')
                 bias_model.data *= mean_scale_factor[0]
-                bias_data *= mean_scale_factor[np.newaxis, :, np.newaxis, 
+                bias_data *= mean_scale_factor[np.newaxis, :, np.newaxis,
                                                np.newaxis]
             else:
-                raise ValueError('Incorrect meta.bias_group value: ' + 
+                raise ValueError('Incorrect meta.bias_group value: ' +
                                  f'{meta.bias_group}. Should be ' +
                                  '[1, 2, ..., each].')
         elif (meta.bias_correction == "group_level") or \
              (meta.bias_correction == "smooth"):
+            # Create 4D bias array for each integration/group and
+            # apply scale factor
+            bias_data = np.ones((nint, ngroup, nrow, ncol)) * \
+                bias_model.data[np.newaxis, np.newaxis, :, :]
             # Apply correction for zeroframe
             bias_model.data *= mean_scale_factor[0]
             if isinstance(meta.bias_group, int):
@@ -112,15 +119,15 @@ def do_correction(input_model, bias_model, meta, log):
                     f", got: {jj}"
                 log.writelog('  Applying group-level bias correction using ' +
                              f'group {jj}.')
-                bias_data *= scale_factor[:, jj-1, np.newaxis, 
+                bias_data *= scale_factor[:, jj-1, np.newaxis,
                                           np.newaxis, np.newaxis]
             elif meta.bias_group == "each":
                 # Scale superbias frame using values from each group
-                log.writelog('  Applying group-level bias correction to ' + 
+                log.writelog('  Applying group-level bias correction to ' +
                              'each group.')
                 bias_data *= scale_factor[:, :, np.newaxis, np.newaxis]
             else:
-                raise ValueError('Incorrect meta.bias_group value: ' + 
+                raise ValueError('Incorrect meta.bias_group value: ' +
                                  f'{meta.bias_group}. Should be ' +
                                  '[1, 2, ..., each].')
         else:
@@ -152,7 +159,7 @@ def subtract_bias(input, bias, bias_data=None):
 
     bias: superbias model object
         the superbias image data
-    
+
     bias_data: array
         4D array of superbias images
 

--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -142,12 +142,12 @@ def mask_trace(input_model, log, meta):
         for nc in range(meta.bg_x1, meta.bg_x2):
             mask_low = np.nanmax([0, smooth_coms[nc]-meta.expand_mask])
             mask_hih = np.nanmin([smooth_coms[nc]+meta.expand_mask, nrow-1])
+            trace_mask[mask_low:mask_hih, nc] = np.nan
     else:
         for nc in range(ncol):
             mask_low = np.nanmax([0, smooth_coms[nc]-meta.expand_mask])
             mask_hih = np.nanmin([smooth_coms[nc]+meta.expand_mask, nrow-1])
-
-        trace_mask[mask_low:mask_hih, nc] = np.nan
+            trace_mask[mask_low:mask_hih, nc] = np.nan
 
     input_model.trace_mask = trace_mask
 

--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -71,24 +71,22 @@ def GLBS(input_model, log, meta):
         data = xrio.makeDataset(dictionary=xrdict)
         data['flux'].attrs['flux_units'] = 'n/a'
         data.attrs['intstart'] = meta.intstart
+        meta.bg_dir = 'CxC'
         if ngrp == all_data.shape[1]-1:
-            data = bkg.BGsubtraction(data, meta,
-                                     log, 0,
+            data = bkg.BGsubtraction(data, meta, log, meta.m,
                                      meta.isplots_S1)
         else:
             # do not show plots except for the last group
-            data = bkg.BGsubtraction(data, meta,
-                                     log, 0, 0)
+            data = bkg.BGsubtraction(data, meta, log, meta.m, 0)
         # Perform BG subtraction along dispersion direction
         # (only useful for NIRCam data)
         if hasattr(meta, 'bg_disp') and meta.bg_disp:
-            log.writelog('  Performing BG subtraction along ' +
-                         'dispersion direction...',
-                         mute=(not meta.verbose))
+            meta.bg_dir = 'RxR'
             if ngrp == all_data.shape[1]-1:
-                data = bkg.BGsubtraction(data, meta, log, 0, meta.isplots_S1)
+                data = bkg.BGsubtraction(data, meta, log, meta.m,
+                                         meta.isplots_S1)
             else:
-                data = bkg.BGsubtraction(data, meta, log, 0, 0)
+                data = bkg.BGsubtraction(data, meta, log, meta.m, 0)
         # Overwrite values in all_data
         all_data[:, ngrp, :, :] = data['flux'].values
     input_model.data = all_data

--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -140,7 +140,7 @@ def mask_trace(input_model, log, meta):
 
     # now create mask based on smooth_coms center.
     if meta.bg_x1 is not None and meta.bg_x2 is not None:
-        range_cols = range(meta.bg_x1, meta.bg_x2):
+        range_cols = range(meta.bg_x1, meta.bg_x2)
     else:
         range_cols = range(ncol)
     for nc in range_cols:

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -106,6 +106,7 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
                 hdulist[0].header['NDITHPTS'] = 1
                 hdulist[0].header['NRIMDTPT'] = 1
 
+            meta.m = m
             meta.intstart = hdulist[0].header['INTSTART']-1
             meta.intend = hdulist[0].header['INTEND']
             EurekaS1Pipeline().run_eurekaS1(filename, meta, log)
@@ -116,7 +117,7 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
 
     # make citations for current stage
     util.make_citations(meta, 1)
-    
+
     # Save results
     if not meta.testing_S1:
         log.writelog('Saving Metadata')
@@ -205,7 +206,7 @@ class EurekaS1Pipeline(Detector1Pipeline):
         self.superbias = Eureka_SuperBiasStep()
         self.superbias.s1_meta = meta
         self.superbias.s1_log = log
-        
+
         # Define ramp fitting procedure
         self.ramp_fit = Eureka_RampFitStep()
         self.ramp_fit.algorithm = meta.ramp_fit_algorithm

--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -234,11 +234,11 @@ class EurekaSpec2Pipeline(Spec2Pipeline):
         '''
 
         if hasattr(meta, 'slit_y_low') and meta.slit_y_low is not None:
-            # Controls the cross-dispersion extraction
+            #  NIRSpec subarray lower bound in cross-dispersion direction
             self.assign_wcs.slit_y_low = meta.slit_y_low
 
         if hasattr(meta, 'slit_y_high') and meta.slit_y_high is not None:
-            # Controls the cross-dispersion extraction
+            #  NIRSpec subarray upper bound in cross-dispersion direction
             self.assign_wcs.slit_y_high = meta.slit_y_high
 
         if hasattr(meta, 'tsgrism_extract_height') and \

--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -143,10 +143,10 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None, input_meta=None):
             if (meta.waverange_start is not None or
                     meta.waverange_end is not None):
                 # By default pipeline can trim the dispersion axis,
-                # override the function that does this with specific 
+                # override the function that does this with specific
                 # wavelength range that you want to trim to.
                 jwst.assign_wcs.nirspec.nrs_wcs_set_input = \
-                    partial(jwst.assign_wcs.nirspec.nrs_wcs_set_input, 
+                    partial(jwst.assign_wcs.nirspec.nrs_wcs_set_input,
                             wavelength_range=[meta.waverange_start,
                                               meta.waverange_end])
     elif telescope == 'HST':
@@ -175,7 +175,7 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None, input_meta=None):
                 hdulist[0].header['NRIMDTPT'] = 1
 
         pipeline.run_eurekaS2(filename, meta, log)
-    
+
     # make citations for current stage
     util.make_citations(meta, 2)
 
@@ -232,7 +232,7 @@ class EurekaSpec2Pipeline(Spec2Pipeline):
             Fragmented code to allow reuse of code between spectral and image
             analysis.
         '''
-        
+
         if meta.slit_y_low is not None:
             # Controls the cross-dispersion extraction
             self.assign_wcs.slit_y_low = meta.slit_y_low
@@ -240,6 +240,11 @@ class EurekaSpec2Pipeline(Spec2Pipeline):
         if meta.slit_y_high is not None:
             # Controls the cross-dispersion extraction
             self.assign_wcs.slit_y_high = meta.slit_y_high
+
+        if meta.tsgrism_extract_height is not None:
+            # NIRCam grism subarray height in cross-dispersion direction
+            self.extract_2d.tsgrism_extract_height = \
+                meta.tsgrism_extract_height
 
         # Skip steps according to input ecf file
         self.bkg_subtract.skip = meta.skip_bkg_subtract

--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -233,15 +233,16 @@ class EurekaSpec2Pipeline(Spec2Pipeline):
             analysis.
         '''
 
-        if meta.slit_y_low is not None:
+        if hasattr(meta, 'slit_y_low') and meta.slit_y_low is not None:
             # Controls the cross-dispersion extraction
             self.assign_wcs.slit_y_low = meta.slit_y_low
 
-        if meta.slit_y_high is not None:
+        if hasattr(meta, 'slit_y_high') and meta.slit_y_high is not None:
             # Controls the cross-dispersion extraction
             self.assign_wcs.slit_y_high = meta.slit_y_high
 
-        if meta.tsgrism_extract_height is not None:
+        if hasattr(meta, 'tsgrism_extract_height') and \
+           meta.tsgrism_extract_height is not None:
             # NIRCam grism subarray height in cross-dispersion direction
             self.extract_2d.tsgrism_extract_height = \
                 meta.tsgrism_extract_height

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -86,7 +86,7 @@ def BGsubtraction(data, meta, log, m, isplots=0):
         return
 
     # Compute background for each integration
-    log.writelog('  Performing background subtraction...',
+    log.writelog('  Performing ' + meta.bg_dir + ' background subtraction...',
                  mute=(not meta.verbose))
     data['bg'] = (['time', 'y', 'x'], np.zeros(data.flux.shape))
     data['bg'].attrs['flux_units'] = data['flux'].attrs['flux_units']

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -243,7 +243,7 @@ def fit_bg(dataim, datamask, n, meta, isplots=0):
     n : int
         The current integration number.
     """
-    if hasattr(meta, 'bg_disp') and meta.bg_disp:
+    if hasattr(meta, 'bg_dir') and meta.bg_dir == 'RxR':
         bg, mask = background.fitbg(dataim, meta, datamask, meta.bg_x1,
                                     meta.bg_x2, deg=meta.bg_deg,
                                     threshold=meta.p3thresh, isrotate=0,

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -93,7 +93,7 @@ def read(filename, data, meta, log):
         # data. Added it here so that code in other sections doesn't have to
         # be changed
         data.attrs['shdr']['DISPAXIS'] = 1
-        
+
         # FINDME: make this better for all filters
         if hdulist[0].header['FILTER'] == 'F210M':
             # will be deleted at the end of S3
@@ -243,10 +243,16 @@ def fit_bg(dataim, datamask, n, meta, isplots=0):
     n : int
         The current integration number.
     """
-    bg, mask = background.fitbg(dataim, meta, datamask, meta.bg_y1,
-                                meta.bg_y2, deg=meta.bg_deg,
-                                threshold=meta.p3thresh, isrotate=2,
-                                isplots=isplots)
+    if hasattr(meta, 'bg_disp') and meta.bg_disp:
+        bg, mask = background.fitbg(dataim, meta, datamask, meta.bg_x1,
+                                    meta.bg_x2, deg=meta.bg_deg,
+                                    threshold=meta.p3thresh, isrotate=0,
+                                    isplots=isplots)
+    else:
+        bg, mask = background.fitbg(dataim, meta, datamask, meta.bg_y1,
+                                    meta.bg_y2, deg=meta.bg_deg,
+                                    threshold=meta.p3thresh, isrotate=2,
+                                    isplots=isplots)
 
     return bg, mask, n
 

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -192,8 +192,8 @@ def image_and_background(data, meta, log, m):
         file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))
                                        + 1))
         int_number = str(n).zfill(int(np.floor(np.log10(meta.n_int))+1))
-        fname = (f'figs{os.sep}fig3301_file{file_number}_int{int_number}' +
-                 '_ImageAndBackground'+plots.figure_filetype)
+        fname = (f'figs{os.sep}fig3301_file{file_number}_int{int_number}_' +
+                 meta.bg_dir + '_ImageAndBackground'+plots.figure_filetype)
         plt.savefig(meta.outputdir+fname, dpi=300)
         if not meta.hide_plots:
             plt.pause(0.2)
@@ -529,7 +529,7 @@ def residualBackground(data, meta, m, vmin=-200, vmax=1000):
     plt.clf()
     fig, (a0, a1) = plt.subplots(1, 2, gridspec_kw={'width_ratios': [3, 1]},
                                  num=3304, figsize=(8, 3.5))
-    
+
     a0.imshow(flux, origin='lower', aspect='auto', vmax=vmax, vmin=vmin,
               cmap=cmap, interpolation='nearest',
               extent=[xmin, xmax, ymin, ymax])
@@ -746,7 +746,7 @@ def phot_centroid(data, meta):
     - 2022-08-02 Sebastian Zieba
         Initial version
     - 2023-02-24 Isaac Edelman
-        Enchanced graph layout, 
+        Enchanced graph layout,
         added sig display values for sy,sx,
         and fixed issue with ax[2] displaying sy instead of sx.
     """
@@ -1182,9 +1182,9 @@ def stddev_profile(meta, n, m, stdevs, p7thresh):
 
 def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
     """
-    Plots the mirror tilt events by divinding 
-    an integrations' flux values by a 
-    median frames' flux values. 
+    Plots the mirror tilt events by divinding
+    an integrations' flux values by a
+    median frames' flux values.
     Creates .pngs and a .gif (Fig 3507a, Fig 3507b, Fig 3507c)
 
     Parameters
@@ -1202,9 +1202,9 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
     saved_refrence_tilt_frame : ndarray
         The median of the first 10 integrations.
 
-    Returns 
-    ------- 
-    ndarray 
+    Returns
+    -------
+    ndarray
         A median frame of the first 10 integrations.
 
     Notes
@@ -1246,7 +1246,7 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
         # Caluculate flux ratio
         flux_tilt = (data.flux.values[i, miny:maxy,
                                       minx:maxx] / refrence_tilt_frame)
-        
+
         # Create plot
         plt.figure(3507, figsize=(6, 6))
         plt.clf()
@@ -1254,7 +1254,7 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
         # Plot figure
         im = plt.imshow(flux_tilt, origin='lower', aspect='equal',
                         vmin=0.98, vmax=1.02, cmap=cmap)
-        
+
         # Figure settings
         plt.title('Tilt Identification')
         plt.xticks(np.arange(0, flux_tilt.shape[1], 1),
@@ -1298,7 +1298,7 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
     log.writelog('  Creating batch tilt event GIF',
                  mute=(not meta.verbose))
     imageio.mimsave(meta.outputdir + f'figs{os.sep}' +
-                    f'fig3507b_tilt_event_batch_{file_number}.gif', 
+                    f'fig3507b_tilt_event_batch_{file_number}.gif',
                     images, fps=20)
 
     # Figure fig3507c

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -303,6 +303,9 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                                             m, meta.isplots_S3)
                     meta.bg_disp = False
                     meta.bg_deg = None
+                # Specify direction = CxC to perform standard BG subtraction
+                # later on in Stage 3. This needs to be set independent of
+                # having performed RxR BG subtraction.
                 meta.bg_dir = 'CxC'
 
                 # Trim data to subarray region of interest
@@ -461,7 +464,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                                 radius=None, size=None, meta=meta, i=None,
                                 m=None,
                                 saved_ref_median_frame=saved_ref_median_frame)
-                        
+
                     if saved_ref_median_frame is None:
                         saved_ref_median_frame = refrence_median_frame
 

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -209,6 +209,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                                  'unsupported!')
             elif meta.inst == 'wfc3':
                 from . import wfc3 as inst
+                meta.bg_dir = 'CxC'
                 meta, log = inst.preparation_step(meta, log)
             else:
                 raise ValueError('Unknown instrument {}'.format(meta.inst))

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -546,7 +546,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                     meta.save_fluxdata = True
 
                 # plot tilt events
-                if meta.isplots_S3 >= 5 and meta.inst == 'nircam' and
+                if meta.isplots_S3 >= 5 and meta.inst == 'nircam' and \
                    meta.photometry:
                     refrence_tilt_frame = \
                         plots_s3.tilt_events(meta, data, log, m,

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -78,7 +78,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
     - July 2022 Sebastian Zieba
         Added photometry S3
     - Feb 2023 Isaac Edelman
-        Added new centroiding method (mgmc_pri, mgmc_sec) to 
+        Added new centroiding method (mgmc_pri, mgmc_sec) to
         correct for shortwave photometry data processing issues
     '''
     s2_meta = deepcopy(s2_meta)
@@ -89,7 +89,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
         ecffile = 'S3_' + eventlabel + '.ecf'
         meta = readECF.MetaClass(ecf_path, ecffile)
     else:
-        meta = input_meta    
+        meta = input_meta
 
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
@@ -238,7 +238,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
 
             datasets = []
             saved_refrence_tilt_frame = None
-            
+
             for m in range(meta.nbatch):
                 first_file = m*meta.files_per_batch
                 last_file = min([meta.num_data_files,
@@ -337,7 +337,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                                        data.wave_2d[meta.src_ypos].values)
                     data['wave_1d'].attrs['wave_units'] = \
                         data.wave_2d.attrs['wave_units']
-                
+
                 # Check for bad wavelength pixels (beyond wavelength solution)
                 util.check_nans(data.wave_1d.values, np.ones(meta.subnx), log,
                                 name='wavelength')
@@ -373,7 +373,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                         data = inst.flag_bg(data, meta, log)
 
                     # Do the background subtraction
-                    data = bg.BGsubtraction(data, meta, log, 
+                    data = bg.BGsubtraction(data, meta, log,
                                             m, meta.isplots_S3)
 
                     # Calulate and correct for 2D drift
@@ -428,14 +428,14 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
 
                     # Setting up arrays for photometry reduction
                     data = util.phot_arrays(data)
-                    
+
                     # Set method used for centroiding
                     if (not hasattr(meta, 'centroid_method')
                             or meta.centroid_method is None):
                         meta.centroid_method = 'fgc'
 
-                    # Compute the median frame 
-                    # and position of first centroid guess 
+                    # Compute the median frame
+                    # and position of first centroid guess
                     # for mgmc method
                     if (hasattr(meta, 'ctr_guess') and
                             meta.ctr_guess is not None):
@@ -444,42 +444,42 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                         position = guess - trim
                     elif meta.centroid_method == 'mgmc':
                         position, extra = \
-                            centerdriver.centerdriver('mgmc_pri', 
-                                                      data.flux.values, 
-                                                      guess=1, trim=0, 
-                                                      radius=None, size=None, 
-                                                      meta=meta, i=None, 
+                            centerdriver.centerdriver('mgmc_pri',
+                                                      data.flux.values,
+                                                      guess=1, trim=0,
+                                                      radius=None, size=None,
+                                                      meta=meta, i=None,
                                                       m=None)
 
                     # for loop for integrations
-                    for i in tqdm(range(len(data.time)), 
+                    for i in tqdm(range(len(data.time)),
                                   desc='  Looping over Integrations'):
                         if (meta.isplots_S3 >= 3
                                 and meta.oneoverf_corr is not None):
                             # save current flux into an array for
                             # plotting 1/f correction comparison
                             flux_w_oneoverf = np.copy(data.flux.values[i])
-                            
+
                         # Determine centroid position
                         # We do this twice. First a coarse estimation,
                         # then a more precise one.
                         # Use the center of the frame as an initial guess
-                        if (meta.centroid_method == 'fgc' and 
+                        if (meta.centroid_method == 'fgc' and
                                 (not hasattr(meta, 'ctr_guess') or
                                  meta.ctr_guess is None)):
-                            centroid_guess = [data.flux.shape[1]//2, 
+                            centroid_guess = [data.flux.shape[1]//2,
                                               data.flux.shape[2]//2]
                             # Do a 2D gaussian fit to the whole frame
                             position, extra = \
-                                centerdriver.centerdriver('fgc', 
+                                centerdriver.centerdriver('fgc',
                                                           data.flux.values[i],
-                                                          centroid_guess, 
+                                                          centroid_guess,
                                                           0, 0, 0,
                                                           mask=None, uncd=None,
-                                                          fitbg=1, 
+                                                          fitbg=1,
                                                           maskstar=True,
                                                           expand=1.0, psf=None,
-                                                          psfctr=None, i=i, 
+                                                          psfctr=None, i=i,
                                                           m=m, meta=meta)
 
                         if meta.oneoverf_corr is not None:
@@ -497,20 +497,20 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                         position, extra = \
                             centerdriver.centerdriver(
                                 meta.centroid_method+'_sec',
-                                data.flux.values[i], 
+                                data.flux.values[i],
                                 guess=position,
-                                trim=meta.ctr_cutout_size, 
+                                trim=meta.ctr_cutout_size,
                                 radius=0, size=0,
-                                mask=data.mask.values[i], 
+                                mask=data.mask.values[i],
                                 uncd=None, fitbg=1,
-                                maskstar=True, expand=1, psf=None, 
+                                maskstar=True, expand=1, psf=None,
                                 psfctr=None, i=i, m=m, meta=meta)
 
                         # Store centroid positions and
                         # the Gaussian 1-sigma half-widths
                         data['centroid_y'][i], data['centroid_x'][i] = position
                         data['centroid_sy'][i], data['centroid_sx'][i] = extra
-                        
+
                         # Plot 2D frame, the centroid and the centroid position
                         if meta.isplots_S3 >= 3 and i < meta.nplots:
                             plots_s3.phot_2d_frame(data, meta, m, i)
@@ -546,10 +546,11 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                     meta.save_fluxdata = True
 
                 # plot tilt events
-                if (meta.isplots_S3 >= 5 and meta.inst == 'nircam'): 
+                if meta.isplots_S3 >= 5 and meta.inst == 'nircam' and
+                   meta.photometry:
                     refrence_tilt_frame = \
-                        plots_s3.tilt_events(meta, data, log, m, 
-                                             position, 
+                        plots_s3.tilt_events(meta, data, log, m,
+                                             position,
                                              saved_refrence_tilt_frame)
 
                     if saved_refrence_tilt_frame is not None:

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -293,9 +293,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 # Perform BG subtraction along dispersion direction
                 # for untrimmed NIRCam spectroscopic data
                 if hasattr(meta, 'bg_disp') and meta.bg_disp:
-                    log.writelog('  Performing BG subtraction along ' +
-                                 'dispersion direction...',
-                                 mute=(not meta.verbose))
+                    meta.bg_dir = 'RxR'
                     # Create bad pixel mask (1 = good, 0 = bad)
                     data['mask'] = (['time', 'y', 'x'],
                                     np.ones(data.flux.shape, dtype=bool))
@@ -303,6 +301,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                                             m, meta.isplots_S3)
                     meta.bg_disp = False
                     meta.bg_deg = None
+                meta.bg_dir = 'CxC'
 
                 # Trim data to subarray region of interest
                 # Dataset object no longer contains untrimmed data

--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -291,7 +291,7 @@ def emceefitter(lc, model, meta, log, **kwargs):
     ndim = len(freenames)
 
     if hasattr(meta, 'old_chain') and meta.old_chain is not None:
-        pos, nwalkers = start_from_oldchain_emcee(meta, log, ndim, lc.channel,
+        pos, nwalkers = start_from_oldchain_emcee(lc, meta, log, ndim,
                                                   freenames)
     else:
         if not hasattr(meta, 'lsq_first') or meta.lsq_first:
@@ -477,19 +477,19 @@ def emceefitter(lc, model, meta, log, **kwargs):
     return best_model
 
 
-def start_from_oldchain_emcee(meta, log, ndim, channel, freenames):
+def start_from_oldchain_emcee(lc, meta, log, ndim, freenames):
     """Restart emcee using the ending point of an old chain.
 
     Parameters
     ----------
+    lc : eureka.S5_lightcurve_fitting.lightcurve.LightCurve
+        The lightcurve data object.
     meta : eureka.lib.readECF.MetaClass
         The meta data object.
     log : logedit.Logedit
         The open log in which notes from this step can be added.
     ndim : int
         The number of fitted parameters.
-    channel : int
-        The channel number.
     freenames : list
         The names of the fitted parameters.
 
@@ -511,7 +511,8 @@ def start_from_oldchain_emcee(meta, log, ndim, channel, freenames):
     if meta.sharedp:
         channel_key = 'shared'
     else:
-        channel_key = f'ch{channel}'
+        ch_number = str(lc.channel).zfill(len(str(lc.nchannel)))
+        channel_key = f'ch{ch_number}'
 
     foldername = os.path.join(meta.topdir, *meta.old_chain.split(os.sep))
     fname = f'S5_emcee_fitparams_{channel_key}.csv'

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -126,7 +126,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
             # Get the number of integrations in this lightcurve so
             # that we know how to split the flattened arrays
             meta.nints = [len(lc.time.values), ]
-            
+
             if meta.multwhite:
                 # Need to normalize each one if doing a joint fit
                 lc_whites = [lc, ]
@@ -332,18 +332,27 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
                     flux_temp, err_temp = util.normalize_spectrum(
                         meta, flux_temp, err_temp)
                     time_temp = lc_whites[pi].time.values - offset
-                    xpos_temp = np.ma.masked_invalid(
-                        lc_whites[pi].centroid_x.values)
-                    xwidth_temp = np.ma.masked_invalid(
-                        lc_whites[pi].centroid_sx.values)
-                    ypos_temp = np.ma.masked_invalid(
-                        lc_whites[pi].centroid_y.values)
-                    ywidth_temp = np.ma.masked_invalid(
-                        lc_whites[pi].centroid_sy.values)
-
                     flux = np.ma.append(flux, flux_temp)
                     flux_err = np.ma.append(flux_err, err_temp)
                     time = np.ma.append(time, time_temp)
+
+                    if hasattr(lc_whites[pi], 'centroid_x'):
+                        xpos_temp = np.ma.masked_invalid(
+                            lc_whites[pi].centroid_x.values)
+                        xwidth_temp = np.ma.masked_invalid(
+                            lc_whites[pi].centroid_sx.values)
+                    else:
+                        xpos_temp = None
+                        xwidth_temp = None
+                    if hasattr(lc_whites[pi], 'centroid_y'):
+                        ypos_temp = np.ma.masked_invalid(
+                            lc_whites[pi].centroid_y.values)
+                        ywidth_temp = np.ma.masked_invalid(
+                            lc_whites[pi].centroid_sy.values)
+                    else:
+                        ypos_temp = None
+                        ywidth_temp = None
+
                     xpos = np.ma.append(xpos, xpos_temp)
                     ypos = np.ma.append(ypos, ypos_temp)
                     xwidth = np.ma.append(xwidth, xwidth_temp)
@@ -360,7 +369,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
                 me.saveevent(meta, (meta.outputdir+'S5_'+meta.eventlabel +
                                     "_Meta_Save"), save=[])
 
-            # Now fit the multi-wavelength light curves    
+            # Now fit the multi-wavelength light curves
             elif meta.sharedp and not meta.multwhite:
                 # Get the number of exposures in this lightcurve so
                 # that we know how to split the flattened arrays
@@ -852,7 +861,7 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
                     prior = 'N'
                 par = [value, ptype, priorpar1, priorpar2, prior]
                 setattr(params, key, par)
-        
+
     return meta, params
 
 

--- a/tests/NIRCam_ecfs/S3_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S3_NIRCam.ecf
@@ -23,9 +23,9 @@ bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rej
 bg_hw           12          # Half-width of exclusion region for BG subtraction (relative to source position)
 bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
 p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
-bg_disp         False       # Row-by-row BG subtraction (only useful for NIRCam)
-bg_x1           None        # Left edge of exclusion region for row-by-row BG subtraction
-bg_x2           None        # Right edge of exclusion region for row-by-row BG subtraction
+bg_disp         True        # Row-by-row BG subtraction (only useful for NIRCam)
+bg_x1           28          # Left edge of exclusion region for row-by-row BG subtraction
+bg_x2           1840        # Right edge of exclusion region for row-by-row BG subtraction
 
 # Spectral extraction parameters
 spec_hw         8			# Half-width of aperture region for spectral extraction (relative to source position)

--- a/tests/NIRCam_ecfs/S3_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S3_NIRCam.ecf
@@ -20,9 +20,12 @@ ff_outlier      True        # Set False to use only background region (recommend
 bg_thresh       [5,5]       # Double-iteration X-sigma threshold for outlier rejection along time axis
 
 # Background parameters
-bg_hw       12          # Half-width of exclusion region for BG subtraction (relative to source position)
-bg_deg      1           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
-p3thresh    5           # X-sigma threshold for outlier rejection during background subtraction
+bg_hw           12          # Half-width of exclusion region for BG subtraction (relative to source position)
+bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
+p3thresh        5           # X-sigma threshold for outlier rejection during background subtraction
+bg_disp         False       # Row-by-row BG subtraction (only useful for NIRCam)
+bg_x1           None        # Left edge of exclusion region for row-by-row BG subtraction
+bg_x2           None        # Right edge of exclusion region for row-by-row BG subtraction
 
 # Spectral extraction parameters
 spec_hw         8			# Half-width of aperture region for spectral extraction (relative to source position)


### PR DESCRIPTION
This resolves #522 by skipping a bunch of unnecessary steps in bias_sub.py when `meta.bias_correction is None`.