### PR TITLE
Accounting for light travel time in starry model

### DIFF
--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
@@ -188,7 +188,7 @@ class StarryModel(PyMC3Model):
             planet.t0 = temp.t0
 
             # Instantiate the system
-            system = starry.System(star, planet)
+            system = starry.System(star, planet, light_delay=True)
             self.systems.append(system)
 
     def eval(self, eval=True, channel=None, **kwargs):
@@ -370,5 +370,5 @@ class StarryModel(PyMC3Model):
             planet.t0 = temp.t0
 
             # Instantiate the system
-            sys = starry.System(star, planet)
+            sys = starry.System(star, planet, light_delay=True)
             self.fit.systems.append(sys)


### PR DESCRIPTION
So Eric Agol pointed out to Mark Hammond who pointed out to me that by default `starry` doesn't account for light travel time. Back before version 1.0 I knew `starry`had accounted for this but I didn't check the newer version, and apparently with v>=1.0 it doesn't by default. This tiny little PR flips that switch within `starry` to account for light travel time