### PR TITLE
Updating instructions for newer exotic-ld versions

### DIFF
--- a/demos/HST/S4_wfc3_template.ecf
+++ b/demos/HST/S4_wfc3_template.ecf
@@ -40,7 +40,7 @@ metallicity     0.1     # Metallicity of the star
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
 exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
-exotic_ld_grid  3D      # 1D or 3D model grid
+exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 
 # Temporal Binning

--- a/demos/HST/S4_wfc3_template.ecf
+++ b/demos/HST/S4_wfc3_template.ecf
@@ -39,7 +39,7 @@ inst_filter     G102    # Filter of JWST/HST instrument, supported list see http
 metallicity     0.1     # Metallicity of the star 
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
-exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
+exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 

--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -39,7 +39,7 @@ inst_filter     prism   # Filter of JWST/HST instrument, supported list see http
 metallicity     0.1     # Metallicity of the star 
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
-exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
+exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  /home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 

--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -40,7 +40,7 @@ metallicity     0.1     # Metallicity of the star
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
 exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
-exotic_ld_grid  3D      # 1D or 3D model grid
+exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  /home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 
 # Diagnostics

--- a/docs/media/S4_template.ecf
+++ b/docs/media/S4_template.ecf
@@ -39,7 +39,7 @@ inst_filter     prism   # Filter of JWST/HST instrument, supported list see http
 metallicity     0.1     # Metallicity of the star 
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
-exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
+exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  /home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 

--- a/docs/media/S4_template.ecf
+++ b/docs/media/S4_template.ecf
@@ -40,7 +40,7 @@ metallicity     0.1     # Metallicity of the star
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
 exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
