### PR TITLE
Switching from celerite to celerite2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - batman-package
     - bokeh[version='<3.0']
     - ccdproc
-    - celerite # Needed for GP
+    - celerite2 # Needed for GP
     - corner
     - dynesty[version='>1.0'] # Lower limit needed for specific arguments
     - emcee[version='>3.0.0'] # Lower limit needed for specific arguments

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -9,7 +9,7 @@ dependencies:
     - batman-package
     - bokeh[version='<3.0']
     - ccdproc
-    - celerite # Needed for GP
+    - celerite2 # Needed for GP
     - corner
     - dynesty[version='>1.0'] # Lower limit needed for specific arguments
     - emcee[version='>3.0.0'] # Lower limit needed for specific arguments

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     batman-package
     bokeh<3.0
     ccdproc
-    celerite # Needed for GP
+    celerite2 # Needed for GP
     corner
     crds
     dynesty>1.0 # Lower limit needed for specific arguments

--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -102,9 +102,9 @@ def lsqfitter(lc, model, meta, log, calling_function='lsq', **kwargs):
                              freenames)
 
     if not hasattr(meta, 'lsq_method'):
-        log.writelog('No lsq optimization method specified - using Nelder-Mead'
+        log.writelog('No lsq optimization method specified - using Powell'
                      ' by default.')
-        meta.lsq_method = 'Nelder-Mead'
+        meta.lsq_method = 'Powell'
     if not hasattr(meta, 'lsq_tol'):
         log.writelog('No lsq tolerance specified - using 1e-6 by default.')
         meta.lsq_tol = 1e-6

--- a/src/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -1,7 +1,7 @@
 import numpy as np
 import george
 from george import kernels
-import celerite
+import celerite2
 
 from .Model import Model
 from ..likelihood import update_uncertainty
@@ -67,11 +67,11 @@ class GPModel(Model):
 
         if self.gp_code_name == 'celerite':
             if self.nkernels > 1:
-                raise AssertionError('Celerite cannot compute multi-'
+                raise AssertionError('Celerite2 cannot compute multi-'
                                      'dimensional GPs. Please choose a '
                                      'different GP code')
             elif self.kernel_types[0] != 'Matern32':
-                raise AssertionError('Our celerite implementation currently '
+                raise AssertionError('Our celerite2 implementation currently '
                                      'only supports a Matern32 kernel.')
 
         # Update coefficients
@@ -121,7 +121,7 @@ class GPModel(Model):
             The rest of the current model evaluated.
         channel : int; optional
             If not None, only consider one of the channels. Defaults to None.
-        gp : celerite.GP, george.GP, or tinygp.GaussianProcess; optional
+        gp : celerite2.GP, george.GP, or tinygp.GaussianProcess; optional
             The current GP object.
         **kwargs : dict
             Must pass in the time array here if not already set.
@@ -236,7 +236,7 @@ class GPModel(Model):
 
         Returns
         -------
-        celerite.GP, george.GP, or tinygp.GaussianProcess
+        celerite2.GP, george.GP, or tinygp.GaussianProcess
             The GP object to use for this fit.
         """
         if self.kernel_inputs is None:
@@ -255,7 +255,7 @@ class GPModel(Model):
                 solver = None
             gp = george.GP(kernel, mean=0, fit_mean=False, solver=solver)
         elif self.gp_code_name == 'celerite':
-            gp = celerite.GP(kernel, mean=0, fit_mean=False)
+            gp = celerite2.GaussianProcess(kernel, mean=0, fit_mean=False)
         elif self.gp_code_name == 'tinygp':
             if self.nchannel_fitted > 1:
                 chan = self.fitted_channels[c]
@@ -281,12 +281,13 @@ class GPModel(Model):
         Returns
         -------
         kernel
-            The requested george, celerite, or tinygp kernel.
+            The requested george, celerite2, or tinygp kernel.
 
         Raises
         ------
         AssertionError
-            Celerite currently only supports a Matern32 kernel.
+            george and tinygp currently only support the Matern32, ExpSquared,
+            RationalQuadratic, and Exp kernels.
         """
         if self.gp_code_name == 'george':
             # get metric and amplitude for the current kernel and channel
@@ -312,12 +313,12 @@ class GPModel(Model):
                                      'ExpSquared, RationalQuadratic, Exp.')
         elif self.gp_code_name == 'celerite':
             # get metric and amplitude for the current kernel and channel
-            amp = self.coeffs[c, k, 0]
-            metric = self.coeffs[c, k, 1]
+            amp = np.exp(self.coeffs[c, k, 0])
+            metric = np.exp(self.coeffs[c, k, 1])
 
-            kernel = celerite.terms.Matern32Term(log_sigma=0, log_rho=metric)
+            kernel = celerite2.terms.Matern32Term(sigma=1, rho=metric)
             # Setting the amplitude
-            kernel *= celerite.terms.RealTerm(log_a=amp, log_c=-10)
+            kernel *= celerite2.terms.RealTerm(a=amp, c=0)
         elif self.gp_code_name == 'tinygp':
             # get metric and amplitude for the current kernel and channel
             amp = np.exp(self.coeffs[c, k, 0]*2)  # Want exp(sigma)^2
@@ -353,7 +354,7 @@ class GPModel(Model):
         Returns
         -------
         float
-            log likelihood of the GP evaluated by george/tinygp/celerite
+            log likelihood of the GP evaluated by george/tinygp/celerite2
         """
         if channel is None:
             nchan = self.nchannel_fitted

--- a/src/eureka/lib/gaussian_min.py
+++ b/src/eureka/lib/gaussian_min.py
@@ -199,7 +199,7 @@ def mingauss(img, yxguess, meta):
               f"while meta.inst is set to {meta.inst}")
         initial_guess = [400, 20, 20]
 
-    # Fit the gaussian width by minimizing minfunc with the Nelder-Mead method.
+    # Fit the gaussian width by minimizing minfunc with the Powell method.
     results = minimize(minfunc, initial_guess,
                        args=(frame, x_mesh, y_mesh, x, y),
                        method='Powell',

--- a/tests/NIRSpec_ecfs/S5_NIRSpec.ecf
+++ b/tests/NIRSpec_ecfs/S5_NIRSpec.ecf
@@ -7,19 +7,19 @@ rescale_err     False    # Rescale uncertainties to have reduced chi-squared of 
 fit_par         ./S5_fit_par.epf # What fitting ecf do you want to use?
 verbose         False # If True, more details will be printed about steps
 fit_method      [lsq] #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
-run_myfuncs     [batman_tr, polynomial] #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, polynomial, step, and GP (can list multiple types separated by commas)
+run_myfuncs     [batman_tr, polynomial, GP] #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, polynomial, step, and GP (can list multiple types separated by commas)
 
 # Manual clipping in time
 manual_clip     None    # A list of lists specifying the start and end integration numbers for manual removal.
 
 # Limb darkening controls
 # IMPORTANT: limb-darkening coefficients are not automatically fixed then, change to 'fixed' in .epf file whether they should be fixed or fitted!
-use_generate_ld  None  # use the generated limb-darkening coefficients from Stage 4? Options: exotic-ld, None. For exotic-ld, the limb-darkening laws available are linear, quadratic, 3-parameter and 4-parameter non-linear.
-ld_file          None  # Fully qualified path to the location of a limb darkening file that you want to use
-ld_file_white    None  # Fully qualified path to the location of a limb darkening file that you want to use for the white-light light curve (required if ld_file is not None and any EPF parameters are set to white_free or white_fixed).
+use_generate_ld None  # use the generated limb-darkening coefficients from Stage 4? Options: exotic-ld, None. For exotic-ld, the limb-darkening laws available are linear, quadratic, 3-parameter and 4-parameter non-linear.
+ld_file         None  # Fully qualified path to the location of a limb darkening file that you want to use
+ld_file_white   None  # Fully qualified path to the location of a limb darkening file that you want to use for the white-light light curve (required if ld_file is not None and any EPF parameters are set to white_free or white_fixed).
 
 #lsq
-lsq_method      'Nelder-Mead' # The scipy.optimize.minimize optimization method to use
+lsq_method      'Powell' # The scipy.optimize.minimize optimization method to use
 lsq_tol         1e-6 # The tolerance for the scipy.optimize.minimize optimization method
 
 #mcmc

--- a/tests/NIRSpec_ecfs/S5_fit_par.epf
+++ b/tests/NIRSpec_ecfs/S5_fit_par.epf
@@ -38,6 +38,9 @@ u2			0.1				'fixed'			0				1				U
 # Drift model variables (xpos, ypos, xwidth, ywidth)
 # --------------------
 c0			1.009			'free'			0.95			1.05			U
+# GP Parameters
+A			-15				'free'			-25				-5			U
+m			-4				'free'			-8				0			U
 # -----------
 # ** White noise **
 # Use scatter_mult to fit a multiplier to the expected noise level from Stage 3 (recommended)

--- a/tests/test_NIRSpec.py
+++ b/tests/test_NIRSpec.py
@@ -108,7 +108,7 @@ def test_NIRSpec(capsys):
     assert os.path.exists(name)
     assert os.path.exists(name+os.sep+'figs')
 
-    s5_cites = np.union1d(s4_cites, COMMON_IMPORTS[4] + ["batman"])
+    s5_cites = np.union1d(s4_cites, COMMON_IMPORTS[4] + ["batman", "celerite"])
     assert np.array_equal(s5_meta.citations, s5_cites)
 
     # remove temporary files


### PR DESCRIPTION
This RP resolves #608

This will later allow us to use celerite2 with PyMC3 fitters/models, and also fixes some annoying bugs caused by celerite. I also added a test of the GP model to the NIRSpec lsq fitting test to get some more coverage of the code. Finally, I also switched the default lsq fitter to Powell instead of Nelder-Mead since I have indeed found that Powell is more performant.