### PR TITLE
Computing uncertainty on Allan variance plots using mc3 package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
     - jupyter
     - lmfit
     - matplotlib[version='>=3.6'] # Lower limit needed for set_layout_engine()
+    - mc3 # Needed for uncertainties in the Allan variance plots in S5
     - nbsphinx # Needed for documentation
     - numpy[version='>=1.20.0,<=1.23'] # Upper limit needed for Apple silicon
     - numpydoc # Needed for documentation

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -21,6 +21,7 @@ dependencies:
     - jupyter
     - lmfit
     - matplotlib[version='>=3.6'] # Lower limit needed for set_layout_engine()
+    - mc3 # Needed for uncertainties in the Allan variance plots in S5
     - mkl-service
     - nbsphinx # Needed for documentation
     - numpy[version='>=1.20.0,<1.22'] # Upper limit needed for Apple silicon and for theano, starry, and pymc3

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     h5py
     lmfit
     matplotlib>=3.6 # Lower limit needed for set_layout_engine()
+    mc3 # Needed for uncertainties in the Allan variance plots in S5
     numpy>=1.20.0,<1.25 # Upper limit needed to avoid deprecations
     pandas
     photutils

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -353,7 +353,9 @@ def plot_rms(lc, model, meta, fitter):
         residuals = flux - model_lc
         residuals = residuals[np.argsort(time)]
 
-        maxbins = residuals.size/10.
+        maxbins = residuals.size//10
+        if maxbins < 2:
+            maxbins = residuals.size//2
         rms, rmslo, rmshi, stderr, binsz = time_avg(residuals, maxbins=maxbins,
                                                     binstep=1)
         normfactor = 1e-6

--- a/tests/MIRI_ecfs/S5_MIRI.ecf
+++ b/tests/MIRI_ecfs/S5_MIRI.ecf
@@ -10,7 +10,7 @@ fit_method      [dynesty] #options are: lsq, emcee, dynesty (can list multiple t
 run_myfuncs     [batman_tr,batman_ecl,sinusoid_pc,expramp,polynomial] #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, polynomial, step, and GP (can list multiple types separated by commas)
 
 # Manual clipping in time
-manual_clip     [[None,1]]  # A list of lists specifying the start and end integration numbers for manual removal.
+manual_clip     None  # A list of lists specifying the start and end integration numbers for manual removal.
 
 # Limb darkening controls
 # IMPORTANT: limb-darkening coefficients are not automatically fixed then, change to 'fixed' in .epf file whether they should be fixed or fitted!

--- a/tests/NIRCam_ecfs/S5_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S5_NIRCam.ecf
@@ -10,7 +10,7 @@ fit_method      [lsq, emcee, dynesty] #options are: lsq, emcee, dynesty (can lis
 run_myfuncs     [batman_tr, polynomial] #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, polynomial, step, and GP (can list multiple types separated by commas)
 
 # Manual clipping in time
-manual_clip     None    # A list of lists specifying the start and end integration numbers for manual removal.
+manual_clip     [[None,1],]    # A list of lists specifying the start and end integration numbers for manual removal.
 
 # Limb darkening controls
 # IMPORTANT: limb-darkening coefficients are not automatically fixed then, change to 'fixed' in .epf file whether they should be fixed or fitted!


### PR DESCRIPTION
This PR resolves #590

Our Allan variance plots so far have been slightly inaccurate and were also lacking uncertainties. This simple little PR adds in those features using the excellent `mc3` utility developed by Patricio and draws some inspiration from code I'd previously written for SPCA.

