### PR TITLE
Corrected issues with mgmc centroiding, cleaned up formatting, and corrected plotting features.

### DIFF
--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -749,6 +749,8 @@ def phot_centroid(data, meta):
         Enchanced graph layout, 
         added sig display values for sy,sx,
         and fixed issue with ax[2] displaying sy instead of sx.
+    - 2023-04-21 Isaac Edelman
+        Added flat "0" lines to plots.
     """
     plt.figure(3109)
     plt.clf()
@@ -763,24 +765,30 @@ def phot_centroid(data, meta):
     csx_rms = np.sqrt(np.nanmean((csx - np.nanmedian(csx)) ** 2))
     csy = data.centroid_sy.values
     csy_rms = np.sqrt(np.nanmean((csy - np.nanmedian(csy)) ** 2))
+    flat_line = range(data.time)
+    flat_line_zeros = np.zeros(data.time)
 
     ax[0].plot(data.time, data.centroid_x-np.nanmean(data.centroid_x),
                label=r'$\sigma$x = {0:.4f} pxls'.format(cx_rms))
+    ax[0].plot(flat_line, flat_line_zeros, linestyle=':', color='r')
     ax[0].set_ylabel('Delta x')
     ax[0].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[1].plot(data.time, data.centroid_y-np.nanmean(data.centroid_y),
                label=r'$\sigma$y = {0:.4f} pxls'.format(cy_rms))
+    ax[1].plot(flat_line, flat_line_zeros, linestyle=':', color='r')
     ax[1].set_ylabel('Delta y')
     ax[1].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[2].plot(data.time, data.centroid_sx-np.nanmean(data.centroid_sx),
                label=r'$\sigma$sx = {0:.4f} pxls'.format(csx_rms))
+    ax[2].plot(flat_line, flat_line_zeros, linestyle=':', color='r')
     ax[2].set_ylabel('Delta sx')
     ax[2].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[3].plot(data.time, data.centroid_sy-np.nanmean(data.centroid_sy),
                label=r'$\sigma$sy = {0:.4f} pxls'.format(csy_rms))
+    ax[3].plot(flat_line, flat_line_zeros, linestyle=':', color='r')
     ax[3].set_ylabel('Delta sy')
     ax[3].set_xlabel('Time')
     ax[3].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
@@ -861,34 +869,55 @@ def phot_centroid_fgc(img, x, y, sx, sy, i, m, meta):
 
     - 2022-08-02 Sebastian Zieba
         Initial version
+    - 2023-04-19 Isaac Edelman
+        Cleaned up plot &
+        corrected plotting feature
     """
     plt.figure(3503)
     plt.clf()
     fig, ax = plt.subplots(2, 2, num=3503, figsize=(8, 8))
-    plt.suptitle('Centroid gaussian fit')
-    ax[0, 0].imshow(img, vmax=5e3, origin='lower', aspect='auto')
 
-    ax[1, 0].plot(range(len(np.sum(img, axis=0))), np.sum(img, axis=0))
-    x_plot = np.linspace(0, len(np.sum(img, axis=0)))
+    # Title
+    plt.suptitle('Centroid gaussian fit')
+
+    # Image of source
+    ax[1, 0].imshow(img, vmax=5e3, origin='lower', aspect='auto')
+
+    # X gaussian plot
+    norm_x_factor = np.sum(np.nansum(img, axis=0))
+    ax[0, 0].plot(range(len(np.nansum(img, axis=0))),
+                  np.nansum(img, axis=0)/norm_x_factor)
+    x_plot = np.linspace(0, len(np.nansum(img, axis=0)))
     norm_distr_x = stats.norm.pdf(x_plot, x, sx)
     norm_distr_x_scaled = \
-        norm_distr_x/np.max(norm_distr_x)*np.max(np.sum(img, axis=0))
-    ax[1, 0].plot(x_plot, norm_distr_x_scaled)
-    ax[1, 0].set_xlabel('x position')
-    ax[1, 0].set_ylabel('Flux (electrons)')
+        norm_distr_x/np.nanmax(norm_distr_x)*np.nanmax(np.nansum(img, axis=0))
+    ax[0, 0].plot(x_plot, norm_distr_x_scaled/norm_x_factor,
+                  linestyle='dashed')
+    ax[0, 0].set_xlabel('x position')
+    ax[0, 0].set_ylabel('Normalized Flux')
 
