### PR TITLE
Logging Eureka! version and CRDS pmap

### DIFF
--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -18,6 +18,12 @@ suffix
 ''''''
 Data file suffix (e.g. uncal).
 
+
+pmap
+''''
+Optional. If you want to use a specific CRDS context pmap (e.g. to reproduce someone else's work), you can specify the pmap number here. For example, to use ``jwst_1089.pmap``, set this ``pmap`` parameter to ``1089``.
+
+
 ramp_fit_algorithm
 ''''''''''''''''''
 Algorithm to use to fit a ramp to the frame-level images of uncalibrated files. Only default (i.e. the JWST pipeline) and mean can be used currently.
@@ -219,6 +225,9 @@ Data file suffix (e.g. rateints).
 .. note::
 	Note that other Instruments might used different suffixes!
 
+pmap
+''''
+Optional. If you want to use a specific CRDS context pmap (e.g. to reproduce someone else's work), you can specify the pmap number here. For example, to use ``jwst_1089.pmap``, set this ``pmap`` parameter to ``1089``.
 
 slit_y_low & slit_y_high
 ''''''''''''''''''''''''
@@ -317,6 +326,10 @@ An optional input parameter. If False (default), convert the units of the images
 poly_wavelength
 '''''''''''''''
 If True, use an updated polynomial wavelength solution for NIRCam longwave spectroscopy instead of the linear wavelength solution currently assumed by STScI.
+
+pmap
+''''
+Optional. If you want to use a specific CRDS context pmap (e.g. to reproduce someone else's work), you can specify the pmap number here. For example, to use ``jwst_1089.pmap``, set this ``pmap`` parameter to ``1089``.
 
 gain
 ''''

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -59,6 +59,10 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
     else:
         meta = input_meta
 
+    # If a specific CRDS context is entered in the ECF, apply it
+    if hasattr(meta, 'pmap') and meta.pmap is not None:
+        os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
+
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -65,7 +65,8 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
     # Otherwise, log and fix the default CRDS context to make sure it doesn't
     # change between different segments.
     if not hasattr(meta, 'pmap') or meta.pmap is None:
-        meta.pmap = crds.get_default_context()
+        # Get just the numerical value
+        meta.pmap = crds.get_context_name('jwst')[5:-5]
     os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
 
     meta.version = version

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -12,6 +12,7 @@ from eureka.S1_detector_processing.superbias import Eureka_SuperBiasStep
 from ..lib import logedit, util
 from ..lib import manageevent as me
 from ..lib import readECF
+from ..version import version
 
 
 def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
@@ -63,6 +64,7 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
     if hasattr(meta, 'pmap') and meta.pmap is not None:
         os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
 
+    meta.version = version
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
@@ -77,6 +79,7 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
     meta.s1_logname = meta.outputdir + 'S1_' + meta.eventlabel + ".log"
     log = logedit.Logedit(meta.s1_logname)
     log.writelog("\nStarting Stage 1 Processing")
+    log.writelog(f"Eureka! Version: {meta.version}", mute=True)
     log.writelog(f"Input directory: {meta.inputdir}")
     log.writelog(f"Output directory: {meta.outputdir}")
 

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from astropy.io import fits
 
 from jwst.pipeline.calwebb_detector1 import Detector1Pipeline
+import crds
 
 from eureka.S1_detector_processing.ramp_fitting import Eureka_RampFitStep
 from eureka.S1_detector_processing.superbias import Eureka_SuperBiasStep
@@ -60,9 +61,12 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
     else:
         meta = input_meta
 
-    # If a specific CRDS context is entered in the ECF, apply it
-    if hasattr(meta, 'pmap') and meta.pmap is not None:
-        os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
+    # If a specific CRDS context is entered in the ECF, apply it.
+    # Otherwise, log and fix the default CRDS context to make sure it doesn't
+    # change between different segments.
+    if not hasattr(meta, 'pmap') or meta.pmap is None:
+        meta.pmap = crds.get_default_context()
+    os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
 
     meta.version = version
     meta.eventlabel = eventlabel
@@ -80,6 +84,7 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
     log = logedit.Logedit(meta.s1_logname)
     log.writelog("\nStarting Stage 1 Processing")
     log.writelog(f"Eureka! Version: {meta.version}", mute=True)
+    log.writelog(f"CRDS Context pmap: {meta.pmap}", mute=True)
     log.writelog(f"Input directory: {meta.inputdir}")
     log.writelog(f"Output directory: {meta.outputdir}")
 

--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -74,6 +74,10 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None, input_meta=None):
     else:
         meta = input_meta
 
+    # If a specific CRDS context is entered in the ECF, apply it
+    if hasattr(meta, 'pmap') and meta.pmap is not None:
+        os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
+
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 

--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -80,7 +80,8 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None, input_meta=None):
     # Otherwise, log and fix the default CRDS context to make sure it doesn't
     # change between different segments.
     if not hasattr(meta, 'pmap') or meta.pmap is None:
-        meta.pmap = crds.get_default_context()
+        # Get just the numerical value
+        meta.pmap = crds.get_context_name('jwst')[5:-5]
     os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
 
     meta.version = version

--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -27,6 +27,7 @@ from ..lib import logedit, util
 from ..lib import manageevent as me
 from ..lib import readECF
 from ..lib import plots
+from ..version import version
 
 
 def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None, input_meta=None):
@@ -78,6 +79,7 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None, input_meta=None):
     if hasattr(meta, 'pmap') and meta.pmap is not None:
         os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
 
+    meta.version = version
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
@@ -108,6 +110,7 @@ def calibrateJWST(eventlabel, ecf_path=None, s1_meta=None, input_meta=None):
     else:
         log = logedit.Logedit(meta.s2_logname)
     log.writelog("\nStarting Stage 2 Reduction")
+    log.writelog(f"Eureka! Version: {meta.version}", mute=True)
     log.writelog(f"Input directory: {meta.inputdir}")
     log.writelog(f"Output directory: {meta.outputdir}")
 

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -93,13 +93,6 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
     else:
         meta = input_meta
 
-    # If a specific CRDS context is entered in the ECF, apply it.
-    # Otherwise, log and fix the default CRDS context to make sure it doesn't
-    # change between different segments.
-    if not hasattr(meta, 'pmap') or meta.pmap is None:
-        meta.pmap = crds.get_default_context()
-    os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
-
     meta.version = version
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
@@ -244,11 +237,28 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 raise ValueError('NIRISS observations are currently '
                                  'unsupported!')
             elif meta.inst == 'wfc3':
+                # If a specific CRDS context is entered in the ECF, apply it.
+                # Otherwise, log and fix the default CRDS context to make sure
+                # it doesn't change between different segments.
+                if not hasattr(meta, 'pmap') or meta.pmap is None:
+                    # Get just the numerical value
+                    meta.pmap = crds.get_context_name('hst')[4:-5]
+                os.environ['CRDS_CONTEXT'] = f'hst_{meta.pmap}.pmap'
+
                 from . import wfc3 as inst
                 meta.bg_dir = 'CxC'
                 meta, log = inst.preparation_step(meta, log)
             else:
                 raise ValueError('Unknown instrument {}'.format(meta.inst))
+
+            if meta.inst != 'wfc3':
+                # If a specific CRDS context is entered in the ECF, apply it.
+                # Otherwise, log and fix the default CRDS context to make sure
+                # it doesn't change between different segments.
+                if not hasattr(meta, 'pmap') or meta.pmap is None:
+                    # Get just the numerical value
+                    meta.pmap = crds.get_context_name('jwst')[5:-5]
+                os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
 
             # Loop over each segment
             # Only reduce the last segment/file if testing_S3 is set to

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -225,6 +225,14 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 raise ValueError('NIRISS observations are currently '
                                  'unsupported!')
             elif meta.inst == 'wfc3':
+                if 'jwst-crds.stsci.edu' in os.environ['CRDS_SERVER_URL']:
+                    log.writelog('CRDS_SERVER_URL is set for JWST and not HST.'
+                                 ' Automatically adjusting it to hst.')
+                    crds.client.api.set_crds_server(
+                        'https://hst-crds.stsci.edu/')
+                    os.environ['CRDS_SERVER_URL'] = \
+                        'https://hst-crds.stsci.edu/'
+
                 # If a specific CRDS context is entered in the ECF, apply it.
                 # Otherwise, log and fix the default CRDS context to make sure
                 # it doesn't change between different segments.

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -91,6 +91,10 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
     else:
         meta = input_meta
 
+    # If a specific CRDS context is entered in the ECF, apply it
+    if hasattr(meta, 'pmap') and meta.pmap is not None:
+        os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
+
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -225,13 +225,14 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 raise ValueError('NIRISS observations are currently '
                                  'unsupported!')
             elif meta.inst == 'wfc3':
+                # Fix issues with CRDS server set for JWST
                 if 'jwst-crds.stsci.edu' in os.environ['CRDS_SERVER_URL']:
                     log.writelog('CRDS_SERVER_URL is set for JWST and not HST.'
-                                 ' Automatically adjusting it to hst.')
-                    crds.client.api.set_crds_server(
-                        'https://hst-crds.stsci.edu/')
-                    os.environ['CRDS_SERVER_URL'] = \
-                        'https://hst-crds.stsci.edu/'
+                                 ' Automatically adjusting it up for HST.')
+                    url = 'https://hst-crds.stsci.edu'
+                    os.environ['CRDS_SERVER_URL'] = url
+                    crds.client.api.set_crds_server(url)
+                    crds.client.api.get_server_info.cache.clear()
 
                 # If a specific CRDS context is entered in the ECF, apply it.
                 # Otherwise, log and fix the default CRDS context to make sure
@@ -248,6 +249,15 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 raise ValueError('Unknown instrument {}'.format(meta.inst))
 
             if meta.inst != 'wfc3':
+                # Fix issues with CRDS server set for HST
+                if 'hst-crds.stsci.edu' in os.environ['CRDS_SERVER_URL']:
+                    log.writelog('CRDS_SERVER_URL is set for HST and not JWST.'
+                                 ' Automatically adjusting it up for JWST.')
+                    url = 'https://jwst-crds.stsci.edu'
+                    os.environ['CRDS_SERVER_URL'] = url
+                    crds.client.api.set_crds_server(url)
+                    crds.client.api.get_server_info.cache.clear()
+
                 # If a specific CRDS context is entered in the ECF, apply it.
                 # Otherwise, log and fix the default CRDS context to make sure
                 # it doesn't change between different segments.

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -40,6 +40,7 @@ from ..lib import readECF
 from ..lib import manageevent as me
 from ..lib import util
 from ..lib import centerdriver, apphot
+from ..version import version
 
 
 def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
@@ -95,6 +96,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
     if hasattr(meta, 'pmap') and meta.pmap is not None:
         os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
 
+    meta.version = version
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
@@ -212,6 +214,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
             else:
                 log = logedit.Logedit(meta.s3_logname)
             log.writelog("\nStarting Stage 3 Reduction\n")
+            log.writelog(f"Eureka! Version: {meta.version}", mute=True)
             log.writelog(f"Input directory: {meta.inputdir}")
             log.writelog(f"Output directory: {meta.outputdir}")
             log.writelog(f"Using ap={spec_hw_val}, " +

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -210,18 +210,6 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 log = logedit.Logedit(meta.s3_logname, read=s2_meta.s2_logname)
             else:
                 log = logedit.Logedit(meta.s3_logname)
-            log.writelog("\nStarting Stage 3 Reduction\n")
-            log.writelog(f"Eureka! Version: {meta.version}", mute=True)
-            log.writelog(f"CRDS Context pmap: {meta.pmap}", mute=True)
-            log.writelog(f"Input directory: {meta.inputdir}")
-            log.writelog(f"Output directory: {meta.outputdir}")
-            log.writelog(f"Using ap={spec_hw_val}, " +
-                         f"bg={bg_hw_val}, " +
-                         f"expand={meta.expand}")
-
-            # Copy ecf
-            log.writelog('Copying S3 control file', mute=(not meta.verbose))
-            meta.copy_ecf()
 
             # Create list of file segments
             meta = util.readfiles(meta, log)
@@ -259,6 +247,19 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                     # Get just the numerical value
                     meta.pmap = crds.get_context_name('jwst')[5:-5]
                 os.environ['CRDS_CONTEXT'] = f'jwst_{meta.pmap}.pmap'
+
+            log.writelog("\nStarting Stage 3 Reduction\n")
+            log.writelog(f"Eureka! Version: {meta.version}", mute=True)
+            log.writelog(f"CRDS Context pmap: {meta.pmap}", mute=True)
+            log.writelog(f"Input directory: {meta.inputdir}")
+            log.writelog(f"Output directory: {meta.outputdir}")
+            log.writelog(f"Using ap={spec_hw_val}, " +
+                         f"bg={bg_hw_val}, " +
+                         f"expand={meta.expand}")
+
+            # Copy ecf
+            log.writelog('Copying S3 control file', mute=(not meta.verbose))
+            meta.copy_ecf()
 
             # Loop over each segment
             # Only reduce the last segment/file if testing_S3 is set to

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -29,6 +29,7 @@ from ..lib import readECF
 from ..lib import manageevent as me
 from ..lib import util
 from ..lib import clipping
+from ..version import version
 
 
 def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
@@ -83,6 +84,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
     else:
         meta = input_meta
 
+    meta.version = version
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
@@ -141,6 +143,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
             meta.s4_logname = meta.outputdir + 'S4_' + meta.eventlabel + ".log"
             log = logedit.Logedit(meta.s4_logname, read=meta.s3_logname)
             log.writelog("\nStarting Stage 4: Generate Light Curves\n")
+            log.writelog(f"Eureka! Version: {meta.version}", mute=True)
             log.writelog(f"Input directory: {meta.inputdir}")
             log.writelog(f"Output directory: {meta.outputdir}")
 

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -9,6 +9,7 @@ from ..lib import manageevent as me
 from ..lib import readECF
 from ..lib import util, logedit
 from ..lib.readEPF import Parameters
+from ..version import version
 from . import lightcurve
 from . import models as m
 try:
@@ -67,6 +68,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
     else:
         meta = input_meta
 
+    meta.version = version
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
@@ -177,6 +179,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
             meta.s5_logname = meta.outputdir + 'S5_' + meta.eventlabel + ".log"
             log = logedit.Logedit(meta.s5_logname, read=meta.s4_logname)
             log.writelog("\nStarting Stage 5: Light Curve Fitting\n")
+            log.writelog(f"Eureka! Version: {meta.version}", mute=True)
             log.writelog(f"Input directory: {meta.inputdir}")
             log.writelog(f"Output directory: {meta.outputdir}")
 

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -22,6 +22,7 @@ from ..lib import readECF
 from ..lib import util, logedit
 from . import plots_s6 as plots
 from ..lib import astropytable
+from ..version import version
 
 
 def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
@@ -64,6 +65,7 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
     else:
         meta = input_meta
 
+    meta.version = version
     meta.eventlabel = eventlabel
     meta.datetime = time_pkg.strftime('%Y-%m-%d')
 
@@ -121,6 +123,7 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
             meta.s6_logname = meta.outputdir+'S6_'+meta.eventlabel+'.log'
             log = logedit.Logedit(meta.s6_logname, read=meta.s5_logname)
             log.writelog("\nStarting Stage 6: Light Curve Fitting\n")
+            log.writelog(f"Eureka! Version: {meta.version}", mute=True)
             log.writelog(f"Input directory: {meta.inputdir}")
             log.writelog(f"Output directory: {meta.outputdir}")
 

--- a/src/eureka/lib/readECF.py
+++ b/src/eureka/lib/readECF.py
@@ -135,6 +135,12 @@ class MetaClass:
             self.__dict__[item] = value
             return
 
+        if ((item == 'pmap') and hasattr(self, 'pmap') and
+                (self.pmap is not None) and (self.pmap != value)):
+            print(f'WARNING: pmap was set to {self.pmap} in the previous stage'
+                  f' but is now set to {value} in this stage. This may cause '
+                  'unexpected or undesireable behaviors.')
+
         # Set the attribute
         self.__dict__[item] = value
 

--- a/src/eureka/lib/readECF.py
+++ b/src/eureka/lib/readECF.py
@@ -141,6 +141,12 @@ class MetaClass:
                   f' but is now set to {value} in this stage. This may cause '
                   'unexpected or undesireable behaviors.')
 
+        if ((item == 'version') and hasattr(self, 'version') and
+                (self.version is not None) and (self.version != value)):
+            print(f'WARNING: The Eureka! version was {self.version} in the '
+                  f'previous stage but is now {value} in this stage. This may '
+                  'cause unexpected or undesireable behaviors.')
+
         # Set the attribute
         self.__dict__[item] = value
 


### PR DESCRIPTION
To help strengthen reproducibility and to allow users to manually control the used pmap, we now (silently) log the Eureka! version for Stages 1-6 and the CRDS pmap from Stages 1-3 (4-6 aren't relevant). For all future analyses, warnings will be printed to the terminal if the Eureka! version or CRDS pmap changes (only in the relevant stages), but this will not apply to previous partial reductions of the data (e.g., running the new code on v0.10 Stage 1 files won't raise any pmap or Eureka! version warnings).