### PR TITLE
Assorted HST and JWST enhancements

### DIFF
--- a/.github/workflows/pytest_testing.yml
+++ b/.github/workflows/pytest_testing.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Environment
         run: |
           python -m pip install --upgrade pip
-          pip install .[jwst,hst,pymc3,test]
+          pip install .[hst,pymc3,test]
           conda install mkl-service
           mkdir $HOME/crds_cache
           echo "CRDS_PATH=$HOME/crds_cache" >> $GITHUB_ENV

--- a/demos/HST/S4_wfc3_template.ecf
+++ b/demos/HST/S4_wfc3_template.ecf
@@ -22,7 +22,8 @@ sub_continuum   True    # Set True to subtract the continuum from the spectra us
 highpassWidth   10      # The integer width of the highpass filter when subtracting the continuum
 
 # Parameters for sigma clipping
-sigma_clip      False   # Whether or not sigma clipping should be performed on the 1D time series
+clip_unbinned   False   # Whether or not sigma clipping should be performed on the unbinned 1D time series
+clip_binned     True    # Whether or not sigma clipping should be performed on the binned 1D time series
 sigma           10      # The number of sigmas a point must be from the rolling median to be considered an outlier
 box_width       10      # The width of the box-car filter (used to calculated the rolling median) in units of number of data points
 maxiters        5       # The number of iterations of sigma clipping that should be performed.

--- a/demos/HST/s5_fit_par_wfc3_template.epf
+++ b/demos/HST/s5_fit_par_wfc3_template.epf
@@ -50,7 +50,9 @@ u2           0.1           'free'         0            1            U
 c0           1             'free'         0.95         1.05         U
 h0           0             'free'         -0.1         0.1          U
 h1           10            'free'         0            100          U
-h3           0             'free'         -1           1            U
+h3           0.0           'fixed'        -1           1            U
+h5           6.6422e-02    'fixed'        6.6422e-02   0.001        N
+h6           0.03          'fixed'        0.03         0.0          N
 # -----------
 # ** White noise **
 # Use scatter_mult to fit a multiplier to the expected noise level from Stage 3 (recommended)

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1079,7 +1079,7 @@ This file describes the transit/eclipse and systematics parameters and their pri
       - ``h0--h5`` - Coefficients for the HST exponential + polynomial ramp model.
 
          The HST ramp model is defined as follows: ``1 + h0*np.exp(-h1*time_batch + h2) + h3*time_batch + h4*time_batch**2``,
-         where ``h0--h2`` describe the exponential ramp per HST orbit, ``h3--h4`` describe the polynomial (up to order two) per HST orbit, and ``h5`` is the orbital period of HST (in the same time units as the data, usually days).  A good starting point for ``h5`` is 0.066422 days.  ``time_batch = time_local % h5``.
+         where ``h0--h2`` describe the exponential ramp per HST orbit, ``h3--h4`` describe the polynomial (up to order two) per HST orbit,  ``h5`` is the orbital period of HST (in the same time units as the data, usually days), and ``h6`` is the time offset when computing ``time_batch``.  A good starting point for ``h5`` is 0.066422 days and ``h6`` is 0.03 days.  ``time_batch = (time_local-h6) % h5``.
          If you want to fit a linear trend in time, you can omit ``h4`` or fix it to ``0``.
          Users should not fit all three parameters from the exponential model at the same time as there are significant degeneracies between the ``h0`` and ``h2`` parameters.  
          One option is to set ``h0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``h0--h1`` and set ``h2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ where = src
 
 [options.extras_require]
 jwst =
-    jwst==1.11.4
+    jwst==1.12.2
     stcal>=1.0.0 # Lower limit needed for our create_integration_model function
 hst =
     image_registration@git+https://github.com/keflavich/image_registration@master # Need GitHub version to avoid np.float issue

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,8 @@ test =
     pytest-cov
     pytest-doctestplus
 pymc3 =
+    jwst==1.11.4
+    stcal>=1.0.0 # Lower limit needed for our create_integration_model function
     exoplanet
     # mkl-service # Needed for theano - only available by conda install mkl-service
     pymc3

