### PR TITLE
Fixing S3 Pickling Bug, S6 Plotting Bug, and Adding S5 LTT Option

### DIFF
--- a/demos/HST/S5_wfc3_template.ecf
+++ b/demos/HST/S5_wfc3_template.ecf
@@ -10,6 +10,7 @@ fit_par         ./S5_fit_par_wfc3_template.epf # What fitting epf do you want to
 verbose         True                   # If True, more details will be printed about steps
 fit_method      [dynesty]              #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
 run_myfuncs     [batman_tr,polynomial,hstramp] # options are: batman_tr, batman_ecl, sinusoid_pc, expramp, hstramp, polynomial, step, xpos, ypos, xwidth, ywidth, and GP (can list multiple types separated by commas)
+compute_ltt     False                   # options are: True (correct model for the light travel time effect), or False (ignore the light travel time effect)
 
 # Manual clipping in time
 manual_clip     None    # A list of lists specifying the start and end integration numbers for manual removal.

--- a/demos/JWST/S5_template.ecf
+++ b/demos/JWST/S5_template.ecf
@@ -10,6 +10,7 @@ fit_par         ./S5_fit_par_template.epf   # What fitting epf do you want to us
 verbose         True                    # If True, more details will be printed about steps
 fit_method      [dynesty]               #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
 run_myfuncs     [batman_tr,polynomial]  # options are: batman_tr, batman_ecl, sinusoid_pc, expramp, polynomial, step, xpos, ypos, xwidth, ywidth, and GP (can list multiple types separated by commas)
+compute_ltt     False                   # options are: True (correct model for the light travel time effect), or False (ignore the light travel time effect)
 
 # Manual clipping in time
 manual_clip     None    # A list of lists specifying the start and end integration numbers for manual removal.

--- a/docs/media/S5_template.ecf
+++ b/docs/media/S5_template.ecf
@@ -10,6 +10,7 @@ fit_par         ./S5_fit_par_template.epf   # What fitting epf do you want to us
 verbose         True                    # If True, more details will be printed about steps
 fit_method      [dynesty]               #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
 run_myfuncs     [batman_tr, polynomial]  # options are: batman_tr, batman_ecl, sinusoid_pc, expramp, hstramp, polynomial, step, xpos, ypos, xwidth, ywidth, and GP (can list multiple types separated by commas)
+compute_ltt     False                   # options are: True (correct model for the light travel time effect), or False (ignore the light travel time effect)
 
 # Manual clipping in time
 manual_clip     None    # A list of lists specifying the start and end integration numbers for manual removal (done before summing reads).

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -853,6 +853,12 @@ For theano-based differentiable functions, this can be one or more of the follow
 [starry, sinusoid_pc, expramp, hstramp, polynomial, step, xpos, ypos, xwidth, ywidth],
 where starry replaces both the batman_tr and batman_ecl models and offers a more complicated phase variation model than sinusoid_pc that accounts for eclipse mapping signals.
 
+compute_ltt
+'''''''''''
+Optional. Determines whether to correct the astrophysical model for the light travel time effect (True) or to ignore the effect (False).
+The light travel time effect is caused by the finite speed of light which means that the signal from a secondary eclipse (which occurs on the far side of the orbit) arrive later than would be expected if the speed of light were infinite.
+Unless specified, compute_ltt is set to True for batman_ecl and starry models but set to False for batman_tr models (since the light travel time is insignificant during transit).
+
 manual_clip
 '''''''''''
 Optional. A list of lists specifying the start and end integration numbers for manual removal. E.g., to remove the first 20 data points specify [[0,20]], and to also remove the last 20 data points specify [[0,20],[-20,None]]. If you want to clip the 10th integration, this would be index 9 since python uses zero-indexing. And the manual_clip start and end values are used to slice a numpy array, so they follow the same convention of *inclusive* start index and *exclusive* end index. In other words, to trim the 10th integrations, you would set manual_clip to [[9,10]].

