### PR TITLE
Yoni bugfix

### DIFF
--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -970,6 +970,9 @@ def cut_aperture(data, meta, log):
     log.writelog('  Extracting aperture region...',
                  mute=(not meta.verbose))
 
+    log.writelog(f'  {data.flux.shape}',
+                 mute=(not meta.verbose))
+
     apdata = np.zeros((meta.n_int, meta.spec_hw*2+1, meta.subnx))
     aperr = np.zeros((meta.n_int, meta.spec_hw*2+1, meta.subnx))
     apmask = np.zeros((meta.n_int, meta.spec_hw*2+1, meta.subnx))
@@ -984,12 +987,29 @@ def cut_aperture(data, meta, log):
             # Figure out the index currently being cut out
             n = f*meta.nreads + r
 
+            #log.writelog(f'\t{f}\t{p}\t{r}\t{n}',
+            #     mute=(not meta.verbose))
+
             # Use the centroid from the relevant reference frame
             guess = meta.guess[p].values[r]
+
             ap_y1 = (guess-meta.spec_hw).astype(int)
             ap_y2 = (guess+meta.spec_hw+1).astype(int)
 
+            if ap_y1 < 0:
+                ap_y1 = 0
+                ap_y2 = 2*meta.spec_hw + 1
+        
+            if ap_y2 > len(data.flux.values[n]):
+                ap_y2 = len(data.flux.values[n])
+                ap_y1 = len(data.flux.values[n]) - (2*meta.spec_hw + 1)
+
+            #log.writelog(f'\t\t{guess}\t{ap_y1}\t{ap_y2}',
+            #     mute=(not meta.verbose))
+
             # Cut out this particular read
+            #log.writelog(f'\t\t\t{data.flux.values[n, ap_y1:ap_y2].shape}',
+            #                mute=(not meta.verbose))
             apdata[n] = data.flux.values[n, ap_y1:ap_y2]
             aperr[n] = data.err.values[n, ap_y1:ap_y2]
             apmask[n] = data.mask.values[n, ap_y1:ap_y2]

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -970,8 +970,8 @@ def cut_aperture(data, meta, log):
     log.writelog('  Extracting aperture region...',
                  mute=(not meta.verbose))
 
-    log.writelog(f'  {data.flux.shape}',
-                 mute=(not meta.verbose))
+    #log.writelog(f'  {data.flux.shape}',
+    #             mute=(not meta.verbose))
 
     apdata = np.zeros((meta.n_int, meta.spec_hw*2+1, meta.subnx))
     aperr = np.zeros((meta.n_int, meta.spec_hw*2+1, meta.subnx))


### PR DESCRIPTION
This might resolve #561, where certain `spec_hw` values sometimes run off the edge of the subarray and break things. `ap_y1` can now no longer be less than 0 and `ap_y2` can now no longer be longer than the subarray in question. I haven't exhaustively tested it, but what I have done seems to handle both failure modes. I don't think this ruins later bits of S3, and my initial runs seem to behave okay, but I'd like some other eyes on this.