### PR TITLE
Edit DL script to put HST files in same directory.

### DIFF
--- a/demos/HST/download_data_HST_template.py
+++ b/demos/HST/download_data_HST_template.py
@@ -34,9 +34,7 @@ for vis in visits:
     if result is not None:
         # Consolodate and move data into new directory
         md.consolidate(result, final_dir)
-        # Sort data into science and calibration folders (scan vs direct image)
-        md.sortHST(final_dir)
-
+        
 # Delete empty temporary directory structure
 md.cleanup(download_dir)
 md.logout()

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -594,15 +594,7 @@ If True, more details will be printed about steps.
 
 topdir + inputdir
 '''''''''''''''''
-The path to the directory containing the Stage 2 JWST data. For HST observations, the sci_dir and cal_dir folders will only be checked if this folder does not contain FITS files.
-
-topdir + inputdir + sci_dir
-'''''''''''''''''''''''''''
-Optional, only used for HST analyses. The path to the folder containing the science spectra. Defaults to 'sci'.
-
-topdir + inputdir + cal_dir
-'''''''''''''''''''''''''''
-Optional, only used for HST analyses. The path to the folder containing the wavelength calibration imaging mode observations. Defaults to 'cal'.
+The path to the directory containing the Stage 2 JWST data, or, for HST observations, the _ima FITS files (including both direct images and spectra) downloaded from MAST.
 
 topdir + outputdir
 ''''''''''''''''''


### PR DESCRIPTION
Edited the demo HST MAST download script to remove the call to `sortHST()` that splits up the direct images and spectra into different directories. Also edited the S3 ECF docs page to remove text that implies these should be split up into sci and cal directories, and clarified they should be in the same directory. This should remove any confusion by new HST users (and me, after several weeks of not thinking about HST).

Should we also remove `sortHST()` as a function? Probably not, right?