--- a/src/eureka/S3_data_reduction/source_pos.py
+++ b/src/eureka/S3_data_reduction/source_pos.py
@@ -71,14 +71,14 @@ def source_pos_wrapper(data, meta, log, m, integ=0):
                 iterfn = tqdm(iterfn)
             for n in iterfn:
                 writePos(source_pos(flux[n], meta, data.attrs['shdr'],
-                                    m, n, log, False, guess))
+                                    m, n, False, guess))
         else:
             # Multiple CPUs
             pool = mp.Pool(meta.ncpu)
             jobs = [pool.apply_async(func=source_pos,
                                      args=(flux[n], meta,
                                            data.attrs['shdr'], m,
-                                           n, log, False, guess),
+                                           n, False, guess),
                                      callback=writePos)
                     for n in range(meta.int_start, meta.n_int)]
             pool.close()
@@ -99,7 +99,7 @@ def source_pos_wrapper(data, meta, log, m, integ=0):
         log.writelog('  Locating source position...', mute=(not meta.verbose))
 
         meta.src_ypos = source_pos(flux[integ], meta, data.attrs['shdr'],
-                                   m, integ, log, True, guess)[0]
+                                   m, integ, True, guess)[0]
 
         log.writelog('    Source position on detector is row '
                      f'{meta.src_ypos}.', mute=(not meta.verbose))
@@ -107,7 +107,7 @@ def source_pos_wrapper(data, meta, log, m, integ=0):
         return data, meta, log
 
 
-def source_pos(flux, meta, shdr, m, n, log, plot=True, guess=None):
+def source_pos(flux, meta, shdr, m, n, plot=True, guess=None):
     '''Determine the source position for one frames.
 
     Parameters
@@ -122,8 +122,6 @@ def source_pos(flux, meta, shdr, m, n, log, plot=True, guess=None):
         The file number.
     n : int
         The integration number.
-    log : logedit.Logedit
-        The current log.
     plot : bool; optional
         If True, plot the source position determination.
         Defaults to True.
@@ -172,9 +170,6 @@ def source_pos(flux, meta, shdr, m, n, log, plot=True, guess=None):
         src_ypos = float(meta.src_pos_type)
     else:
         # Some unrecognized string
-        log.writelog(f'WARNING: {meta.src_pos_type} is not a recognized ' +
-                     'source position type. Options: header, gaussian, ' +
-                     'weighted, max, hst, or a numeric value.')
         raise Exception(f'{meta.src_pos_type} is not a recognized source ' +
                         'position type. Options: header, gaussian, weighted,' +
                         ' max, hst, or a numeric value.')

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
@@ -41,6 +41,10 @@ class StarryModel(PyMC3Model):
         # Define model type (physical, systematic, other)
         self.modeltype = 'physical'
 
+        # Set default to turn light-travel correction on if not specified
+        if not hasattr(self, 'compute_ltt') or self.compute_ltt is None:
+            self.compute_ltt = True
+
         required = np.array(['Ms', 'Rs'])
         missing = np.array([name not in self.paramtitles for name in required])
         if np.any(missing):
@@ -188,7 +192,7 @@ class StarryModel(PyMC3Model):
             planet.t0 = temp.t0
 
             # Instantiate the system
-            system = starry.System(star, planet, light_delay=True)
+            system = starry.System(star, planet, light_delay=self.compute_ltt)
             self.systems.append(system)
 
     def eval(self, eval=True, channel=None, **kwargs):
@@ -370,5 +374,5 @@ class StarryModel(PyMC3Model):
             planet.t0 = temp.t0
 
             # Instantiate the system
-            sys = starry.System(star, planet, light_delay=True)
+            sys = starry.System(star, planet, light_delay=self.compute_ltt)
             self.fit.systems.append(sys)


### PR DESCRIPTION
This PR resolves #602 by removing the log which cannot be pickled for multiprocessing. The log wasn't really needed anyway, so this was an easy fix.

This PR also fixes a small nuance in how the S6 final spectra are computed since we were previously using sigmas but should be using percentiles which are more robust to non-Gaussian posteriors. I also slightly tweaked how some parameters were loaded in S6 which will become more important as we add more and more fitted parameters (the old code could sometimes get confused in some edge cases).

Finally, this PR allows users to choose whether or not to apply the light travel time correction. This allows backwards compatibilty with old code while also permitting more user freedom. This new S5 ECF parameter has been noted in the docs and has defaults baked into the code.