### PR TITLE
Default to only compute median frame for 1st batch

### DIFF
--- a/demos/HST/S3_wfc3_template.ecf
+++ b/demos/HST/S3_wfc3_template.ecf
@@ -5,6 +5,7 @@
 ncpu            4           # Number of CPUs
 nfiles          1000        # The max number of data files to analyze simultaneously. Strongly recommended to be >>1 for HST data.
 max_memory      0.5         # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
+indep_batches   False       # Independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True.
 suffix          ima         # Data file suffix
 
 # Calibration files

--- a/demos/JWST/S3_miri_lrs_template.ecf
+++ b/demos/JWST/S3_miri_lrs_template.ecf
@@ -5,6 +5,7 @@
 ncpu            1           # Number of CPUs
 nfiles          1           # The number of data files to analyze simultaneously
 max_memory      0.5         # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
+indep_batches   False       # Independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True.
 suffix          calints     # Data file suffix
 
 calibrated_spectra  False   # Set True to generate flux-calibrated spectra/photometry in mJy

--- a/demos/JWST/S3_miri_photometry_template.ecf
+++ b/demos/JWST/S3_miri_photometry_template.ecf
@@ -5,6 +5,7 @@
 ncpu            1           # Number of CPUs
 nfiles          1           # The number of data files to analyze simultaneously
 max_memory      0.5         # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
+indep_batches   False       # Independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True.
 suffix          calints     # Data file suffix
 photometry      True        # Set to True if the user wants to analyse a photometric dataset
 

--- a/demos/JWST/S3_nircam_photometry_template.ecf
+++ b/demos/JWST/S3_nircam_photometry_template.ecf
@@ -2,14 +2,15 @@
 
 # Stage 3 Documentation: https://eurekadocs.readthedocs.io/en/latest/ecf.html#stage-3
 
-ncpu                 1           # Number of CPUs
+ncpu                 1                # Number of CPUs
 nfiles               1                # The number of data files to analyze simultaneously
 max_memory           0.5              # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
+indep_batches        False            # Independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True.
 suffix               calints          # Data file suffix
 photometry           True             # Set to True if the user wants to analyse a photometric dataset
 
-calibrated_spectra  False   # Set True to generate flux-calibrated spectra/photometry in mJy
-                            # Set False to convert to electrons
+calibrated_spectra  False             # Set True to generate flux-calibrated spectra/photometry in mJy
+                                      # Set False to convert to electrons
 
 # Subarray region of interest
 ywindow              [4, 256]         # Vertical axis as seen in DS9
@@ -34,16 +35,16 @@ centroid_tech        com              # (mgmc method param) Technique used for c
 gauss_frame          100              # (mgmc method param) Half-width away from second centroid guess to include in centroiding map for gaussian widths. Recommend ~100 for defocused NIRCam photometry.
 
 # Diagnostics
-isplots_S3           3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
-nplots               5           # How many of each type of figure do you want to make per file?
-testing_S3           False       # Boolean, set True to only use last file and generate select figures
-hide_plots           False       # If True, plots will automatically be closed rather than popping up
-save_output          True        # Save outputs for use in S4
-verbose              True        # If True, more details will be printed about steps
+isplots_S3           3                # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+nplots               5                # How many of each type of figure do you want to make per file?
+testing_S3           False            # Boolean, set True to only use last file and generate select figures
+hide_plots           False            # If True, plots will automatically be closed rather than popping up
+save_output          True             # Save outputs for use in S4
+verbose              True             # If True, more details will be printed about steps
 
 # Project directory
 topdir          /home/User/Data/JWST-Sim/NIRCam/
 
 # Directories relative to topdir
-inputdir        Stage2      # The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
+inputdir        Stage2                # The folder containing the outputs from Eureka!'s S2 or JWST's S2 pipeline (will be overwritten if calling S2 and S3 sequentially)
 outputdir       Stage3

--- a/demos/JWST/S3_nircam_wfss_template.ecf
+++ b/demos/JWST/S3_nircam_wfss_template.ecf
@@ -5,6 +5,7 @@
 ncpu            1           # Number of CPUs
 nfiles          1           # The number of data files to analyze simultaneously
 max_memory      0.5         # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
