### PR TITLE
Updated install instructions to fix deprecation

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -49,13 +49,13 @@ Once in your new conda environment, you can install the ``Eureka!`` package with
 
 .. code-block:: bash
 
-	pip install -e git+https://github.com/kevin218/Eureka.git@v0.9#egg=eureka[jwst]
+	pip install eureka[jwst]@git+https://github.com/kevin218/Eureka.git@v0.9
 
 Other specific branches can be installed using:
 
 .. code-block:: bash
 
-	pip install -e git+https://github.com/kevin218/Eureka.git@mybranchname#egg=eureka[jwst]
+	pip install eureka[jwst]@git+https://github.com/kevin218/Eureka.git@mybranchname
 
 In order to use any of the demo ECF files, follow the instructions in the :ref:`Demos <demos>` section of the :ref:`Quickstart <quickstart>` page.
 


### PR DESCRIPTION
The current pip installation method using egg= raises a warning about a deprecation that is coming with pip version 25.0. To get ahead of that, let's change things now.

The warning that is currently raised is:

> DEPRECATION: git+https://github.com/kevin218/Eureka.git@dev/tjb#egg=eureka[jwst] contains an egg fragment with a non-PEP 508 name pip 25.0 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/11617