--- a/src/eureka/S3_data_reduction/hst_scan.py
+++ b/src/eureka/S3_data_reduction/hst_scan.py
@@ -52,24 +52,20 @@ def imageCentroid(filenames, guess, trim, ny, CRPIX1, CRPIX2, POSTARG1,
         Added IRSUB256
     - December 8, 2021, Taylor J Bell
         Updated for Eureka
+    - December 15, 2023, Kevin Stevenson
+        Cleaned up function
     '''
     nfiles = len(filenames)
     centers = []
-    # images = []
 
     # Swap the x-y order for the other, older code which used to have (y,x)
     guess = guess[::-1]
 
     for i in range(nfiles):
-        # images.append(fits.getdata(filenames[i].rstrip()))
         image = fits.getdata(filenames[i].rstrip())
-        # hdr0 = fits.getheader(filenames[i],0)
-        # hdr1 = fits.getheader(filenames[i],1)
         calhdr0 = fits.getheader(filenames[i].rstrip(), 0)
         calhdr1 = fits.getheader(filenames[i].rstrip(), 1)
         # Calculate centroid, correct for difference in image size, if any
-        # centers.append(centroid.ctrgauss(images[i], guess=guess, trim=trim) -
-        #                (images[i].shape[0]-ny)/2.)
         centers.append(centroid.ctrgauss(image, guess=guess, trim=trim) -
                        (image.shape[0]-ny)/2.)
         xoffset = (CRPIX1 - calhdr1['CRPIX1'] +
@@ -82,36 +78,10 @@ def imageCentroid(filenames, guess, trim, ny, CRPIX1, CRPIX2, POSTARG1,
                      f" pixels to x, y centroid position for integrations "
                      f"related to staring-mode image #{i}.",
                      mute=(not meta.verbose))
-        """
-        if calhdr0['APERTURE'] == 'IRSUB256':
-            # centers[i][1] -= 111
-            # xref_correct = (xref + CRPIX1_spec - CRPIX1_im +
-            #                 (POSTARG1_spec - POSTARG1_im)/0.135)
-            # offset = (scihdr1['CRPIX1'] - calhdr1['CRPIX1'] +
-            #           (scihdr0['POSTARG1'] - calhdr0['POSTARG1'])/0.135)
-            # centers[i][1] += offset
-            xoffset = (scihdr1['CRPIX1'] - calhdr1['CRPIX1'] +
-                       (scihdr0['POSTARG1'] - calhdr0['POSTARG1'])/0.135)
-            yoffset = (scihdr1['CRPIX2'] - calhdr1['CRPIX2'] +
-                       (scihdr0['POSTARG2'] - calhdr0['POSTARG2'])/0.121)
-            centers[i][0] += yoffset
-            centers[i][1] += xoffset
-            print(f"****WARNING: Direct image uses IRSUB256, adding {xoffset},"
-                  f"{yoffset} pixels to x,y position.")
-        if calhdr0['APERTURE'] == 'IRSUB512':
-            # centers[i][1] -= 111
-            # xref_correct = (xref + CRPIX1_spec - CRPIX1_im +
-            #                 (POSTARG1_spec - POSTARG1_im)/0.135)
-            xoffset = (scihdr1['CRPIX1'] - calhdr1['CRPIX1'] +
-                       (scihdr0['POSTARG1'] - calhdr0['POSTARG1'])/0.135)
-            yoffset = (scihdr1['CRPIX2'] - calhdr1['CRPIX2'] +
-                       (scihdr0['POSTARG2'] - calhdr0['POSTARG2'])/0.121)
-            centers[i][0] += yoffset
-            centers[i][1] += xoffset
-            print(f"****WARNING: Direct image uses IRSUB512, adding {xoffset},"
-                  f"{yoffset} pixels to x,y position.")
-        """
-    return centers  # , images
+        log.writelog(f"Final centroid is {np.round(centers[i][0], 3)},"
+                     f" {np.round(centers[i][1], 3)}",
+                     mute=(not meta.verbose))
+    return centers
 
 
 def groupFrames(dates):
@@ -325,7 +295,6 @@ def makeflats(flatfile, wave, xwindow, ywindow, flatoffset, n_spec, ny, nx,
     # Read in flat frames
     hdulist = fits.open(flatfile)
     flat_mhdr = hdulist[0].header
-    # print(hdulist[0].data)
     wmin = float(flat_mhdr['wmin'])/1e4
     wmax = float(flat_mhdr['wmax'])/1e4
     # nx = flat_mhdr['naxis1']
@@ -354,7 +323,6 @@ def makeflats(flatfile, wave, xwindow, ywindow, flatoffset, n_spec, ny, nx,
             # WFC3.IR.G141.flat.2 OR WFC3.IR.G102.flat.2
             flat_window = hdulist[0].data[ylower:yupper, xlower:xupper]
             for j in range(1, len(hdulist)):
-                # print(j)
                 flat_window += hdulist[j].data[ylower:yupper,
                                                xlower:xupper]*x**j
 

--- a/src/eureka/S3_data_reduction/nirspec.py
+++ b/src/eureka/S3_data_reduction/nirspec.py
@@ -272,14 +272,14 @@ def calibrated_spectra(data, meta, log, cutoff=1e-4):
         Initial version.
     """
     # Mask uncalibrated BG region
-    # log.writelog("  Setting uncalibrated pixels to zero...",
-    #              mute=(not meta.verbose))
-    # boolmask = np.abs(data.flux.data) > cutoff
-    # data['flux'].data = np.where(np.abs(data.flux.data) >
-    #                              cutoff, 0,
-    #                              data.flux.data)
-    # log.writelog(f"    Zeroed {np.sum(boolmask.data)} " +
-    #              "pixels in total.", mute=(not meta.verbose))
+    log.writelog("  Setting uncalibrated pixels to zero...",
+                 mute=(not meta.verbose))
+    boolmask = np.abs(data.flux.data) > cutoff
+    data['flux'].data = np.where(np.abs(data.flux.data) >
+                                 cutoff, 0,
+                                 data.flux.data)
+    log.writelog(f"    Zeroed {np.sum(boolmask.data)} " +
+                 "pixels in total.", mute=(not meta.verbose))
     
     # Convert from MJy to mJy
     log.writelog("  Converting from MJy to mJy...",

--- a/src/eureka/S3_data_reduction/nirspec.py
+++ b/src/eureka/S3_data_reduction/nirspec.py
@@ -272,14 +272,14 @@ def calibrated_spectra(data, meta, log, cutoff=1e-4):
         Initial version.
     """
     # Mask uncalibrated BG region
-    log.writelog("  Setting uncalibrated pixels to zero...",
-                 mute=(not meta.verbose))
-    boolmask = np.abs(data.flux.data) > cutoff
-    data['flux'].data = np.where(np.abs(data.flux.data) >
-                                 cutoff, 0,
-                                 data.flux.data)
-    log.writelog(f"    Zeroed {np.sum(boolmask.data)} " +
-                 "pixels in total.", mute=(not meta.verbose))
+    # log.writelog("  Setting uncalibrated pixels to zero...",
+    #              mute=(not meta.verbose))
+    # boolmask = np.abs(data.flux.data) > cutoff
+    # data['flux'].data = np.where(np.abs(data.flux.data) >
+    #                              cutoff, 0,
+    #                              data.flux.data)
+    # log.writelog(f"    Zeroed {np.sum(boolmask.data)} " +
+    #              "pixels in total.", mute=(not meta.verbose))
     
     # Convert from MJy to mJy
     log.writelog("  Converting from MJy to mJy...",
@@ -289,8 +289,8 @@ def calibrated_spectra(data, meta, log, cutoff=1e-4):
     data['v0'].data *= 1e9
     
     # Update units
-    data['flux'].flux_units = 'mJy'
-    data['err'].flux_units = 'mJy'
-    data['v0'].flux_units = 'mJy'
+    data['flux'].attrs["flux_units"] = 'mJy'
+    data['err'].attrs["flux_units"] = 'mJy'
+    data['v0'].attrs["flux_units"] = 'mJy'
 
     return data

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -532,7 +532,7 @@ def residualBackground(data, meta, m, vmin=None, vmax=None):
     flux_hr = f(ny_hr)
     # Set vmin and vmax
     if vmin is None:
-        vmin = np.min((0,np.nanmin(flux_hr)))
+        vmin = np.min((0, np.nanmin(flux_hr)))
     if vmax is None:
         vmax = np.nanmax(flux_hr)/3
     # Set bad pixels to plot as black
@@ -1365,6 +1365,7 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
                         all_images, fps=60)
 
     return refrence_tilt_frame
+
 
 def get_bounds(x, y=None):
     """

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -242,6 +242,7 @@ def optimal_spectrum(data, meta, n, m):
     m : int
         The file number.
     '''
+    xmin, xmax = get_bounds(data.stdspec.x.values)
     intstart, stdspec, optspec, opterr = (data.attrs['intstart'],
                                           data.stdspec.values,
                                           data.optspec.values,
@@ -254,6 +255,7 @@ def optimal_spectrum(data, meta, n, m):
                  label='Standard Spec')
     plt.errorbar(data.stdspec.x.values, optspec[n], yerr=opterr[n], fmt='-',
                  color='C2', ecolor='C2', label='Optimal Spec')
+    plt.xlim(xmin, xmax)
     plt.ylabel('Flux')
     plt.xlabel('Detector Pixel Position')
     plt.legend(loc='best')
@@ -545,7 +547,7 @@ def residualBackground(data, meta, m, vmin=None, vmax=None):
     a0.imshow(flux, origin='lower', aspect='auto', vmax=vmax, vmin=vmin,
               cmap=cmap, interpolation='nearest',
               extent=[xmin, xmax, ymin, ymax])
-    a0.hlines([ymin+meta.bg_y1, ymin+meta.bg_y2-1], xmin, xmax, color='orange')
+    a0.hlines([ymin+meta.bg_y1, ymin+meta.bg_y2], xmin, xmax, color='orange')
     a0.hlines([ymin+meta.src_ypos+meta.spec_hw+1,
               ymin+meta.src_ypos-meta.spec_hw], xmin,
               xmax, color='mediumseagreen', linestyle='dashed')
@@ -554,14 +556,14 @@ def residualBackground(data, meta, m, vmin=None, vmax=None):
     a1.scatter(flux_hr, ny_hr, 5, flux_hr, cmap=cmap,
                norm=plt.Normalize(vmin, vmax))
     a1.vlines([0], ymin, ymax, color='0.5', linestyle='dotted')
-    a1.hlines([ymin+meta.bg_y1, ymin+meta.bg_y2-1], vmin, vmax, color='orange',
+    a1.hlines([ymin+meta.bg_y1, ymin+meta.bg_y2], vmin, vmax, color='orange',
               linestyle='solid', label='bg'+str(meta.bg_hw))
     a1.hlines([ymin+meta.src_ypos+meta.spec_hw+1,
               ymin+meta.src_ypos-meta.spec_hw], vmin,
               vmax, color='mediumseagreen', linestyle='dashed',
               label='ap'+str(meta.spec_hw))
     a1.legend(loc='upper right', fontsize=8)
-    a1.axes.set_xlabel("Flux [e-]")
+    a1.axes.set_xlabel("Flux")
     a1.axes.set_xlim(vmin, vmax)
     a1.axes.set_ylim(ymin, ymax)
     a1.axes.set_yticklabels([])
@@ -1364,7 +1366,7 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
 
     return refrence_tilt_frame
 
-def get_bounds(x, y):
+def get_bounds(x, y=None):
     """
     Define bounds by adding half pixel to all edges
 
@@ -1372,7 +1374,7 @@ def get_bounds(x, y):
     ----------
     x : 1D array
         Pixel indeces along x axis.
-    y : 1D array
+    y : 1D array, optional
         Pixel indeces along y axis.
 
     Returns
@@ -1381,9 +1383,9 @@ def get_bounds(x, y):
         Minimum x bound
     xmax
         Maximum x bound
-    ymin
+    ymin, optional
         Minimum y bound
-    ymax
+    ymax, optional
         Maximum y bound
 
     Notes
@@ -1393,7 +1395,6 @@ def get_bounds(x, y):
         Initial implementation.
     """
     xmin, xmax = x[0], x[-1]
-    ymin, ymax = y[0], y[-1]
     if xmin < xmax:
         # NIR instruments
         xmin -= 0.5
@@ -1402,12 +1403,16 @@ def get_bounds(x, y):
         # MIRI
         xmin += 0.5
         xmax -= 0.05
-    if ymin < ymax:
-        # All instruments
-        ymin -= 0.5
-        ymax += 0.5
+    if y is not None:
+        ymin, ymax = y[0], y[-1]
+        if ymin < ymax:
+            # All instruments
+            ymin -= 0.5
+            ymax += 0.5
+        else:
+            # Possible future use
+            ymin += 0.5
+            ymax -= 0.05
+        return xmin, xmax, ymin, ymax
     else:
-        # Possible future use
-        ymin += 0.5
-        ymax -= 0.05
-    return xmin, xmax, ymin, ymax
+        return xmin, xmax

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -292,6 +292,13 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 meta.max_memory = 0.5
             if not hasattr(meta, 'nfiles'):
                 meta.nfiles = 1
+            if meta.nfiles == 1 and meta.nfiles > 1 and \
+                    meta.indep_batches == True:
+                log.writelog('WARNING: You have selected non-ideal settings '
+                             'with indep_batches = True and nfiles = 1.'
+                             'If your computer has enough RAM to '
+                             'load many/all of your Stage 2 files, it is '
+                             'strongly recommended to increase nfiles.')
             system_RAM = psutil.virtual_memory().total
             filesize = os.path.getsize(meta.segment_list[istart])*meta.expand
             maxfiles = max([1, int(system_RAM*meta.max_memory/filesize)])

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -464,7 +464,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                         saved_ref_median_frame = data.medflux
                     else:
                         # Load the original median frame
-                        data.medflux = saved_ref_median_frame
+                        data['medflux'] = saved_ref_median_frame
 
                     # correct spectral curvature
                     if not hasattr(meta, 'curvature'):

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -292,8 +292,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 meta.max_memory = 0.5
             if not hasattr(meta, 'nfiles'):
                 meta.nfiles = 1
-            if meta.nfiles == 1 and meta.nfiles > 1 and \
-                    meta.indep_batches == True:
+            if meta.nfiles == 1 and meta.nfiles > 1 and meta.indep_batches:
                 log.writelog('WARNING: You have selected non-ideal settings '
                              'with indep_batches = True and nfiles = 1.'
                              'If your computer has enough RAM to '

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -292,11 +292,6 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 meta.max_memory = 0.5
             if not hasattr(meta, 'nfiles'):
                 meta.nfiles = 1
-            if meta.nfiles == 1 and meta.nfiles > 1:
-                log.writelog('WARNING: Strange behaviors can occur if you set '
-                             'nfiles to 1. If your computer has enough RAM to '
-                             'load many/all of your Stage 2 files, it is '
-                             'strongly recommended to increase nfiles.')
             system_RAM = psutil.virtual_memory().total
             filesize = os.path.getsize(meta.segment_list[istart])*meta.expand
             maxfiles = max([1, int(system_RAM*meta.max_memory/filesize)])
@@ -770,7 +765,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 meta.mad_s3 = 0
 
             if meta.isplots_S3 >= 1 and not meta.photometry:
-                log.writelog('Generating figure')
+                log.writelog('Generating figures')
                 # 2D light curve without drift correction
                 plots_s3.lc_nodriftcorr(meta, spec.wave_1d, spec.optspec,
                                         optmask=spec.optmask)

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -630,13 +630,11 @@ def difference_frames(data, meta, log):
             pass
 
         # Guess spectrum position only using subarray region
-        masked_data = diffflux[n, 
-                               meta.ywindow[0]:meta.ywindow[1],
-                               meta.xwindow[0]:meta.xwindow[1]] * \
-                      diffmask[n, 
-                               meta.ywindow[0]:meta.ywindow[1],
-                               meta.xwindow[0]:meta.xwindow[1]]
-        guess[n] = (np.median(np.where(masked_data > np.mean(masked_data))[0]) \
+        masked_data = diffflux[n, meta.ywindow[0]:meta.ywindow[1],
+                                  meta.xwindow[0]:meta.xwindow[1]] * \
+                      diffmask[n, meta.ywindow[0]:meta.ywindow[1],
+                                  meta.xwindow[0]:meta.xwindow[1]]
+        guess[n] = (np.median(np.where(masked_data > np.mean(masked_data))[0]) 
                     + meta.ywindow[0]).astype(int)
     # Guess may be skewed if first read is zeros
     if guess[0] < 0 or guess[0] > meta.ny:

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -632,8 +632,8 @@ def difference_frames(data, meta, log):
         # Guess spectrum position only using subarray region
         masked_data = diffflux[n, meta.ywindow[0]:meta.ywindow[1],
                                meta.xwindow[0]:meta.xwindow[1]] * \
-                diffmask[n, meta.ywindow[0]:meta.ywindow[1],
-                         meta.xwindow[0]:meta.xwindow[1]]
+            diffmask[n, meta.ywindow[0]:meta.ywindow[1],
+                     meta.xwindow[0]:meta.xwindow[1]]
         guess[n] = (np.median(np.where(masked_data > np.mean(masked_data))[0]) 
                     + meta.ywindow[0]).astype(int)
     # Guess may be skewed if first read is zeros

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -632,12 +632,12 @@ def difference_frames(data, meta, log):
         # Guess spectrum position only using subarray region
         masked_data = diffflux[n, 
                                meta.ywindow[0]:meta.ywindow[1],
-                               meta.xwindow[0]:meta.xwindow[1]]* \
+                               meta.xwindow[0]:meta.xwindow[1]] * \
                       diffmask[n, 
                                meta.ywindow[0]:meta.ywindow[1],
                                meta.xwindow[0]:meta.xwindow[1]]
-        guess[n] = (np.median(np.where(masked_data > np.mean(masked_data)
-                                      )[0]) + meta.ywindow[0]).astype(int)
+        guess[n] = (np.median(np.where(masked_data > np.mean(masked_data))[0]) \
+                    + meta.ywindow[0]).astype(int)
     # Guess may be skewed if first read is zeros
     if guess[0] < 0 or guess[0] > meta.ny:
         guess[0] = guess[1]

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -39,6 +39,7 @@ def preparation_step(meta, log):
     meta, log = separate_scan_direction(meta, log)
 
     # Calculate centroid of direct image(s)
+    # meta.centroid order is (y,x)
     meta.centroid = hst.imageCentroid(meta.direct_list, meta.centroidguess,
                                       meta.centroidtrim, meta.ny, meta.CRPIX1,
                                       meta.CRPIX2, meta.postarg1,
@@ -100,7 +101,7 @@ def get_reference_frames(meta, log):
 
     # Save the reference frame for each scan direction
     for i in meta.iref:
-        log.writelog(f"Preparing reference frame {i}...")
+        log.writelog(f"Capturing info from reference frame {i}...")
         data = xrio.makeDataset()
         data, meta, log = read(meta.segment_list[i], data, meta, log)
         meta.n_int, meta.ny, meta.nx = data.flux.shape
@@ -403,7 +404,7 @@ def read(filename, data, meta, log):
         # Determine if we are using IMA or FLT files
         if filename.endswith('flt.fits'):
             # FLT files subtract first from last, 2 reads
-            meta.nreads = 2
+            meta.nreads = 1
         else:
             meta.nreads = data.attrs['shdr']['SAMPNUM']
 
@@ -411,14 +412,12 @@ def read(filename, data, meta, log):
         err = np.zeros((meta.nreads, meta.ny, meta.nx))  # Error
         dq = np.zeros((meta.nreads, meta.ny, meta.nx))  # Flags
         jd = []
-        j = 0
-        for rd in range(meta.nreads, 0, -1):
+        for j, rd in enumerate(range(meta.nreads, 0, -1)):
             sci[j] = hdulist['SCI', rd].data
             err[j] = hdulist['ERR', rd].data
             dq[j] = hdulist['DQ', rd].data
             jd.append(2400000.5+hdulist['SCI', rd].header['ROUTTIME']
                       - 0.5*hdulist['SCI', rd].header['DELTATIM']/3600/24)
-            j += 1
         jd = np.array(jd)
 
     ra = data.attrs['mhdr']['RA_TARG']*np.pi/180
@@ -599,7 +598,7 @@ def difference_frames(data, meta, log):
     log : logedit.Logedit
         The current log.
     '''
-    if meta.firstInBatch:
+    if meta.nreads > 1 and meta.firstInBatch:
         log.writelog('  Differencing non-destructive reads...',
                      mute=(not meta.verbose))
 
@@ -623,17 +622,22 @@ def difference_frames(data, meta, log):
     guess = np.zeros((meta.nreads), dtype=int)
     for n in range(meta.nreads):
         diffmask[n] = data['flatmask'][0][0]
-        try:
+        if meta.nreads > 1:
             diffmask[n][np.where(differr[n] > meta.diffthresh *
                         np.median(differr[n], axis=1)[:, np.newaxis])] = 0
-        except:
-            # FINDME: Need to only catch the expected exception
-            # May fail for FLT files
-            log.writelog("Diffthresh failed - this may happen for FLT files.")
+        else:
+            # Don't use diffthresh for FLT files
+            pass
 
-        masked_data = diffflux[n]*diffmask[n]
-        guess[n] = np.median(np.where(masked_data > np.mean(masked_data)
-                                      )[0]).astype(int)
+        # Guess spectrum position only using subarray region
+        masked_data = diffflux[n, 
+                               meta.ywindow[0]:meta.ywindow[1],
+                               meta.xwindow[0]:meta.xwindow[1]]* \
+                      diffmask[n, 
+                               meta.ywindow[0]:meta.ywindow[1],
+                               meta.xwindow[0]:meta.xwindow[1]]
+        guess[n] = (np.median(np.where(masked_data > np.mean(masked_data)
+                                      )[0]) + meta.ywindow[0]).astype(int)
     # Guess may be skewed if first read is zeros
     if guess[0] < 0 or guess[0] > meta.ny:
         guess[0] = guess[1]
@@ -657,7 +661,11 @@ def difference_frames(data, meta, log):
     # Create Xarray Dataset with updated time axis for differenced frames
     flux_units = data.flux.attrs['flux_units']
     time_units = data.flux.attrs['time_units']
-    difftime = data.time[:-1] + 0.5*np.ediff1d(data.time)
+    if meta.nreads > 1:
+        difftime = data.time[:-1] + 0.5*np.ediff1d(data.time)
+    else:
+        # FLT data has already been differenced
+        difftime = data.time
     diffdata = xrio.makeDataset()
     diffdata['flux'] = xrio.makeFluxLikeDA(diffflux, difftime, flux_units,
                                            time_units, name='flux')

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -631,9 +631,9 @@ def difference_frames(data, meta, log):
 
         # Guess spectrum position only using subarray region
         masked_data = diffflux[n, meta.ywindow[0]:meta.ywindow[1],
-                                  meta.xwindow[0]:meta.xwindow[1]] * \
-                      diffmask[n, meta.ywindow[0]:meta.ywindow[1],
-                                  meta.xwindow[0]:meta.xwindow[1]]
+                               meta.xwindow[0]:meta.xwindow[1]] * \
+                diffmask[n, meta.ywindow[0]:meta.ywindow[1],
+                         meta.xwindow[0]:meta.xwindow[1]]
         guess[n] = (np.median(np.where(masked_data > np.mean(masked_data))[0]) 
                     + meta.ywindow[0]).astype(int)
     # Guess may be skewed if first read is zeros

--- a/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
@@ -123,10 +123,10 @@ class HSTRampModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
             
-            h0, h1, h2, h3, h4, h5 = self.coeffs[c]
+            h0, h1, h2, h3, h4, h5, h6 = self.coeffs[c]
             # Batch time is relative to the start of each HST orbit
             # h5 is the orbital period of HST (~96 minutes)
-            self.time_batch = self.time_local % h5
+            self.time_batch = (self.time_local-h6) % h5
             lcpiece = (1+h0*np.exp(-h1*self.time_batch + h2)
                        + h3*self.time_batch + h4*self.time_batch**2)
             lcfinal = np.append(lcfinal, lcpiece)

--- a/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
@@ -35,7 +35,7 @@ class HSTRampModel(Model):
             self.parameters = Parameters(**params)
 
         # Update coefficients
-        self.coeffs = np.zeros((self.nchannel_fitted, 6))
+        self.coeffs = np.zeros((self.nchannel_fitted, 7))
         self._parse_coeffs()
 
     @property
@@ -76,7 +76,7 @@ class HSTRampModel(Model):
             else:
                 chan = 0
 
-            for i in range(6):
+            for i in range(7):
                 try:
                     if chan == 0:
                         self.coeffs[c, i] = self.parameters.dict[f'h{i}'][0]


### PR DESCRIPTION
This PR implements a few, unrelated enhancements based on my needs while working on several projects over the past week.  Fitting LCs to HST WFC3 data is now less sensitive to HST's period because, by adding h6, the reset now happens during Earth occultation instead of at the time of the first science frame.  This PR also solves an issue reported in #570 in a slightly different manner than @taylorbell57's solution because I wanted to get the half-pixel edges correct (bounds for detector pixels 5-28 need to be 4.5-28.5).  Here's a brief list of fixes:
- Enable HST FLT reduction
- Enhance HSTRampModel
- Update WFC3 template
- Implement `plots_s3.get_bounds()` to correctly define xlim and ylim while accounting for instrument and half-pixels offsets
- Enable calibrated spectra with NIRSpec
- Small bug fixes