### PR TITLE
Update background subtraction method options to address waterfall effect in lightcurves

### DIFF
--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -49,6 +49,7 @@ ncpu                6
 bg_y1               6
 bg_y2               26
 bg_deg              0
+bg_method		    med		    #Options: std (Standard Deviation), med (Median Absolute Deviation), mean (Mean Absolute Deviation)
 p3thresh            5
 verbose             True
 isplots_S1          3

--- a/demos/JWST/S3_nirspec_fs_template.ecf
+++ b/demos/JWST/S3_nirspec_fs_template.ecf
@@ -27,6 +27,7 @@ bg_thresh       [4,4]       # Double-iteration X-sigma threshold for outlier rej
 # Background parameters
 bg_hw           7           # Half-width of exclusion region for BG subtraction (relative to source position)
 bg_deg          0           # Polynomial order for column-by-column background subtraction, -1 for median of entire frame
+bg_method		med		    #Options: std (Standard Deviation), med (Median Absolute Deviation), mean (Mean Absolute Deviation)
 p3thresh        10          # X-sigma threshold for outlier rejection during background subtraction
 
 # Spectral extraction parameters

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -262,14 +262,14 @@ def fitbg(dataim, meta, mask, x1, x2, deg=1, threshold=5, isrotate=False,
                     # Calculate residuals and number of sigma from the model
                     residuals = dataslice - model
                     #Choose method for finding bad pixels
-                    if meta.bg_method=='std':
+                    if hasattr(meta, 'bg_method') and meta.bg_method=='std':
                         # Simple standard deviation (faster but prone to missing
                         # scanned background stars)
                         stdres = np.std(residuals)
-                    elif meta.bg_method=='med':
+                    elif hasattr(meta, 'bg_method') and meta.bg_method=='med':
                         # Median Absolute Deviation (slower but more robust)
                         stdres  = np.median(np.abs(np.ediff1d(residuals)))
-                    elif meta.bg_method=='mean':
+                    elif hasattr(meta, 'bg_method') and meta.bg_method=='mean':
                         # Mean Absolute Deviation (good compromise)
                         stdres = np.mean(np.abs(np.ediff1d(residuals)))
                     if stdres == 0:

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -224,6 +224,8 @@ def fitbg(dataim, meta, mask, x1, x2, deg=1, threshold=5, isrotate=False,
         degs = np.ones(ny)*deg
         # Initiate background image with zeros
         bg = np.zeros((ny, nx))
+        
+            
         # Fit polynomial to each column
         for j in range(ny):
             nobadpixels = False
@@ -259,13 +261,17 @@ def fitbg(dataim, meta, mask, x1, x2, deg=1, threshold=5, isrotate=False,
                     model = np.polyval(coeffs, goodxvals)
                     # Calculate residuals and number of sigma from the model
                     residuals = dataslice - model
-                    # Simple standard deviation (faster but prone to missing
-                    # scanned background stars)
-                    stdres = np.std(residuals)
-                    # Median Absolute Deviation (slower but more robust)
-                    # stdres  = np.median(np.abs(np.ediff1d(residuals)))
-                    # Mean Absolute Deviation (good compromise)
-                    # stdres = np.mean(np.abs(np.ediff1d(residuals)))
+                    #Choose method for finding bad pixels
+                    if meta.bg_method=='std':
+                        # Simple standard deviation (faster but prone to missing
+                        # scanned background stars)
+                        stdres = np.std(residuals)
+                    elif meta.bg_method=='med':
+                        # Median Absolute Deviation (slower but more robust)
+                        stdres  = np.median(np.abs(np.ediff1d(residuals)))
+                    elif meta.bg_method=='mean':
+                        # Mean Absolute Deviation (good compromise)
+                        stdres = np.mean(np.abs(np.ediff1d(residuals)))
                     if stdres == 0:
                         stdres = np.inf
                     stdevs = np.abs(residuals) / stdres
@@ -276,7 +282,6 @@ def fitbg(dataim, meta, mask, x1, x2, deg=1, threshold=5, isrotate=False,
                         mask[j, goodxvals[loc]] = 0
                     else:
                         nobadpixels = True  # exit while loop
-
             # Evaluate background model at all points, write model to
             # background image
             if len(goodxvals) != 0:


### PR DESCRIPTION
Added the option to use Mean & Median Absolute Deviations in background subtraction vice standard deviation. This addresses issues seen when too many outliers exist before ramp-fitting and cause waterfall effect in lightcurves. See before (standard deviation) and after (median absolute deviation) images for comparison. Tagging @erinmmay for reference.
![fig4102_white_1D_LC](https://github.com/kevin218/Eureka/assets/123774945/8140a719-dc6f-4689-b452-98160a0da28f)
![fig4102_white_1D_LC](https://github.com/kevin218/Eureka/assets/123774945/2af8f3c5-b36f-43c4-befe-70d9e69543f1)
