### PR TITLE
Ms no longer used in starry models; batman `w` parameter no long must be between (0,360); minor tweaks

### DIFF
--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1038,13 +1038,8 @@ This file describes the transit/eclipse and systematics parameters and their pri
 
          This parameter is recommended for batman_ecl fits as it allows for a conversion of a/R* to physical units in order to account for light travel time.
          If not provided for batman_ecl fits, the finite speed of light will not be accounted for.
-         Fits with the starry model **require** that ``Rs`` be provided as starry always accounts for light travel time. This parameter should be set to ``fixed``
+         Fits with the starry model **require** that ``Rs`` be provided as starry always uses physical units. This parameter should be set to ``fixed``
          unless you really want to marginalize over ``Rs``.
-      - ``Ms`` - the host star's mass in units of solar masses.
-
-         This parameter is **required** for fits with the starry model as starry currently requires the parameter to be provided. In practice, the stellar mass is not
-         actually used in Eureka! though as we allow for ``a`` and ``per`` to be provided directly. This parameter should be set to ``fixed``
-         unless you really want to marginalize over ``Ms``.
    - Sinusoidal Phase Curve Parameters
       The sinusoid_pc phase curve model for the standard numpy models allows for the inclusion of up to four sinusoids into a single phase curve. The theano-based differentiable functions allow for any number of sinusoids.
 

--- a/src/eureka/S3_data_reduction/source_pos.py
+++ b/src/eureka/S3_data_reduction/source_pos.py
@@ -410,7 +410,7 @@ def source_pos_gauss(flux, meta, m, n=0, plot=True):
     p0 = [np.ma.max(med_row), pos_max, sigma0, np.ma.median(med_row)]
 
     # Fit
-    popt, pcov = curve_fit(gauss, y_pixels, med_row, p0)
+    popt, pcov = curve_fit(gauss, y_pixels, med_row, p0, maxfev=10000)
 
     # Diagnostic plot
     if meta.isplots_S3 >= 1 and plot:

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -305,20 +305,6 @@ class CompositePyMC3Model(PyMC3Model):
 
         # Setup PyMC3 model parameters
         with self.model:
-
-            # Check that Ms, per, and a are compatible
-            a = (self.parameters.a.value*self.parameters.Rs.value
-                 * const.R_sun.value)
-            p = self.parameters.per.value*(24.*3600.)
-            Mp = (((2.*np.pi*a**(3./2.))/p)**2/const.G.value/const.M_sun.value
-                  - self.parameters.Ms.value)
-            if Mp <= 0:
-                raise AssertionError('The input Ms, per, and a values are '
-                                     'incompatible and imply a negative '
-                                     'planetary mass. As a result, the '
-                                     'starry model is going to crash. '
-                                     'You should likely reduce your Ms value.')
-
             for parname in self.paramtitles:
                 param = getattr(self.parameters, parname)
                 if param.ptype in ['independent', 'fixed']:

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -2,7 +2,6 @@ import os
 import copy
 import numpy as np
 import matplotlib.pyplot as plt
-import astropy.constants as const
 
 import theano
 theano.config.gcc__cxxflags += " -fexceptions"

--- a/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
@@ -153,8 +153,7 @@ class BatmanTransitModel(Model):
             # Enforce physicality to avoid crashes from batman by returning
             # something that should be a horrible fit
             if not ((0 < bm_params.per) and (0 < bm_params.inc < 90) and
-                    (1 < bm_params.a) and (0 <= bm_params.ecc < 1) and
-                    (0 <= bm_params.w <= 360)):
+                    (1 < bm_params.a) and (0 <= bm_params.ecc < 1)):
                 # Returning nans or infs breaks the fits, so this was the
                 # best I could think of
                 lcfinal = np.append(lcfinal, 1e12*np.ones_like(time))
@@ -297,8 +296,7 @@ class BatmanEclipseModel(Model):
             # Enforce physicality to avoid crashes from batman by
             # returning something that should be a horrible fit
             if not ((0 < bm_params.per) and (0 < bm_params.inc < 90) and
-                    (1 < bm_params.a) and (0 <= bm_params.ecc < 1) and
-                    (0 <= bm_params.w <= 360)):
+                    (1 < bm_params.a) and (0 <= bm_params.ecc < 1)):
                 # Returning nans or infs breaks the fits, so this was
                 # the best I could think of
                 lcfinal = np.append(lcfinal, 1e12*np.ones_like(time))


### PR DESCRIPTION
The requirement for Ms was always a nuisance since it could potentially crash the code if Ms was larger than allowed by Kepler's 3rd law. The only reason it was added was so that starry would be able to accept both a/Rs and Porb, but Everett Schlawin pointed out to me that we can just set Mp=0 and then solve for Ms which is way easier and removes that nuisance parameter.

Some folks allow negative omega values, and sometimes its useful to use a prior like Intial Guess +/- 180 so that your fits don't end up bi-modal if they're near 0 or 360.

Finally, sometimes curve_fit will fail to converge with the default maxfev value, so I just increased it by 10x which solved my problems. Might be worth changing this to scipy.optimize.minimize and using Powell instead since that's been working so well for us elsewhere.