-    ax[0, 1].plot(np.sum(img, axis=1), range(len(np.sum(img, axis=1))))
-    y_plot = np.linspace(0, len(np.sum(img, axis=1)))
+    # Y gaussian plot
+    norm_y_factor = np.sum(np.nansum(img, axis=0))
+    ax[1, 1].plot(np.nansum(img, axis=1)/norm_y_factor,
+                  range(len(np.nansum(img, axis=1))))
+    y_plot = np.linspace(0, len(np.nansum(img, axis=1)))
     norm_distr_y = stats.norm.pdf(y_plot, y, sy)
     norm_distr_y_scaled = \
-        norm_distr_y/np.max(norm_distr_y)*np.max(np.sum(img, axis=1))
-    ax[0, 1].plot(norm_distr_y_scaled, y_plot)
-    ax[0, 1].set_ylabel('y position')
-    ax[0, 1].set_xlabel('Flux (electrons)')
+        norm_distr_y/np.nanmax(norm_distr_y)*np.nanmax(np.nansum(img, axis=1))
+    ax[1, 1].plot(norm_distr_y_scaled/norm_y_factor, y_plot,
+                  linestyle='dashed')
+    ax[1, 1].set_ylabel('y position')
+    ax[1, 1].set_xlabel('Normalized Flux')
 
+    # Last plot in (0,1) not used
+    ax[0, 1].set_axis_off()
+
+    fig.tight_layout()
+    plt.tight_layout()
+
+    # Naming figure
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
     int_number = str(i).zfill(int(np.floor(np.log10(meta.n_int))+1))
-    plt.tight_layout()
     fname = (f'figs{os.sep}fig3503_file{file_number}_int{int_number}'
              f'_Centroid_Fit' + plots.figure_filetype)
     plt.savefig(meta.outputdir + fname, dpi=250)
@@ -1119,8 +1148,6 @@ def phot_2d_frame_diff(data, meta):
         flux1 = data.flux.values[i]
         flux2 = data.flux.values[i+1]
         plt.imshow(flux2-flux1, origin='lower', vmin=-600, vmax=600)
-        plt.xlim(1064-120-512, 1064+120-512)
-        plt.ylim(0, flux1.shape[0])
         plt.xlabel('x pixels')
         plt.ylabel('y pixels')
         plt.colorbar(label='Delta Flux (electrons)')
@@ -1232,7 +1259,7 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
     asb_xpos_max = data.x.values[maxx]
     asb_ypos_min = data.y.values[miny]
     asb_ypos_max = data.y.values[maxy]
