### PR TITLE
Add HSTRampModel to __init__ for proper importing

### DIFF
--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/__init__.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/__init__.py
@@ -1,6 +1,7 @@
 from .PyMC3Models import PyMC3Model, CompositePyMC3Model
 from .CentroidModel import CentroidModel
 from .ExpRampModel import ExpRampModel
+from .HSTRampModel import HSTRampModel
 from .PolynomialModel import PolynomialModel
 from .SinusoidPhaseCurve import SinusoidPhaseCurveModel
 from .StarryModel import StarryModel

--- a/src/eureka/S5_lightcurve_fitting/models/__init__.py
+++ b/src/eureka/S5_lightcurve_fitting/models/__init__.py
@@ -2,6 +2,8 @@ from .BatmanModels import BatmanTransitModel, BatmanEclipseModel
 from .CentroidModel import CentroidModel
 from .ExpRampModel import ExpRampModel
 from .GPModel import GPModel
+from .HSTRampModel import HSTRampModel
+from .KeplerOrbit import KeplerOrbit
 from .Model import Model, CompositeModel
 from .PolynomialModel import PolynomialModel
 from .SinusoidPhaseCurve import SinusoidPhaseCurveModel


### PR DESCRIPTION
The various `__init__.py` files in `S5/models` and `S5/differentiable_models` needed to have the actual HST ramp models specified so they could be used when fitting WFC3 data. I also added the KeplerOrbit as that wasn't available either, but I have not actually tried to use that orbit model and just assumed it was an oversight.