+indep_batches   False       # Independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True.
 suffix          calints     # Data file suffix
 
 calibrated_spectra  False   # Set True to generate flux-calibrated spectra/photometry in mJy

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -5,6 +5,7 @@
 ncpu            1           # Number of CPUs
 nfiles          1           # The number of data files to analyze simultaneously
 max_memory      0.5         # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
+indep_batches   False       # Independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True.
 suffix          calints     # Data file suffix
 
 calibrated_spectra  False   # Set True to generate flux-calibrated spectra/photometry in mJy

--- a/docs/media/S3_template.ecf
+++ b/docs/media/S3_template.ecf
@@ -5,6 +5,7 @@
 ncpu            1           # Number of CPUs
 nfiles          1           # The number of data files to analyze simultaneously
 max_memory      0.5         # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
+indep_batches   False       # Independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True.
 suffix          calints     # Data file suffix
 
 calibrated_spectra  False   # Set True to generate flux-calibrated spectra/photometry in mJy

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -287,6 +287,10 @@ max_memory
 ''''''''''
 Sets the maximum memory fraction (0--1) that should be used by the loaded in data files. This will reduce nfiles if needed. Note that more RAM than this may be used during operations like sigma clipping, so you're best off setting max_memory <= 0.5.
 
+indep_batches
+'''''''''''''
+Do you want to independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True. If set to True, you may end up with jump discontinuities between batches.
+
 suffix
 ''''''
 If your data directory (``topdir + inputdir``, see below) contains files with different data formats, you want to consider setting this variable.

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -289,7 +289,7 @@ Sets the maximum memory fraction (0--1) that should be used by the loaded in dat
 
 indep_batches
 '''''''''''''
-Do you want to independently treat each batch of files? Strongly recommended to leave this as False unless you have a clear reason to set it to True. If set to True, you may end up with jump discontinuities between batches.
+Do you want to independently treat each batch of files? When False, the median spectrum from the first batch is applied too all batches. Strongly recommended to leave this as False unless you have a clear reason to set it to True. If set to True, you may end up with jump discontinuities between batches.
 
 suffix
 ''''''

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -264,10 +264,19 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                                       meta.files_per_batch))
 
             datasets = []
+
+            if (not hasattr(meta, 'indep_batches') or
+                    meta.indep_batches is None):
+                meta.indep_batches = False
             saved_refrence_tilt_frame = None
             saved_ref_median_frame = None
 
             for m in range(meta.nbatch):
+                # Reset saved median frame if meta.indep_batches
+                if meta.indep_batches:
+                    saved_ref_median_frame = None
+                    saved_refrence_tilt_frame = None
+
                 first_file = m*meta.files_per_batch
                 last_file = min([meta.num_data_files,
                                  (m+1)*meta.files_per_batch])
@@ -385,7 +394,8 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 if not meta.photometry:
                     # Locate source postion for the first integration of
                     # the first batch
-                    if not hasattr(meta, 'src_ypos'):
+                    if (meta.indep_batches or
+                            (not hasattr(meta, 'src_ypos'))):
                         data, meta, log = \
                             source_pos.source_pos_wrapper(data, meta, log, m)
 

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -382,14 +382,6 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 
                 if not hasattr(meta, 'calibrated_spectra'):
                     meta.calibrated_spectra = False
-                if meta.calibrated_spectra:
-                    # Instrument-specific steps for generating
-                    # calibrated stellar spectra
-                    data = inst.calibrated_spectra(data, meta, log)
-                else:
-                    # Convert flux units to electrons
-                    # (eg. MJy/sr -> DN -> Electrons)
-                    data, meta = b2f.convert_to_e(data, meta, log)
 
                 if not meta.photometry:
                     # Locate source postion for the first integration of
@@ -409,6 +401,15 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                     # Check for bad wavelengths (beyond wavelength solution)
                     util.check_nans(data.wave_1d.values, np.ones(meta.subnx),
                                     log, name='wavelength')
+
+                    if meta.calibrated_spectra:
+                        # Instrument-specific steps for generating
+                        # calibrated stellar spectra
+                        data = inst.calibrated_spectra(data, meta, log)
+                    else:
+                        # Convert flux units to electrons
+                        # (eg. MJy/sr -> DN -> Electrons)
+                        data, meta = b2f.convert_to_e(data, meta, log)
 
                     # Perform outlier rejection of
                     # full frame along time axis
@@ -498,6 +499,15 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                     meta.photap = meta.spec_hw
                     meta.skyin, meta.skyout = np.array(meta.bg_hw.split('_')
                                                        ).astype(int)
+
+                    if meta.calibrated_spectra:
+                        # Instrument-specific steps for generating
+                        # calibrated stellar spectra
+                        data = inst.calibrated_spectra(data, meta, log)
+                    else:
+                        # Convert flux units to electrons
+                        # (eg. MJy/sr -> DN -> Electrons)
+                        data, meta = b2f.convert_to_e(data, meta, log)
 
                     # Do outlier reduction along time axis for
                     # each individual pixel

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -373,33 +373,33 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 
                 if not hasattr(meta, 'calibrated_spectra'):
                     meta.calibrated_spectra = False
-                # Instrument-specific steps for generating
-                # calibrated stellar spectra
                 if meta.calibrated_spectra:
+                    # Instrument-specific steps for generating
+                    # calibrated stellar spectra
                     data = inst.calibrated_spectra(data, meta, log)
-
-                if not meta.photometry:
-                    # Locate source postion
-                    data, meta, log = \
-                        source_pos.source_pos_wrapper(data, meta, log, m)
-
-                # Compute 1D wavelength solution
-                if 'wave_2d' in data:
-                    data['wave_1d'] = (['x'],
-                                       data.wave_2d[meta.src_ypos].values)
-                    data['wave_1d'].attrs['wave_units'] = \
-                        data.wave_2d.attrs['wave_units']
-
-                # Check for bad wavelength pixels (beyond wavelength solution)
-                util.check_nans(data.wave_1d.values, np.ones(meta.subnx), log,
-                                name='wavelength')
-
-                # Convert flux units to electrons
-                # (eg. MJy/sr -> DN -> Electrons)
-                if not meta.calibrated_spectra:
+                else:
+                    # Convert flux units to electrons
+                    # (eg. MJy/sr -> DN -> Electrons)
                     data, meta = b2f.convert_to_e(data, meta, log)
 
                 if not meta.photometry:
+                    # Locate source postion for the first integration of
+                    # the first batch
+                    if not hasattr(meta, 'src_ypos'):
+                        data, meta, log = \
+                            source_pos.source_pos_wrapper(data, meta, log, m)
+
+                    # Compute 1D wavelength solution
+                    if 'wave_2d' in data:
+                        data['wave_1d'] = (['x'],
+                                           data.wave_2d[meta.src_ypos].values)
+                        data['wave_1d'].attrs['wave_units'] = \
+                            data.wave_2d.attrs['wave_units']
+
+                    # Check for bad wavelengths (beyond wavelength solution)
+                    util.check_nans(data.wave_1d.values, np.ones(meta.subnx),
+                                    log, name='wavelength')
+
                     # Perform outlier rejection of
                     # full frame along time axis
                     if hasattr(meta, 'ff_outlier') and meta.ff_outlier:

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -405,8 +405,14 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                     if hasattr(meta, 'ff_outlier') and meta.ff_outlier:
                         data = inst.flag_ff(data, meta, log)
 
-                    # Compute clean median frame
-                    data = optspex.clean_median_flux(data, meta, log, m)
+                    if saved_ref_median_frame is None:
+                        # Compute clean median frame
+                        data = optspex.clean_median_flux(data, meta, log, m)
+                        # Save the original median frame
+                        saved_ref_median_frame = data.medflux
+                    else:
+                        # Load the original median frame
+                        data.medflux = saved_ref_median_frame
 
                     # correct spectral curvature
                     if not hasattr(meta, 'curvature'):


### PR DESCRIPTION
Before this PR, a different median frame was computed for each batch. For those like me who always only a single huge batch, this bug was absent. However, if you used more than one batch (e.g. had too little RAM to load all segments at once), then sometimes things like the computed centroid or curvature correction would change between different segments which would cause jump discontinuities between segments

This partially resolves Issue #538, although I still need to add an override option to the ECF