### PR TITLE
Resolved libGL ImportError by removing opencv-python dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,7 @@ dmypy.json
 niriss_cython.c
 
 # Dockerfiles
-Dockerfile
+Dockerfile*
 docker-compose.yml
 docker-setup.sh
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -36,6 +36,18 @@ Be sure that you are installing (or have installed) batman-package (not batman) 
 installed the wrong package you can try pip uninstalling it, but you may just need to make a whole new environment.
 In general, we strongly recommend you closely follow the instructions on the :ref:`installation` page.
 
+Issues running starry/theano code
+'''''''''''''''''''''''''''''''''
+
+Be sure that you have installed the ``pymc3`` optional dependencies when installing Eureka! as described on the
+:ref:`installation` page. If you're getting an error that includes ``theano/tensor/elemwise.py:264: TypeError``,
+you most likely need to make sure that you have the g++ compiler installed (i.e., do ``sudo apt install g++`` if you're
+on Ubuntu). If you're getting issues stating something like numpy was compiled for a different version, then you likely
+need to make sure you're starting with a new conda environment and use the ``pymc3`` optional dependencies which set a
+more strict upper-limit on the numpy version permitted. If you're getting an error that includes ``ImportError: libGL.so.1``,
+then you either need to start with a new conda environment and make sure that you only install ``opencv-python-headless``
+and not ``opencv-python``, or you need to install libgl1 by doing ``sudo apt install libgl1``.
+
 
 .. _faq-install:
 

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -44,7 +44,6 @@ dependencies:
         - image_registration@git+https://github.com/keflavich/image_registration@master # Need GitHub version to avoid np.float issue
         - jwst==1.11.4
         - myst-parser # Needed for documentation
-        - opencv-python<4.8 # Upper limit needed for numpy<1.22
         - opencv-python-headless<4.8 # Upper limit needed for numpy<1.22
         - pymc3
         - setuptools_scm # Needed for version number

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,7 +83,6 @@ pymc3 =
     theano-pymc
     # Extra version limits
     numpy>=1.20.0,<1.22 # Upper limit needed for theano, starry, and pymc3
-    opencv-python<4.8 # Upper limit needed for numpy<1.22
     opencv-python-headless<4.8 # Upper limit needed for numpy<1.22
     scipy>=1.4.0,<1.8.0 # Lower limit needed for scipy.fft, upper limit needed for theano, starry, and pymc3
     xarray<2023.10.0 # Upper limit needed for numpy<1.22


### PR DESCRIPTION
This resolves #586 by only installing `opencv-python-headless` and not `opencv-python`. I also added instructions about resolving `g++` related issues to the FAQ page and explained what to do if folks end up encountering this libGL ImportError issue anyway (e.g., they install `opencv-python` themselves, or another dependency does)