-exotic_ld_grid  3D      # 1D or 3D model grid
+exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  /home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 
 # Diagnostics

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -763,11 +763,11 @@ Used by exotic-ld if compute_ld=True. The surface gravity in log g.
 
 exotic_ld_direc
 '''''''''''''''
-Used by exotic-ld if compute_ld=True. The fully qualified path to the directory for ancillary files for exotic-ld, download at https://zenodo.org/record/6344946.
+Used by exotic-ld if compute_ld=True. The fully qualified path to the directory for ancillary files for exotic-ld, available for download at https://zenodo.org/doi/10.5281/zenodo.6047317.
 
 exotic_ld_grid
 ''''''''''''''
-Used by exotic-ld if compute_ld=True. 1D or 3D model grid.
+Used by exotic-ld if compute_ld=True. You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids, if you're using exotic-ld v3.1.2. For more details about these grids, see https://exotic-ld.readthedocs.io/en/latest/views/supported_stellar_grids.html.
 
 exotic_ld_file
 ''''''''''''''

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -767,7 +767,7 @@ Used by exotic-ld if compute_ld=True. The fully qualified path to the directory 
 
 exotic_ld_grid
 ''''''''''''''
-Used by exotic-ld if compute_ld=True. You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids, if you're using exotic-ld v3.1.2. For more details about these grids, see https://exotic-ld.readthedocs.io/en/latest/views/supported_stellar_grids.html.
+Used by exotic-ld if compute_ld=True. You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids, if you're using exotic-ld v3. For more details about these grids, see https://exotic-ld.readthedocs.io/en/latest/views/supported_stellar_grids.html.
 
 exotic_ld_file
 ''''''''''''''

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -104,6 +104,14 @@ To update your ``Eureka!`` installation to the most recent version, you can do t
 	pip install --no-deps --upgrade .
 
 
+Additional ExoTiC-LD Downloads
+------------------------------
+
+If you wish to use the ExoTiC-LD package to compute model stellar limb-darkening profile coefficients (computed in Eureka!'s Stage 4 and used in Stage 5),
+you will need to download the ExoTiC-LD stellar models and instrument throughputs. For details on how to do that, please visit ExoTiC-LD's
+`installation instructions <https://exotic-ld.readthedocs.io/en/latest/views/installation.html>`_, making sure to download the files corresponding to your
+installed ExoTiC-LD version.
+
 
 CRDS Environment Variables
 --------------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -110,7 +110,7 @@ Additional ExoTiC-LD Downloads
 If you wish to use the ExoTiC-LD package to compute model stellar limb-darkening profile coefficients (computed in Eureka!'s Stage 4 and used in Stage 5),
 you will need to download the ExoTiC-LD stellar models and instrument throughputs. For details on how to do that, please visit ExoTiC-LD's
 `installation instructions <https://exotic-ld.readthedocs.io/en/latest/views/installation.html>`_, making sure to download the files corresponding to your
-installed ExoTiC-LD version.
+installed ExoTiC-LD version (make sure the first number in the version number is the same, e.g. you can use the v3.1.2 files with the v3.0.0 ExoTiC-LD package version).
 
 
 CRDS Environment Variables

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
     - pip:
         - astraeus@git+https://github.com/kevin218/Astraeus@main
         - crds
-        - exotic-ld>=3.1.2 # Lower limit needed for updated JWST sensitivity files
+        - exotic-ld==3 # Lower limit needed for updated JWST sensitivity files, upper limit needed for breaking changes
         - image_registration@git+https://github.com/keflavich/image_registration@master # Need GitHub version to avoid np.float issue
         - jwst==1.11.4
         - myst-parser # Needed for documentation

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
     - pip:
         - astraeus@git+https://github.com/kevin218/Astraeus@main
         - crds
-        - exotic-ld
+        - exotic-ld>=3.1.2 # Lower limit needed for updated JWST sensitivity files
         - image_registration@git+https://github.com/keflavich/image_registration@master # Need GitHub version to avoid np.float issue
         - jwst==1.11.4
         - myst-parser # Needed for documentation

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -40,7 +40,7 @@ dependencies:
         - astraeus@git+https://github.com/kevin218/Astraeus@main
         - crds
         - exoplanet
-        - exotic-ld>=3.1.2 # Lower limit needed for updated JWST sensitivity files
+        - exotic-ld==3 # Lower limit needed for updated JWST sensitivity files, upper limit needed for breaking changes
         - image_registration@git+https://github.com/keflavich/image_registration@master # Need GitHub version to avoid np.float issue
         - jwst==1.11.4
         - myst-parser # Needed for documentation

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -40,7 +40,7 @@ dependencies:
         - astraeus@git+https://github.com/kevin218/Astraeus@main
         - crds
         - exoplanet
-        - exotic-ld
+        - exotic-ld>=3.1.2 # Lower limit needed for updated JWST sensitivity files
         - image_registration@git+https://github.com/keflavich/image_registration@master # Need GitHub version to avoid np.float issue
         - jwst==1.11.4
         - myst-parser # Needed for documentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     crds
     dynesty>1.0 # Lower limit needed for specific arguments
     emcee>3.0.0 # Lower limit needed for specific arguments
-    exotic-ld
+    exotic-ld>=3.1.2 # Lower limit needed for updated JWST sensitivity files
     george # Needed for GP
     h5py
     lmfit

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     crds
     dynesty>1.0 # Lower limit needed for specific arguments
     emcee>3.0.0 # Lower limit needed for specific arguments
-    exotic-ld>=3.1.2 # Lower limit needed for updated JWST sensitivity files
+    exotic-ld==3 # Lower limit needed for updated JWST sensitivity files, upper limit needed for breaking changes
     george # Needed for GP
     h5py
     lmfit

--- a/tests/MIRI_ecfs/S4_MIRI.ecf
+++ b/tests/MIRI_ecfs/S4_MIRI.ecf
@@ -34,7 +34,7 @@ inst_filter     LRS     # filter of JWST/HST instrument, supported list see http
 metallicity     0.1     # metallicity of the star 
 teff            6000    # effective temperature of the star in K
 logg            4.0     # surface gravity in log g
-exotic_ld_direc /home/User/exotic-ld_data/ # directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
+exotic_ld_direc /home/User/exotic-ld_data/ # directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 

--- a/tests/MIRI_ecfs/S4_MIRI.ecf
+++ b/tests/MIRI_ecfs/S4_MIRI.ecf
@@ -35,7 +35,7 @@ metallicity     0.1     # metallicity of the star
 teff            6000    # effective temperature of the star in K
 logg            4.0     # surface gravity in log g
 exotic_ld_direc /home/User/exotic-ld_data/ # directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
-exotic_ld_grid  3D      # 1D or 3D model grid
+exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 
 # Diagnostics

--- a/tests/NIRCam_ecfs/S4_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S4_NIRCam.ecf
@@ -33,7 +33,7 @@ inst_filter     F322W2  # filter of JWST/HST instrument, supported list see http
 metallicity     0.1     # metallicity of the star 
 teff            6000    # effective temperature of the star in K
 logg            4.0     # surface gravity in log g
-exotic_ld_direc /home/User/exotic-ld_data/ # directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
+exotic_ld_direc /home/User/exotic-ld_data/ # directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 

--- a/tests/NIRCam_ecfs/S4_NIRCam.ecf
+++ b/tests/NIRCam_ecfs/S4_NIRCam.ecf
@@ -34,7 +34,7 @@ metallicity     0.1     # metallicity of the star
 teff            6000    # effective temperature of the star in K
 logg            4.0     # surface gravity in log g
 exotic_ld_direc /home/User/exotic-ld_data/ # directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
-exotic_ld_grid  3D      # 1D or 3D model grid
+exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 
 # Diagnostics

--- a/tests/NIRSpec_ecfs/S4_NIRSpec.ecf
+++ b/tests/NIRSpec_ecfs/S4_NIRSpec.ecf
@@ -34,7 +34,7 @@ metallicity     0.1     # Metallicity of the star
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
 exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
-exotic_ld_grid  3D      # 1D or 3D model grid
+exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 
 # Diagnostics

--- a/tests/NIRSpec_ecfs/S4_NIRSpec.ecf
+++ b/tests/NIRSpec_ecfs/S4_NIRSpec.ecf
@@ -33,7 +33,7 @@ inst_filter     prism   # Filter of JWST/HST instrument, supported list see http
 metallicity     0.1     # Metallicity of the star 
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
-exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
+exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 

--- a/tests/Photometry_NIRCam_ecfs/S4_Photometry_NIRCam.ecf
+++ b/tests/Photometry_NIRCam_ecfs/S4_Photometry_NIRCam.ecf
@@ -37,7 +37,7 @@ metallicity     0.1     # Metallicity of the star
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
 exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
-exotic_ld_grid  3D      # 1D or 3D model grid
+exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  /home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 
 # Diagnostics

--- a/tests/Photometry_NIRCam_ecfs/S4_Photometry_NIRCam.ecf
+++ b/tests/Photometry_NIRCam_ecfs/S4_Photometry_NIRCam.ecf
@@ -36,7 +36,7 @@ inst_filter     prism   # Filter of JWST/HST instrument, supported list see http
 metallicity     0.1     # Metallicity of the star 
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
-exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
+exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  /home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 

--- a/tests/WFC3_ecfs/S4_WFC3.ecf
+++ b/tests/WFC3_ecfs/S4_WFC3.ecf
@@ -36,7 +36,7 @@ inst_filter     G102    # Filter of JWST/HST instrument, supported list see http
 metallicity     0.1     # Metallicity of the star
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
-exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
+exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 

--- a/tests/WFC3_ecfs/S4_WFC3.ecf
+++ b/tests/WFC3_ecfs/S4_WFC3.ecf
@@ -37,7 +37,7 @@ metallicity     0.1     # Metallicity of the star
 teff            6000    # Effective temperature of the star in K
 logg            4.0     # Surface gravity in log g
 exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/record/6344946
-exotic_ld_grid  3D      # 1D or 3D model grid
+exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids
 exotic_ld_file  #/home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 
 # Temporal Binning


### PR DESCRIPTION
This PR resolves #540

I've set a lower limit on the exotic-ld version to 3.1.2 which is their latest version (contains the updated post commissioning sensitivity files for JWST), and I've updated the documentation to make sure folks know how to download those reference files and know that the reference files change with different ExoTiC-LD reference files.