### PR TITLE
Stage 1 Jump Step Parallelization

### DIFF
--- a/demos/JWST/S1_miri_template.ecf
+++ b/demos/JWST/S1_miri_template.ecf
@@ -4,9 +4,10 @@
 
 suffix              uncal
 
+maximum_cores       'none'  #Options are 'none', quarter', 'half','all'
+
 # Control ramp fitting method
 ramp_fit_algorithm  'default'   #Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores  'none'  #Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
 skip_group_scale    False

--- a/demos/JWST/S1_miri_template.ecf
+++ b/demos/JWST/S1_miri_template.ecf
@@ -4,7 +4,7 @@
 
 suffix              uncal
 
-maximum_cores       'none'  #Options are 'none', quarter', 'half','all'
+maximum_cores       'half'  #Options are 'none', quarter', 'half','all'
 
 # Control ramp fitting method
 ramp_fit_algorithm  'default'   #Options are 'default', 'mean', or 'differenced'
@@ -14,8 +14,8 @@ skip_group_scale    False
 skip_dq_init        False
 skip_saturation     False
 skip_ipc            True    #Skipped by default for all instruments
-skip_firstframe     True    #Skipped by default for MIRI TSO
-skip_lastframe      True
+skip_firstframe     False   #Typically best to set False for MIRI TSO, but you should experiment
+skip_lastframe      False   #Typically best to set False for MIRI TSO, but you should experiment
 skip_refpix         False
 skip_linearity      False
 skip_rscd           True    #Skipped by default for MIRI TSO

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -4,9 +4,10 @@
 
 suffix              uncal
 
+maximum_cores       'half'  #Options are 'none', quarter', 'half', 'all'
+
 # Control ramp fitting method
 ramp_fit_algorithm  'default'   #Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores  'none'  #Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
 skip_group_scale    False

--- a/docs/media/S1_template.ecf
+++ b/docs/media/S1_template.ecf
@@ -4,9 +4,10 @@
 
 suffix              uncal
 
+maximum_cores       'half'  #Options are 'none', quarter', 'half', 'all'
+
 # Control ramp fitting method
 ramp_fit_algorithm  'default'   #Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores  'none'  #Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
 skip_group_scale    False

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -29,9 +29,9 @@ ramp_fit_algorithm
 Algorithm to use to fit a ramp to the frame-level images of uncalibrated files. Only default (i.e. the JWST pipeline) and mean can be used currently.
 
 
-ramp_fit_max_cores
+maximum_cores
 ''''''''''''''''''
-Fraction of processor cores to use to compute the ramp fits, options are ``none``, ``quarter``, ``half``, ``all``.
+Fraction of processor cores to use when computing the jump step and the ramp fits. Options are ``''none'``, ``'quarter'``, ``'half'``, or ``'all'``.
 
 
 skip_*

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -201,6 +201,7 @@ class EurekaS1Pipeline(Detector1Pipeline):
             self.linearity.override_linearity = meta.linearity_file
         self.dark_current.skip = meta.skip_dark_current
         self.jump.skip = meta.skip_jump
+        self.jump.maximum_cores = meta.maximum_cores
         if (hasattr(meta, 'jump_rejection_threshold') and
                 isinstance(meta.jump_rejection_threshold, float)):
             self.jump.rejection_threshold = meta.jump_rejection_threshold
@@ -223,7 +224,7 @@ class EurekaS1Pipeline(Detector1Pipeline):
         # Define ramp fitting procedure
         self.ramp_fit = Eureka_RampFitStep()
         self.ramp_fit.algorithm = meta.ramp_fit_algorithm
-        self.ramp_fit.maximum_cores = meta.ramp_fit_max_cores
+        self.ramp_fit.maximum_cores = meta.maximum_cores
         self.ramp_fit.skip = meta.skip_ramp_fitting
         self.ramp_fit.s1_meta = meta
         self.ramp_fit.s1_log = log

--- a/src/eureka/S5_lightcurve_fitting/__init__.py
+++ b/src/eureka/S5_lightcurve_fitting/__init__.py
@@ -5,8 +5,9 @@ Package to fit models to light curve data
 try:
     from . import differentiable_models
 except ModuleNotFoundError:
-    print("Could not import starry and/or pymc3 related packages. "
-          "Functionality may be limited.")
+    # Don't require that the pymc3, starry, and theano packages be installed
+    # but also don't raise a warning here to avoid excessive spam
+    pass
 
 from . import fitters
 from . import gradient_fitters

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -88,6 +88,13 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
 
     meta = me.mergeevents(meta, s4_meta)
 
+    # Check to make sure that dm is accessible if using dm models/fitters
+    if 'starry' in meta.fit_method or 'exoplanet' in meta.fit_method:
+        raise AssertionError(f"fit_method is set to {meta.fit_method}, but "
+                             "could not import starry and/or pymc3 related "
+                             "packages. Ensure that you have installed the "
+                             "pymc3-related packages when installing Eureka!.")
+
     if not meta.allapers:
         # The user indicated in the ecf that they only want to consider one
         # aperture in which case the code will consider only the one which

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -16,7 +16,7 @@ try:
     from . import differentiable_models as dm
 except:
     # PyMC3 hasn't been installed
-    pass
+    dm = None
 
 
 def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
@@ -89,7 +89,8 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
     meta = me.mergeevents(meta, s4_meta)
 
     # Check to make sure that dm is accessible if using dm models/fitters
-    if 'starry' in meta.fit_method or 'exoplanet' in meta.fit_method:
+    if (dm is None and ('starry' in meta.fit_method or
+                        'exoplanet' in meta.fit_method)):
         raise AssertionError(f"fit_method is set to {meta.fit_method}, but "
                              "could not import starry and/or pymc3 related "
                              "packages. Ensure that you have installed the "

--- a/tests/MIRI_ecfs/S1_MIRI.ecf
+++ b/tests/MIRI_ecfs/S1_MIRI.ecf
@@ -2,7 +2,7 @@
 
 suffix 						uncal
 
-maximum_cores				'all'		#Options are 'none', quarter', 'half','all'
+maximum_cores				'half'		#Options are 'none', quarter', 'half', 'all'
 
 # Control ramp fitting method
 ramp_fit_algorithm			'default' 	#Options are 'default', 'mean', or 'differenced'

--- a/tests/MIRI_ecfs/S1_MIRI.ecf
+++ b/tests/MIRI_ecfs/S1_MIRI.ecf
@@ -2,9 +2,10 @@
 
 suffix 						uncal
 
+maximum_cores				'all'		#Options are 'none', quarter', 'half','all'
+
 # Control ramp fitting method
 ramp_fit_algorithm			'default' 	#Options are 'default', 'mean', or 'differenced'
-ramp_fit_max_cores 			'all'		#Options are 'none', quarter', 'half','all'
 
 # Pipeline stages
 skip_group_scale			False


### PR DESCRIPTION
This little PR parallelizes the Stage 1 Jump Step (an option long offered by STScI's jwst pipeline but not supported by us for some reason). I also tweaked the MIRI S1 template to reflect the best settings I've found from multiple analyses so far. Finally, I also reduced the frequency of the warnings about pymc3/starry not being installed (which others have complained about), and now these will only pop up when the user tries to use the packages and causes an informative `AssertionError`.