-
+    
     # Create median frame
     if saved_refrence_tilt_frame is None:
         refrence_tilt_frame = ((np.nanmedian(data.flux.values[:10],
@@ -1278,7 +1305,7 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
         int_number = str(i).zfill(int(np.floor(np.log10(meta.n_int))+1))
 
         # Define names of files and labels
-        plt.suptitle((f'Segment {file_number}, Integration {int_number}'),
+        plt.suptitle((f'Batch {file_number}, Integration {int_number}'),
                      y=0.99)
         fname = (f'figs{os.sep}tilt_events{os.sep}'
                  f'fig3507a_file{file_number}_int{int_number}'

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -765,29 +765,28 @@ def phot_centroid(data, meta):
     csx_rms = np.sqrt(np.nanmean((csx - np.nanmedian(csx)) ** 2))
     csy = data.centroid_sy.values
     csy_rms = np.sqrt(np.nanmean((csy - np.nanmedian(csy)) ** 2))
-    flat_line = np.zeros(len(data.centroid_x))
 
     ax[0].plot(data.time, data.centroid_x-np.nanmean(data.centroid_x),
                label=r'$\sigma$x = {0:.4f} pxls'.format(cx_rms))
-    ax[0].plot(data.time, flat_line, linestyle=':', color='r')
+    ax[0].axhline(y=0, linestyle=':', c='r')
     ax[0].set_ylabel('Delta x')
     ax[0].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[1].plot(data.time, data.centroid_y-np.nanmean(data.centroid_y),
                label=r'$\sigma$y = {0:.4f} pxls'.format(cy_rms))
-    ax[1].plot(data.time, flat_line, linestyle=':', color='r')
+    ax[1].axhline(y=0, linestyle=':', c='r')
     ax[1].set_ylabel('Delta y')
     ax[1].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[2].plot(data.time, data.centroid_sx-np.nanmean(data.centroid_sx),
                label=r'$\sigma$sx = {0:.4f} pxls'.format(csx_rms))
-    ax[2].plot(data.time, flat_line, linestyle=':', color='r')
+    ax[2].axhline(y=0, linestyle=':', c='r')
     ax[2].set_ylabel('Delta sx')
     ax[2].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[3].plot(data.time, data.centroid_sy-np.nanmean(data.centroid_sy),
                label=r'$\sigma$sy = {0:.4f} pxls'.format(csy_rms))
-    ax[3].plot(data.time, flat_line, linestyle=':', color='r')
+    ax[3].axhline(y=0, linestyle=':', c='r')
     ax[3].set_ylabel('Delta sy')
     ax[3].set_xlabel('Time')
     ax[3].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
@@ -911,7 +910,6 @@ def phot_centroid_fgc(img, x, y, sx, sy, i, m, meta):
     # Last plot in (0,1) not used
     ax[0, 1].set_axis_off()
 
-    fig.tight_layout()
     plt.tight_layout()
 
     # Naming figure

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -1256,7 +1256,7 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
     asb_xpos_max = data.x.values[maxx]
     asb_ypos_min = data.y.values[miny]
     asb_ypos_max = data.y.values[maxy]
-    
+
     # Create median frame
     if saved_refrence_tilt_frame is None:
         refrence_tilt_frame = ((np.nanmedian(data.flux.values[:10],

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -765,30 +765,29 @@ def phot_centroid(data, meta):
     csx_rms = np.sqrt(np.nanmean((csx - np.nanmedian(csx)) ** 2))
     csy = data.centroid_sy.values
     csy_rms = np.sqrt(np.nanmean((csy - np.nanmedian(csy)) ** 2))
-    flat_line = range(data.time)
-    flat_line_zeros = np.zeros(data.time)
+    flat_line = np.zeros(len(data.centroid_x))
 
     ax[0].plot(data.time, data.centroid_x-np.nanmean(data.centroid_x),
                label=r'$\sigma$x = {0:.4f} pxls'.format(cx_rms))
-    ax[0].plot(flat_line, flat_line_zeros, linestyle=':', color='r')
+    ax[0].plot(data.time, flat_line, linestyle=':', color='r')
     ax[0].set_ylabel('Delta x')
     ax[0].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[1].plot(data.time, data.centroid_y-np.nanmean(data.centroid_y),
                label=r'$\sigma$y = {0:.4f} pxls'.format(cy_rms))
-    ax[1].plot(flat_line, flat_line_zeros, linestyle=':', color='r')
+    ax[1].plot(data.time, flat_line, linestyle=':', color='r')
     ax[1].set_ylabel('Delta y')
     ax[1].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[2].plot(data.time, data.centroid_sx-np.nanmean(data.centroid_sx),
                label=r'$\sigma$sx = {0:.4f} pxls'.format(csx_rms))
-    ax[2].plot(flat_line, flat_line_zeros, linestyle=':', color='r')
+    ax[2].plot(data.time, flat_line, linestyle=':', color='r')
     ax[2].set_ylabel('Delta sx')
     ax[2].legend(bbox_to_anchor=(1.03, 0.5), loc=6)
 
     ax[3].plot(data.time, data.centroid_sy-np.nanmean(data.centroid_sy),
                label=r'$\sigma$sy = {0:.4f} pxls'.format(csy_rms))
-    ax[3].plot(flat_line, flat_line_zeros, linestyle=':', color='r')
+    ax[3].plot(data.time, flat_line, linestyle=':', color='r')
     ax[3].set_ylabel('Delta sy')
     ax[3].set_xlabel('Time')
     ax[3].legend(bbox_to_anchor=(1.03, 0.5), loc=6)

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -238,7 +238,8 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
 
             datasets = []
             saved_refrence_tilt_frame = None
-            
+            saved_ref_median_frame = None
+
             for m in range(meta.nbatch):
                 first_file = m*meta.files_per_batch
                 last_file = min([meta.num_data_files,
@@ -441,18 +442,20 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                             meta.ctr_guess is not None):
                         guess = np.array(meta.ctr_guess)[::-1]
                         trim = np.array([meta.ywindow[0], meta.xwindow[0]])
-                        position = guess - trim
+                        position_pri = guess - trim
                     elif meta.centroid_method == 'mgmc':
-                        position, extra = \
-                            centerdriver.centerdriver('mgmc_pri', 
-                                                      data.flux.values, 
-                                                      guess=1, trim=0, 
-                                                      radius=None, size=None, 
-                                                      meta=meta, i=None, 
-                                                      m=None)
+                        position_pri, extra, refrence_median_frame = \
+                            centerdriver.centerdriver(
+                                'mgmc_pri', data.flux.values, guess=1, trim=0,
+                                radius=None, size=None, meta=meta, i=None,
+                                m=None,
+                                saved_ref_median_frame=saved_ref_median_frame)
+                        
+                    if saved_ref_median_frame is None:
+                        saved_ref_median_frame = refrence_median_frame
 
                     # for loop for integrations
-                    for i in tqdm(range(len(data.time)), 
+                    for i in tqdm(range(len(data.time)),
                                   desc='  Looping over Integrations'):
                         if (meta.isplots_S3 >= 3
                                 and meta.oneoverf_corr is not None):
@@ -467,26 +470,26 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                         if (meta.centroid_method == 'fgc' and 
                                 (not hasattr(meta, 'ctr_guess') or
                                  meta.ctr_guess is None)):
-                            centroid_guess = [data.flux.shape[1]//2, 
+                            centroid_guess = [data.flux.shape[1]//2,
                                               data.flux.shape[2]//2]
                             # Do a 2D gaussian fit to the whole frame
-                            position, extra = \
-                                centerdriver.centerdriver('fgc', 
+                            position_pri, extra = \
+                                centerdriver.centerdriver('fgc',
                                                           data.flux.values[i],
-                                                          centroid_guess, 
+                                                          centroid_guess,
                                                           0, 0, 0,
                                                           mask=None, uncd=None,
-                                                          fitbg=1, 
+                                                          fitbg=1,
                                                           maskstar=True,
                                                           expand=1.0, psf=None,
-                                                          psfctr=None, i=i, 
+                                                          psfctr=None, i=i,
                                                           m=m, meta=meta)
 
                         if meta.oneoverf_corr is not None:
                             # Correct for 1/f
                             data = \
                                 inst.do_oneoverf_corr(data, meta, i,
-                                                      position[1], log)
+                                                      position_pri[1], log)
                             if meta.isplots_S3 >= 3 and i < meta.nplots:
                                 plots_s3.phot_2d_frame_oneoverf(
                                     data, meta, m, i, flux_w_oneoverf)
@@ -494,17 +497,18 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                         # Use the determined centroid and
                         # cut out ctr_cutout_size pixels around it
                         # Then perform another 2D gaussian fit
-                        position, extra = \
+                        position, extra, refrence_median_frame = \
                             centerdriver.centerdriver(
                                 meta.centroid_method+'_sec',
-                                data.flux.values[i], 
-                                guess=position,
-                                trim=meta.ctr_cutout_size, 
+                                data.flux.values[i],
+                                guess=position_pri,
+                                trim=meta.ctr_cutout_size,
                                 radius=0, size=0,
-                                mask=data.mask.values[i], 
+                                mask=data.mask.values[i],
                                 uncd=None, fitbg=1,
-                                maskstar=True, expand=1, psf=None, 
-                                psfctr=None, i=i, m=m, meta=meta)
+                                maskstar=True, expand=1, psf=None,
+                                psfctr=None, i=i, m=m, meta=meta,
+                                saved_ref_median_frame=saved_ref_median_frame)
 
                         # Store centroid positions and
                         # the Gaussian 1-sigma half-widths
@@ -548,8 +552,8 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 # plot tilt events
                 if (meta.isplots_S3 >= 5 and meta.inst == 'nircam'): 
                     refrence_tilt_frame = \
-                        plots_s3.tilt_events(meta, data, log, m, 
-                                             position, 
+                        plots_s3.tilt_events(meta, data, log, m,
+                                             position,
                                              saved_refrence_tilt_frame)
 
                     if saved_refrence_tilt_frame is not None:

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -109,19 +109,19 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
         if isTitle:
             ax[0].set_title(f'{meta.eventlabel} - Channel {channel} - '
                             f'{fitter}')
-        ax[0].set_ylabel('Normalized Flux', size=14)
+        ax[0].set_ylabel('Normalized Flux', size=10)
         ax[0].set_xticks([])
 
         ax[1].errorbar(binned_time, binned_normflux, yerr=binned_unc, fmt='.',
                        color='w', ecolor=color, mec=color)
         ax[1].plot(new_timet, model_phys, color='0.3', zorder=10)
-        ax[1].set_ylabel('Calibrated Flux', size=14)
+        ax[1].set_ylabel('Calibrated Flux', size=10)
         ax[1].set_xticks([])
 
         ax[2].errorbar(binned_time, binned_res*1e6, yerr=binned_unc*1e6,
                        fmt='.', color='w', ecolor=color, mec=color)
         ax[2].plot(time, np.zeros_like(time), color='0.3', zorder=10)
-        ax[2].set_ylabel('Residuals (ppm)', size=14)
+        ax[2].set_ylabel('Residuals (ppm)', size=10)
         ax[2].set_xlabel(str(lc.time_units), size=14)
 
         fig.subplots_adjust(hspace=0)

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -109,19 +109,19 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
         if isTitle:
             ax[0].set_title(f'{meta.eventlabel} - Channel {channel} - '
                             f'{fitter}')
-        ax[0].set_ylabel('Normalized Flux', size=10)
+        ax[0].set_ylabel('Normalized Flux', size=14)
         ax[0].set_xticks([])
 
         ax[1].errorbar(binned_time, binned_normflux, yerr=binned_unc, fmt='.',
                        color='w', ecolor=color, mec=color)
         ax[1].plot(new_timet, model_phys, color='0.3', zorder=10)
-        ax[1].set_ylabel('Calibrated Flux', size=10)
+        ax[1].set_ylabel('Calibrated Flux', size=14)
         ax[1].set_xticks([])
 
         ax[2].errorbar(binned_time, binned_res*1e6, yerr=binned_unc*1e6,
                        fmt='.', color='w', ecolor=color, mec=color)
         ax[2].plot(time, np.zeros_like(time), color='0.3', zorder=10)
-        ax[2].set_ylabel('Residuals (ppm)', size=10)
+        ax[2].set_ylabel('Residuals (ppm)', size=14)
         ax[2].set_xlabel(str(lc.time_units), size=14)
 
         fig.subplots_adjust(hspace=0)

--- a/src/eureka/lib/centerdriver.py
+++ b/src/eureka/lib/centerdriver.py
@@ -10,40 +10,39 @@ def centerdriver(method, data, guess, trim, radius, size, i, m, meta,
                  mask=None, uncd=None, fitbg=1, maskstar=True,
                  expand=5.0, psf=None, psfctr=None):
     """
-    method = fgc : Use the center method to find the center of a star in data,
-    starting from position guess.
-    method = mgmc : Use the specified centroiding method 1dg, 2dg, or com,
-    to create a centroid inital guess
-    then hone in on the centroid position using that guess.
+    Use the center method to find the center of a star in data, starting
+    from position guess.
 
     Parameters
     ----------
     method : string
-             Name of the centering method to use.
+        Name of the centering method to use.
     data : 2D ndarray
-           Array containing the star image.
+        Array containing the star image.
     guess : 2 elements 1D array
-            y, x initial guess position of the target.
+        y, x initial guess position of the target.
     trim : integer
-           Semi-lenght of the box around the target that will be trimmed.
+        Semi-lenght of the box around the target that will be trimmed.
     radius : float
-             least asymmetry parameter. See err_fasym_c.
+        least asymmetry parameter. See err_fasym_c.
     size : float
-           least asymmetry parameter. See err_fasym_c.
+        least asymmetry parameter. See err_fasym_c.
     mask : 2D ndarray
-           A mask array of bad pixels. Same shape of data.
+        A mask array of bad pixels. Same shape of data.
     uncd : 2D ndarray
-           An array containing the uncertainty values of data.
-           Same shape of data.
+        An array containing the uncertainty values of data.
+        Same shape of data.
     saved_ref_median_frame : ndarray
-                             Stored median frame of the first batch.
+        Stored median frame of the first batch.
 
     Returns
     -------
-    A y,x tuple (scalars) with the coordinates of center of the target
-    in data. refrence_median_frame an ndarray which is the median
-    of the first batch to be used as the refrence frame for the first
-    centroid location guess in the mgmc method. 
+    tuple
+        A (y,x) tuple (scalars) with the coordinates of center of the target
+        in data.
+    ndarray
+        The median of the first batch to be used as the refrence
+        frame for the first centroid location guess in the mgmc method.
 
     Notes
     -----

--- a/src/eureka/lib/centerdriver.py
+++ b/src/eureka/lib/centerdriver.py
@@ -5,7 +5,8 @@ from . import gaussian_min as gmin
 from ..S3_data_reduction import plots_s3
 
 
-def centerdriver(method, data, guess, trim, radius, size, i, m, meta,
+def centerdriver(method, data, guess, trim, radius, size, i, m, meta, 
+                 saved_ref_median_frame,
                  mask=None, uncd=None, fitbg=1, maskstar=True,
                  expand=5.0, psf=None, psfctr=None):
     """
@@ -90,15 +91,17 @@ def centerdriver(method, data, guess, trim, radius, size, i, m, meta,
         extra = sy, sx  # Gaussian 1-sigma half-widths
     elif method == 'mgmc_pri':
         # Median frame creation + first centroid
-        x, y = gmin.pri_cent(img, meta)
+        x, y, refrence_median_frame = gmin.pri_cent(img, meta,
+                                                    saved_ref_median_frame)
     elif method == 'mgmc_sec': 
         # Second enhanced centroid position + gaussian widths
         sy, sx, y, x = gmin.mingauss(img, yxguess=loc, meta=meta)
         extra = sy, sx  # Gaussian 1-sigma half-widths
+        refrence_median_frame = None
 
     # only plot when we do the second fit
     if (meta.isplots_S3 >= 5 and method[-4:] == '_sec' and i < meta.nplots):
         plots_s3.phot_centroid_fgc(img, x, y, sx, sy, i, m, meta)
 
     # Make trimming correction and return
-    return ((y, x) + cen - trim), extra
+    return ((y, x) + cen - trim), extra, refrence_median_frame

--- a/src/eureka/lib/centerdriver.py
+++ b/src/eureka/lib/centerdriver.py
@@ -10,33 +10,40 @@ def centerdriver(method, data, guess, trim, radius, size, i, m, meta,
                  mask=None, uncd=None, fitbg=1, maskstar=True,
                  expand=5.0, psf=None, psfctr=None):
     """
-    Use the center method to find the center of a star in data, starting
-    from position guess.
+    method = fgc : Use the center method to find the center of a star in data,
+    starting from position guess.
+    method = mgmc : Use the specified centroiding method 1dg, 2dg, or com,
+    to create a centroid inital guess
+    then hone in on the centroid position using that guess.
 
     Parameters
     ----------
-    method: string
-            Name of the centering method to use.
-    data:   2D ndarray
-            Array containing the star image.
-    guess:  2 elements 1D array
+    method : string
+             Name of the centering method to use.
+    data : 2D ndarray
+           Array containing the star image.
+    guess : 2 elements 1D array
             y, x initial guess position of the target.
-    trim:   integer
-            Semi-lenght of the box around the target that will be trimmed.
-    radius: float
-            least asymmetry parameter. See err_fasym_c.
-    size:   float
-            least asymmetry parameter. See err_fasym_c.
-    mask:   2D ndarray
-            A mask array of bad pixels. Same shape of data.
-    uncd:   2D ndarray
-            An array containing the uncertainty values of data. Same
-            shape of data.
+    trim : integer
+           Semi-lenght of the box around the target that will be trimmed.
+    radius : float
+             least asymmetry parameter. See err_fasym_c.
+    size : float
+           least asymmetry parameter. See err_fasym_c.
+    mask : 2D ndarray
+           A mask array of bad pixels. Same shape of data.
+    uncd : 2D ndarray
+           An array containing the uncertainty values of data.
+           Same shape of data.
+    saved_ref_median_frame : ndarray
+                             Stored median frame of the first batch.
 
     Returns
     -------
     A y,x tuple (scalars) with the coordinates of center of the target
-    in data.
+    in data. refrence_median_frame an ndarray which is the median
+    of the first batch to be used as the refrence frame for the first
+    centroid location guess in the mgmc method. 
 
     Notes
     -----

--- a/src/eureka/lib/gaussian_min.py
+++ b/src/eureka/lib/gaussian_min.py
@@ -13,16 +13,16 @@ def evalgauss(params, x, y, x0, y0):
     Parameters
     ----------
     params : list
-        List components : amplitude, x_stddev, y_stddev. 
-        Acts as the inital guess from meta (params_guess).
+             List components : amplitude, x_stddev, y_stddev. 
+             Acts as the inital guess from meta (params_guess).
     x : ndarray
         The x-coordinates for every pixel within the considered frame.
     y :  ndarray
-        The y-coordinates for every pixel within the considered frame.
+         The y-coordinates for every pixel within the considered frame.
     x0 : float
-        X position guess for centroid.
+         X position guess for centroid.
     y0 : float
-        Y position guess for centroid.
+         Y position guess for centroid.
 
     Returns
     -------
@@ -52,18 +52,18 @@ def minfunc(params, frame, x, y, x_mean, y_mean):
     Parameters
     ----------
     params : list
-        List components : amplitude, x_stddev, y_stddev. 
-        Acts as the inital guess from meta (params_guess).
+             List components : amplitude, x_stddev, y_stddev. 
+             Acts as the inital guess from meta (params_guess).
     frame : 2D ndarray
-        Array containing the star image.
+            Array containing the star image.
     x : ndarray
         The x-coordinates for every pixel within the considered frame.
     y : ndarray
         The y-coordinates for every pixel within the considered frame.
     x_mean : float
-        X position guess for centroid.
+             X position guess for centroid.
     y_mean : float
-        Y position guess for centroid.
+             Y position guess for centroid.
 
     Returns 
     ------- 
@@ -91,9 +91,11 @@ def pri_cent(img, meta, saved_ref_median_frame):
     Parameters
     ----------
     img : 2D ndarray
-        Array containing the star image.
+          Array containing the star image.
     meta : eureka.lib.readECF.MetaClass
-        The metadata object.
+           The metadata object.
+    saved_ref_median_frame : ndarray
+                             The stored median frame of the first batch.
 
     Returns 
     ------- 
@@ -101,6 +103,8 @@ def pri_cent(img, meta, saved_ref_median_frame):
         First guess of x centroid position. 
     y : float 
         First guess of y centroid position.
+    refrence_median_frame : ndarray
+                            Median frame of the first batch.
 
     Notes
     -----
@@ -109,8 +113,7 @@ def pri_cent(img, meta, saved_ref_median_frame):
     - Feb 22, 2023 Isaac Edelman 
         Initial implementation.
     """
-    # Create median frame from batch
-    # median_Frame = np.ma.median(img, axis=0)
+
     # Create median frame
     if saved_ref_median_frame is None:
         refrence_median_frame = np.ma.median(img, axis=0)
@@ -137,18 +140,18 @@ def mingauss(img, yxguess, meta):
     Parameters
     ----------
     img : 2D ndarray
-        Array containing the star image.
+          Array containing the star image.
     yxguess : tuple
-        A guess at the y and x centroid positions.
+              A guess at the y and x centroid positions.
     meta : eureka.lib.readECF.MetaClass
-        The metadata object.
+           The metadata object.
 
     Returns
     -------
     sy : float
-        Gaussian width in y direction.
+         Gaussian width in y direction.
     sx : float
-        Gaussian width in x direction.
+         Gaussian width in x direction.
     x : float
         Refined centroid x position.
     y : float

--- a/src/eureka/lib/gaussian_min.py
+++ b/src/eureka/lib/gaussian_min.py
@@ -13,16 +13,16 @@ def evalgauss(params, x, y, x0, y0):
     Parameters
     ----------
     params : list
-             List components : amplitude, x_stddev, y_stddev. 
-             Acts as the inital guess from meta (params_guess).
+        List components : amplitude, x_stddev, y_stddev. 
+        Acts as the inital guess from meta (params_guess).
     x : ndarray
         The x-coordinates for every pixel within the considered frame.
     y :  ndarray
-         The y-coordinates for every pixel within the considered frame.
+        The y-coordinates for every pixel within the considered frame.
     x0 : float
-         X position guess for centroid.
+        X position guess for centroid.
     y0 : float
-         Y position guess for centroid.
+        Y position guess for centroid.
 
     Returns
     -------
@@ -52,18 +52,18 @@ def minfunc(params, frame, x, y, x_mean, y_mean):
     Parameters
     ----------
     params : list
-             List components : amplitude, x_stddev, y_stddev. 
-             Acts as the inital guess from meta (params_guess).
+        List components : amplitude, x_stddev, y_stddev. 
+        Acts as the inital guess from meta (params_guess).
     frame : 2D ndarray
-            Array containing the star image.
+        Array containing the star image.
     x : ndarray
         The x-coordinates for every pixel within the considered frame.
     y : ndarray
         The y-coordinates for every pixel within the considered frame.
     x_mean : float
-             X position guess for centroid.
+        X position guess for centroid.
     y_mean : float
-             Y position guess for centroid.
+        Y position guess for centroid.
 
     Returns 
     ------- 
@@ -91,11 +91,11 @@ def pri_cent(img, meta, saved_ref_median_frame):
     Parameters
     ----------
     img : 2D ndarray
-          Array containing the star image.
+        Array containing the star image.
     meta : eureka.lib.readECF.MetaClass
-           The metadata object.
+        The metadata object.
     saved_ref_median_frame : ndarray
-                             The stored median frame of the first batch.
+        The stored median frame of the first batch.
 
     Returns 
     ------- 
@@ -104,7 +104,7 @@ def pri_cent(img, meta, saved_ref_median_frame):
     y : float 
         First guess of y centroid position.
     refrence_median_frame : ndarray
-                            Median frame of the first batch.
+        Median frame of the first batch.
 
     Notes
     -----
@@ -140,18 +140,18 @@ def mingauss(img, yxguess, meta):
     Parameters
     ----------
     img : 2D ndarray
-          Array containing the star image.
+        Array containing the star image.
     yxguess : tuple
-              A guess at the y and x centroid positions.
+        A guess at the y and x centroid positions.
     meta : eureka.lib.readECF.MetaClass
-           The metadata object.
+        The metadata object.
 
     Returns
     -------
     sy : float
-         Gaussian width in y direction.
+        Gaussian width in y direction.
     sx : float
-         Gaussian width in x direction.
+        Gaussian width in x direction.
     x : float
         Refined centroid x position.
     y : float

--- a/src/eureka/lib/gaussian_min.py
+++ b/src/eureka/lib/gaussian_min.py
@@ -84,7 +84,7 @@ def minfunc(params, frame, x, y, x_mean, y_mean):
     return np.nanmean((model_gauss-frame)**2)
 
 
-def pri_cent(img, meta):
+def pri_cent(img, meta, saved_ref_median_frame):
     """
     Create initial centroid guess based off of median frame of data.
     
@@ -110,17 +110,22 @@ def pri_cent(img, meta):
         Initial implementation.
     """
     # Create median frame from batch
-    median_Frame = np.ma.median(img, axis=0)
+    # median_Frame = np.ma.median(img, axis=0)
+    # Create median frame
+    if saved_ref_median_frame is None:
+        refrence_median_frame = np.ma.median(img, axis=0)
+    else:
+        refrence_median_frame = saved_ref_median_frame
 
     # Create initial centroid guess using specified method
     if meta.centroid_tech.lower() in ['com', '1dg', '2dg']:
         cent_func = getattr(sys.modules[__name__],
                             ("centroid_" + meta.centroid_tech.lower()))
-        x, y = cent_func(median_Frame)
+        x, y = cent_func(refrence_median_frame)
     else:
         print("Invalid centroid_tech option")
 
-    return x, y
+    return x, y, refrence_median_frame
 
 
 def mingauss(img, yxguess, meta):


### PR DESCRIPTION
Corrected plotting features, addressed edge cases with the mgmc centroiding method, and cleaned up formatting.

----
-Added dashed zero lines to fig.3109 to help identify if any slopes occur.

Before:
---
![fig3109-Centroid](https://user-images.githubusercontent.com/113392078/236344142-2ca8fcb6-0400-4b87-ba7d-1fa6b1522857.png)

after:
---
![fig3109-Centroid](https://user-images.githubusercontent.com/113392078/236344061-181f2dc4-8334-49c1-8bbf-c79b7ece5932.png)

-Reformatted fig.3503 to display and corrected 1D gaussians to source in x and y directions.

Before:
---
![fig3503_file0_int001_Centroid_Fit](https://user-images.githubusercontent.com/113392078/236344495-0b3596fc-3037-4c03-bfed-0fbdfe1cf234.png)

After:
---
![fig3503_file0_int000_Centroid_Fit](https://user-images.githubusercontent.com/113392078/236344340-0674dbeb-40c1-473f-87a1-7a706d69eed2.png)

-Corrected labeling in fig.3507 to display batch values instead of segment values.

-Tweaked s3_reduce.py to remember the first median frame for centroiding method to address issues where a new batch could have a bad start frame for the primary centroid guess causing the position to drift over time.

-Renamed the initial centroiding guess position variable for the mgmc method to address issues with position variable being over written by fgc position.

-Changed font size for fig.5101 to make the side labels not smooshed.

Before:
---
![fig5101_ch0_lc_nuts](https://user-images.githubusercontent.com/113392078/236343928-f9eaa3f6-a0df-4dfe-95cf-02e2a7575c90.png)

After:
---
![fig5101_ch0_lc_nuts](https://user-images.githubusercontent.com/113392078/236343800-176b1c47-6f19-4c4b-ae0d-1a9690a1d43c.png)

-Updated the mgmc centroiding method to account for the saved median frame used for centroiding position.

----

This passes test_Photometry_NIRCam.py on my laptop and is flake8 compliant.