### PR TITLE
Changing the MAD computation direction

### DIFF
--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -288,7 +288,7 @@ def separate_direct(meta, log):
                 index = indices[-1]
             meta.direct_index[i] = index
 
-    meta.obstimes = obstimes
+    meta.obstimes = science_times
     meta.CRPIX1 = CRPIX1
     meta.CRPIX2 = CRPIX2
     meta.postarg1 = postarg1

--- a/src/eureka/S4_generate_lightcurves/wfc3.py
+++ b/src/eureka/S4_generate_lightcurves/wfc3.py
@@ -75,7 +75,8 @@ def sum_reads(spec, lc, meta):
     spec.guess['time'] = time
     spec.scandir['time'] = time
     lc.centroid_x['time'] = time
-    lc.centroid_sx['time'] = time
+    if hasattr(lc, 'centroid_sx'):
+        lc.centroid_sx['time'] = time
     lc.centroid_y['time'] = time
     lc.scandir['time'] = time
     lc.driftmask['time'] = time

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -468,9 +468,9 @@ def get_mad(meta, log, wave_1d, optspec, optmask=None,
     """Computes variation on median absolute deviation (MAD) using ediff1d
     for 2D data.
 
-    The computed MAD is the average MAD along the wavelength direction. In
-    otherwords, the MAD is computed in the spectral direction for each
-    integration, and then the returned value is the average of those MAD
+    The computed MAD is the average MAD along the time axis. In
+    otherwords, the MAD is computed in the time direction for each
+    wavelength, and then the returned value is the average of those MAD
     values.
 
     Parameters
@@ -514,22 +514,39 @@ def get_mad(meta, log, wave_1d, optspec, optmask=None,
     # Normalize the spectrum
     normspec = normalize_spectrum(meta, optspec[:, iwmin:iwmax])
 
-    # Compute the MAD
-    n_int = normspec.shape[0]
-    ediff = np.ma.zeros(n_int)
-    for m in range(n_int):
-        ediff[m] = get_mad_1d(normspec[m])
-
     if meta.inst == 'wfc3':
+        # Setup 1D MAD arrays
+        n_wav = normspec.shape[1]
+        ediff = np.ma.zeros(2, n_wav)
+
         scandir = np.repeat(meta.scandir, meta.nreads)
 
         # Compute the MAD for each scan direction
         for p in range(2):
             iscans = np.where(scandir == p)[0]
             if len(iscans) > 0:
-                mad = np.ma.mean(ediff[iscans])
-                log.writelog(f"Scandir {p} MAD = {int(np.round(mad))} ppm")
-                setattr(meta, f'mad_scandir{p}', mad)
+                # Compute the MAD
+                for m in range(n_wav):
+                    ediff[p, m] = get_mad_1d(normspec[iscans, m])
+
+            mad = np.ma.mean(ediff[p])
+            log.writelog(f"Scandir {p} MAD = {int(np.round(mad))} ppm")
+            setattr(meta, f'mad_scandir{p}', mad)
+        
+        if np.all(scandir == scandir[0]):
+            # Only scanned in one direction, so get rid of the other
+            ediff = ediff[scandir[0]]
+        else:
+            # Collapse the MAD along the scan direction
+            ediff = np.mean(ediff, axis=0)
+    else:
+        # Setup 1D MAD array
+        n_wav = normspec.shape[1]
+        ediff = np.ma.zeros(n_wav)
+
+        # Compute the MAD
+        for m in range(n_wav):
+            ediff[m] = get_mad_1d(normspec[:, m])
 
     return np.ma.mean(ediff)
 

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -529,9 +529,9 @@ def get_mad(meta, log, wave_1d, optspec, optmask=None,
                 for m in range(n_wav):
                     ediff[p, m] = get_mad_1d(normspec[iscans, m])
 
-            mad = np.ma.mean(ediff[p])
-            log.writelog(f"Scandir {p} MAD = {int(np.round(mad))} ppm")
-            setattr(meta, f'mad_scandir{p}', mad)
+                mad = np.ma.mean(ediff[p])
+                log.writelog(f"Scandir {p} MAD = {int(np.round(mad))} ppm")
+                setattr(meta, f'mad_scandir{p}', mad)
         
         if np.all(scandir == scandir[0]):
             # Only scanned in one direction, so get rid of the other

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -517,7 +517,7 @@ def get_mad(meta, log, wave_1d, optspec, optmask=None,
     if meta.inst == 'wfc3':
         # Setup 1D MAD arrays
         n_wav = normspec.shape[1]
-        ediff = np.ma.zeros(2, n_wav)
+        ediff = np.ma.zeros((2, n_wav))
 
         scandir = np.repeat(meta.scandir, meta.nreads)
 

--- a/tests/WFC3_ecfs/S3_WFC3.ecf
+++ b/tests/WFC3_ecfs/S3_WFC3.ecf
@@ -3,7 +3,7 @@
 # Stage 3 Documentation: https://eurekadocs.readthedocs.io/en/latest/ecf.html#stage-3
 
 ncpu            1           # Number of CPUs
-nfiles          1           # The max number of data files to analyze simultaneously
+nfiles          2           # The max number of data files to analyze simultaneously
 max_memory      0.5         # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
 suffix          ima         # Data file suffix
 
@@ -27,7 +27,7 @@ centroidguess   [29, 154]
 
 # Flatfield parameters
 flatoffset      [[374, 374]]  #[[379, 379]]
-flatsigma       3
+flatsigma       50
 
 # Sigma theshold for bad pixel identification in the differential non-destructive reads (NDRs)
 diffthresh      10
@@ -59,6 +59,7 @@ time_axis       'y'         # Determines whether the time axis in Figure 3101 is
 testing_S3      False       # Boolean, set True to only use last file and generate select figures
 hide_plots      True        # If True, plots will automatically be closed rather than popping up
 save_output     True        # Save outputs for use in S4
+save_fluxdata   False		# Save FluxData outputs for debugging or use with other tools (can be quite large files)
 verbose         False       # If True, more details will be printed about steps
 
 # Project directory

--- a/tests/WFC3_ecfs/S4_WFC3.ecf
+++ b/tests/WFC3_ecfs/S4_WFC3.ecf
@@ -10,7 +10,7 @@ wave_max        1.175       # Maximum wavelength. Set to None to use the longest
 allapers        False       # Run S4 on all of the apertures considered in S3? Otherwise will use newest output in the inputdir
 
 # Parameters for drift correction of 1D spectra
-recordDrift     False   # Set True to record drift/jitter in 1D spectra (always recorded if correctDrift is True)
+recordDrift     True    # Set True to record drift/jitter in 1D spectra (always recorded if correctDrift is True)
 correctDrift    True    # Set True to correct drift/jitter in 1D spectra (not recommended for simulated data)
 drift_preclip   0       # Ignore first drift_preclip points of spectrum
 drift_postclip  100     # Ignore last drift_postclip points of spectrum, None = no clipping
@@ -23,7 +23,7 @@ highpassWidth   10      # The integer width of the highpass filter when subtract
 
 # Parameters for sigma clipping
 clip_unbinned   False   # Whether or not sigma clipping should be performed on the unbinned 1D time series
-clip_binned     True    # Whether or not sigma clipping should be performed on the binned 1D time series
+clip_binned     False   # Whether or not sigma clipping should be performed on the binned 1D time series
 sigma           10      # The number of sigmas a point must be from the rolling median to be considered an outlier
 box_width       10      # The width of the box-car filter (used to calculated the rolling median) in units of number of data points
 maxiters        5       # The number of iterations of sigma clipping that should be performed.


### PR DESCRIPTION
Resolves #304

Previously, the MAD was computed along the wavelength axis and then an average value was computed. Minimizing this 2D MAD is essentially minimizing noise in the spectral direction. Instead, we typically want to minimize noise in the temporal direction, so I've rotated the MAD calculation so that it is computed along the time axis for each wavelength, and then averaged. I also separately handle each WFC3 scan direction to avoid issues there.

I also had to fix a couple of WFC3-related bugs and testing issues in order to get the tests to pass (resolves #542 and other unsubmitted bugs).