### PR TITLE
Fixing new POET bugs, and old bugs with multwhite fits, masked values in fits, nbin_plot in S5, and S6 model loading

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
     - pandas
     - photutils
     - pip # required for the pip installs below
-    - pytest # Needed for testing
+    - pytest[version='<8.0'] # Upper limit needed to avoid some conflict between pytest, an asdf package, and something in the pymc3 set of installs. Needed for testing
     - pytest-cov # Needed for testing
     - pytest-doctestplus # Needed for testing
     - requests

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -29,7 +29,7 @@ dependencies:
     - pandas
     - photutils
     - pip # required for the pip installs below
-    - pytest # Needed for testing
+    - pytest[version='<8.0'] # Upper limit needed to avoid some conflict between pytest, an asdf package, and something in the pymc3 set of installs. Needed for testing
     - pytest-cov # Needed for testing
     - pytest-doctestplus # Needed for testing
     - requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ docs =
     sphinx-rtd-theme
 test =
     flake8
-    pytest
+    pytest<8.0 # Upper limit needed to avoid some conflict between pytest, an asdf package, and something in the pymc3 set of installs
     pytest-cov
     pytest-doctestplus
 pymc3 =

--- a/src/eureka/S5_lightcurve_fitting/lightcurve.py
+++ b/src/eureka/S5_lightcurve_fitting/lightcurve.py
@@ -146,12 +146,6 @@ class LightCurve(m.Model):
         - Dec 29, 2021 Taylor Bell
             Updated documentation and reduced repeated code
         """
-        # Empty default fit
-        fit_model = None
-
-        model.time = self.time
-        model.multwhite = meta.multwhite
-
         if fitter not in ['exoplanet', 'nuts']:
             # Make sure the model is a CompositeModel
             if not isinstance(model, m.CompositeModel):
@@ -194,9 +188,9 @@ class LightCurve(m.Model):
         """
         # Make the figure
         for i, channel in enumerate(self.fitted_channels):
-            flux = self.flux
+            flux = np.ma.copy(self.flux)
             unc = np.ma.copy(self.unc_fit)
-            time = self.time
+            time = np.ma.copy(self.time)
             
             if self.share and not meta.multwhite:
                 # Split the arrays that have lengths of the original time axis
@@ -210,11 +204,14 @@ class LightCurve(m.Model):
             if not hasattr(meta, 'nbin_plot') or meta.nbin_plot is None or \
                meta.nbin_plot > len(time):
                 nbin_plot = len(time)
+                binned_time = time
+                binned_flux = flux
+                binned_unc = unc
             else:
                 nbin_plot = meta.nbin_plot
-            binned_time = util.binData_time(time, time, nbin_plot)
-            binned_flux = util.binData_time(flux, time, nbin_plot)
-            binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
+                binned_time = util.binData_time(time, time, nbin_plot)
+                binned_flux = util.binData_time(flux, time, nbin_plot)
+                binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
 
             fig = plt.figure(5103, figsize=(8, 6))
             fig.clf()

--- a/src/eureka/S5_lightcurve_fitting/likelihood.py
+++ b/src/eureka/S5_lightcurve_fitting/likelihood.py
@@ -337,7 +337,7 @@ def computeRedChiSq(lc, log, model, meta, freenames):
     model_lc = model.eval(incl_GP=True)
     residuals = (lc.flux - model_lc)
     chi2 = np.ma.sum((residuals / lc.unc_fit) ** 2)
-    chi2red = chi2 / (len(lc.flux) - len(freenames))
+    chi2red = chi2 / (np.sum(~lc.flux.mask) - len(freenames))
 
     log.writelog(f'Reduced Chi-squared: {chi2red}', mute=(not meta.verbose))
 
@@ -384,8 +384,8 @@ def computeRMS(data, maxnbins=None, binstep=1, isrmserr=False):
         maxnbins = npts / 10.
     binsz = np.arange(1, maxnbins + binstep, step=binstep, dtype=int)
     nbins = np.zeros(binsz.size, dtype=int)
-    rms = np.zeros(binsz.size)
-    rmserr = np.zeros(binsz.size)
+    rms = np.ma.zeros(binsz.size)
+    rmserr = np.ma.zeros(binsz.size)
     for i in range(binsz.size):
         nbins[i] = int(np.floor(data.size / binsz[i]))
         bindata = np.ma.zeros(nbins[i], dtype=float)
@@ -394,7 +394,7 @@ def computeRMS(data, maxnbins=None, binstep=1, isrmserr=False):
         for j in range(nbins[i]):
             bindata[j] = np.ma.mean(data[j * binsz[i]:(j + 1) * binsz[i]])
         # get rms
-        rms[i] = np.sqrt(np.ma.mean(bindata ** 2))
+        rms[i] = np.ma.sqrt(np.ma.mean(bindata ** 2))
         rmserr[i] = rms[i] / np.sqrt(2. * nbins[i])
     # expected for white noise (WINN 2008, PONT 2006)
     stderr = (np.ma.std(data) / np.sqrt(binsz)) * np.sqrt(nbins / (nbins - 1.))

--- a/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
@@ -223,7 +223,7 @@ class BatmanTransitModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            light_curve = np.ma.ones_like(time)
+            light_curve = np.ma.ones(time.shape)
             for pid in pid_iter:
                 # Initialize planet
                 pl_params = PlanetParams(self, pid, chan)
@@ -244,7 +244,7 @@ class BatmanTransitModel(Model):
                         (1 < pl_params.a) and (0 <= pl_params.ecc < 1)):
                     # Returning nans or infs breaks the fits, so this was the
                     # best I could think of
-                    light_curve = 1e12*np.ma.ones_like(time)
+                    light_curve = 1e12*np.ma.ones(time.shape)
                     continue
 
                 # Use batman ld_profile name
@@ -256,7 +256,7 @@ class BatmanTransitModel(Model):
                     if pl_params.u[0] <= 0:
                         # Returning nans or infs breaks the fits, so this was
                         # the best I could think of
-                        light_curve = 1e12*np.ma.ones_like(time)
+                        light_curve = 1e12*np.ma.ones(time.shape)
                         continue
                     pl_params.limb_dark = 'quadratic'
                     u1 = 2*np.sqrt(pl_params.u[0])*pl_params.u[1]
@@ -384,7 +384,7 @@ class BatmanEclipseModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            light_curve = np.ma.ones_like(time)
+            light_curve = np.ma.ones(time.shape)
             for pid in pid_iter:
                 # Initialize planet
                 pl_params = PlanetParams(self, pid, chan)
@@ -398,7 +398,7 @@ class BatmanEclipseModel(Model):
                         (1 < pl_params.a) and (0 <= pl_params.ecc < 1)):
                     # Returning nans or infs breaks the fits, so this was
                     # the best I could think of
-                    light_curve = 1e12*np.ma.ones_like(time)
+                    light_curve = 1e12*np.ma.ones(time.shape)
                     continue
 
                 # Compute light travel time

--- a/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
@@ -16,7 +16,7 @@ class PlanetParams():
     """
     Define planet parameters.
     """
-    def __init__(self, model, pid=0):
+    def __init__(self, model, pid=0, channel=0):
         """ 
         Set attributes to PlanetParams object.
 
@@ -27,9 +27,22 @@ class PlanetParams():
             and their current values.
         pid : int; optional
             Planet ID, default is 0.
+        channel : int, optional
+            The channel number for multi-wavelength fits or mutli-white fits.
+            Defaults to 0.
         """
         # Planet ID
-        self.pid = pid       
+        self.pid = pid
+        if pid == 0:
+            self.pid_id = ''
+        else:
+            self.pid_id = str(self.pid)
+        # Channel ID
+        self.channel = channel
+        if channel == 0:
+            self.channel_id = ''
+        else:
+            self.channel_id = f'_{self.channel}'
         # Set transit/eclipse parameters
         self.t0 = None
         self.rprs = None
@@ -40,8 +53,8 @@ class PlanetParams():
         self.per = None
         self.ecc = 0.
         self.w = None
-        self.fpfs = 0.
-        self.fp = 0.
+        self.fpfs = None
+        self.fp = None
         self.t_secondary = None
         self.cos1_amp = 0.
         self.cos1_off = 0.
@@ -52,56 +65,56 @@ class PlanetParams():
         self.AmpCos2 = 0.
         self.AmpSin2 = 0.
         for item in self.__dict__.keys():
-            if pid > 0:
-                item0 = item + str(pid)
-            else:
-                item0 = item
+            item0 = item+self.pid_id
             try:
+                if model.parameters.dict[item0][1] == 'free':
+                    item0 += self.channel_id
                 setattr(self, item, model.parameters.dict[item0][0])
             except KeyError:
                 pass
         # Allow for rp or rprs
         if (self.rprs is None) and ('rp' in model.parameters.dict.keys()):
-            if pid > 0:
-                item0 = 'rp' + str(pid)
-            else:
-                item0 = 'rp'
+            item0 = 'rp' + self.pid_id
+            if model.parameters.dict[item0][1] == 'free':
+                item0 += self.channel_id
             setattr(self, 'rprs', model.parameters.dict[item0][0])
         if (self.rp is None) and ('rprs' in model.parameters.dict.keys()):
-            if pid > 0:
-                item0 = 'rprs' + str(pid)
-            else:
-                item0 = 'rprs'
+            item0 = 'rprs' + self.pid_id
+            if model.parameters.dict[item0][1] == 'free':
+                item0 += self.channel_id
             setattr(self, 'rp', model.parameters.dict[item0][0])
         # Allow for a or ars
         if (self.ars is None) and ('a' in model.parameters.dict.keys()):
-            if pid > 0:
-                item0 = 'a' + str(pid)
-            else:
-                item0 = 'a'
+            item0 = 'a' + self.pid_id
+            if model.parameters.dict[item0][1] == 'free':
+                item0 += self.channel_id
             setattr(self, 'ars', model.parameters.dict[item0][0])
         if (self.a is None) and ('ars' in model.parameters.dict.keys()):
-            if pid > 0:
-                item0 = 'ars' + str(pid)
-            else:
-                item0 = 'ars'
+            item0 = 'ars' + self.pid_id
+            if model.parameters.dict[item0][1] == 'free':
+                item0 += self.channel_id
             setattr(self, 'a', model.parameters.dict[item0][0])
         # Allow for fp or fpfs
         if (self.fpfs is None) and ('fp' in model.parameters.dict.keys()):
-            if pid > 0:
-                item0 = 'fp' + str(pid)
-            else:
-                item0 = 'fp'
+            item0 = 'fp' + self.pid_id
+            if model.parameters.dict[item0][1] == 'free':
+                item0 += self.channel_id
             setattr(self, 'fpfs', model.parameters.dict[item0][0])
+        elif self.fpfs is None:
+            setattr(self, 'fpfs', 0.)
         if (self.fp is None) and ('fpfs' in model.parameters.dict.keys()):
-            if pid > 0:
-                item0 = 'fpfs' + str(pid)
-            else:
-                item0 = 'fpfs'
+            item0 = 'fpfs' + self.pid_id
+            if model.parameters.dict[item0][1] == 'free':
+                item0 += self.channel_id
             setattr(self, 'fp', model.parameters.dict[item0][0])
+        elif self.fp is None:
+            setattr(self, 'fp', 0.)
         # Set stellar radius
         if 'Rs' in model.parameters.dict.keys():
-            setattr(self, 'Rs', model.parameters.dict['Rs'][0])
+            item0 = 'Rs'
+            if model.parameters.dict[item0][1] == 'free':
+                item0 += self.channel_id
+            setattr(self, 'Rs', model.parameters.dict[item0][0])
 
 
 class BatmanTransitModel(Model):
@@ -210,10 +223,10 @@ class BatmanTransitModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            light_curve = np.ones_like(time)
+            light_curve = np.ma.ones_like(time)
             for pid in pid_iter:
                 # Initialize planet
-                pl_params = PlanetParams(self, pid)
+                pl_params = PlanetParams(self, pid, chan)
 
                 # Set limb darkening parameters
                 uarray = []
@@ -231,7 +244,7 @@ class BatmanTransitModel(Model):
                         (1 < pl_params.a) and (0 <= pl_params.ecc < 1)):
                     # Returning nans or infs breaks the fits, so this was the
                     # best I could think of
-                    light_curve = 1e12*np.ones_like(time)
+                    light_curve = 1e12*np.ma.ones_like(time)
                     continue
 
                 # Use batman ld_profile name
@@ -243,7 +256,7 @@ class BatmanTransitModel(Model):
                     if pl_params.u[0] <= 0:
                         # Returning nans or infs breaks the fits, so this was
                         # the best I could think of
-                        light_curve = 1e12*np.ones_like(time)
+                        light_curve = 1e12*np.ma.ones_like(time)
                         continue
                     pl_params.limb_dark = 'quadratic'
                     u1 = 2*np.sqrt(pl_params.u[0])*pl_params.u[1]
@@ -255,7 +268,7 @@ class BatmanTransitModel(Model):
                                                transittype='primary')
                 light_curve *= m_transit.light_curve(pl_params)
 
-            lcfinal = np.append(lcfinal, light_curve)
+            lcfinal = np.ma.append(lcfinal, light_curve)
 
         return lcfinal
 
@@ -359,7 +372,7 @@ class BatmanEclipseModel(Model):
             self.time = kwargs.get('time')
 
         # Set all parameters
-        lcfinal = np.array([])
+        lcfinal = np.ma.array([])
         for c in range(nchan):
             if self.nchannel_fitted > 1:
                 chan = channels[c]
@@ -371,10 +384,10 @@ class BatmanEclipseModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            light_curve = np.ones_like(time)
+            light_curve = np.ma.ones_like(time)
             for pid in pid_iter:
                 # Initialize planet
-                pl_params = PlanetParams(self, pid)
+                pl_params = PlanetParams(self, pid, chan)
 
                 # Set limb darkening parameters
                 pl_params.u = []
@@ -385,7 +398,7 @@ class BatmanEclipseModel(Model):
                         (1 < pl_params.a) and (0 <= pl_params.ecc < 1)):
                     # Returning nans or infs breaks the fits, so this was
                     # the best I could think of
-                    light_curve = 1e12*np.ones_like(time)
+                    light_curve = 1e12*np.ma.ones_like(time)
                     continue
 
                 # Compute light travel time
@@ -408,7 +421,7 @@ class BatmanEclipseModel(Model):
                                                transittype='secondary')
                 light_curve += m_eclipse.light_curve(pl_params)-1
 
-            lcfinal = np.append(lcfinal, light_curve)
+            lcfinal = np.ma.append(lcfinal, light_curve)
 
         return lcfinal
 

--- a/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
@@ -408,8 +408,7 @@ class BatmanEclipseModel(Model):
                 else:
                     self.adjusted_time = time
 
-                if not np.any(['t_secondary' in key
-                              for key in self.longparamlist[chan]]):
+                if pl_params.t_secondary is None:
                     # If not explicitly fitting for the time of eclipse, get
                     # the time of eclipse from the time of transit, period,
                     # eccentricity, and argument of periastron

--- a/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
@@ -52,15 +52,15 @@ class CentroidModel(Model):
         if self.centroid is not None:
             # Convert to local centroid
             if self.multwhite:
-                self.centroid_local = []
+                self.centroid_local = np.ma.zeros(0)
                 for chan in self.fitted_channels:
                     # Split the arrays that have lengths
                     # of the original time axis
                     centroid = split([self.centroid, ], self.nints, chan)[0]
-                    self.centroid_local.extend(centroid - centroid.mean())
-                self.centroid_local = np.array(self.centroid_local)
+                    self.centroid_local = np.ma.append(
+                        self.centroid_local, centroid-np.ma.mean(centroid))
             else:
-                self.centroid_local = self.centroid - self.centroid.mean()
+                self.centroid_local = self.centroid - np.ma.mean(self.centroid)
 
     def eval(self, channel=None, **kwargs):
         """Evaluate the function with the given values.
@@ -89,7 +89,7 @@ class CentroidModel(Model):
             self.centroid = kwargs.get('centroid')
 
         # Create the centroid model for each wavelength
-        lcfinal = np.array([])
+        lcfinal = np.ma.array([])
         for c in range(nchan):
             if self.nchannel_fitted > 1:
                 chan = channels[c]
@@ -103,5 +103,5 @@ class CentroidModel(Model):
 
             coeff = getattr(self.parameters, self.coeff_keys[chan]).value
             lcpiece = 1 + centroid*coeff
-            lcfinal = np.append(lcfinal, lcpiece)
+            lcfinal = np.ma.append(lcfinal, lcpiece)
         return lcfinal

--- a/src/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -60,7 +60,7 @@ class GPModel(Model):
         self.useHODLR = useHODLR
         self.nkernels = len(kernel_classes)
         self.flux = lc.flux
-        self.fit = np.ones_like(self.flux)
+        self.fit = np.ma.ones_like(self.flux)
         self.unc = lc.unc
         self.unc_fit = lc.unc_fit
         self.time = lc.time
@@ -143,7 +143,7 @@ class GPModel(Model):
             self.time = kwargs.get('time')
         self.fit = fit
 
-        lcfinal = np.array([])
+        lcfinal = np.ma.array([])
         for c in range(nchan):
             if self.nchannel_fitted > 1:
                 chan = channels[c]
@@ -154,7 +154,7 @@ class GPModel(Model):
                     fit = split([self.fit, ], self.nints, chan)[0]
                 else:
                     # If only a specific channel is being evaluated, then only
-                    # that channel's fitted mode will be passed in
+                    # that channel's fitted model will be passed in
                     fit = self.fit
             else:
                 chan = 0
@@ -164,14 +164,9 @@ class GPModel(Model):
                 unc_fit = self.unc_fit
             residuals = flux-fit
 
-            time = self.time
-            if self.multwhite:
-                # Split the arrays that have lengths of the original time axis
-                time = split([time, ], self.nints, chan)[0]
-
             # Create the GP object with current parameters
             if gp is None:
-                gp = self.setup_GP(c)
+                gp = self.setup_GP(chan)
 
             if self.gp_code_name == 'george':
                 gp.compute(self.kernel_inputs[chan].T, unc_fit)
@@ -183,7 +178,9 @@ class GPModel(Model):
             elif self.gp_code_name == 'tinygp':
                 cond_gp = gp.condition(residuals, noise=unc_fit).gp
                 mu = cond_gp.loc
-            lcfinal = np.append(lcfinal, mu)
+            # Mask interpolated/extrapolated values
+            mu = np.ma.masked_where(np.ma.getmaskarray(residuals), mu)
+            lcfinal = np.ma.append(lcfinal, mu)
 
         return lcfinal
 
@@ -200,10 +197,15 @@ class GPModel(Model):
             else:
                 chan = 0
 
-            kernel_inputs_channel = []
+            if self.multwhite:
+                time = split([self.time, ], self.nints, chan)[0]
+            else:
+                time = self.time
+
+            kernel_inputs_channel = np.ma.zeros((0,time.size))
             for name in self.kernel_input_names:
                 if name == 'time':
-                    x = np.copy(self.time)        
+                    x = np.ma.copy(self.time)
                 else:
                     # add more input options here
                     raise ValueError('Currently, only GPs as a function of '
@@ -215,14 +217,10 @@ class GPModel(Model):
                     x = split([x, ], self.nints, chan)[0]
 
                 if self.normalize:
-                    x = (x-x.mean())/x.std()
+                    x = (x-np.ma.mean(x))/np.ma.std(x)
 
-                kernel_inputs_channel.append(x)
-            kernel_inputs_channel = np.array(kernel_inputs_channel)
-
-            # Need to reshape if there is only one covariate
-            if len(kernel_inputs_channel.shape) == 1:
-                kernel_inputs_channel = kernel_inputs_channel[np.newaxis]
+                kernel_inputs_channel = np.ma.append(kernel_inputs_channel,
+                                                     x[np.newaxis], axis=0)
 
             self.kernel_inputs.append(kernel_inputs_channel)
 
@@ -366,13 +364,19 @@ class GPModel(Model):
         # update uncertainty
         self.fit = fit
 
-        logL = []
+        logL = 0
         for c in np.arange(nchan):
             if self.nchannel_fitted > 1:
                 chan = channels[c]
                 # get flux and uncertainties for current channel
-                flux, fit, unc_fit = split([self.flux, self.fit, self.unc_fit],
-                                           self.nints, chan)
+                flux, unc_fit = split([self.flux, self.unc_fit],
+                                      self.nints, chan)
+                if channel is None:
+                    fit = split([self.fit, ], self.nints, chan)[0]
+                else:
+                    # If only a specific channel is being evaluated, then only
+                    # that channel's fitted model will be passed in
+                    fit = self.fit
             else:
                 chan = 0
                 # get flux and uncertainties for current channel
@@ -381,18 +385,23 @@ class GPModel(Model):
                 unc_fit = self.unc_fit
             residuals = flux-fit
 
+            # Remove poorly handled masked values
+            unc_fit = unc_fit[~np.ma.getmaskarray(residuals)]
+
             # set up GP with current parameters
-            gp = self.setup_GP(c)
+            gp = self.setup_GP(chan)
 
             if self.gp_code_name == 'george':
-                gp.compute(self.kernel_inputs[chan].T, unc_fit)
-                logL_temp = gp.lnlikelihood(residuals, quiet=True)
+                gp.compute(kernel_inputs, unc_fit)
+                logL_temp = gp.lnlikelihood(self.kernel_inputs[chan].T, quiet=True)
             elif self.gp_code_name == 'celerite':
-                gp.compute(self.kernel_inputs[chan][0], yerr=unc_fit)
+                kernel_inputs = self.kernel_inputs[chan][0][~np.ma.getmaskarray(residuals)]
+                residuals = residuals[~np.ma.getmaskarray(residuals)]
+                gp.compute(kernel_inputs, yerr=unc_fit)
                 logL_temp = gp.log_likelihood(residuals)
             elif self.gp_code_name == 'tinygp':
                 cond = gp.condition(residuals, diag=unc_fit)
                 logL_temp = cond.log_probability
-            logL.append(logL_temp)
+            logL += logL_temp
 
-        return sum(logL)
+        return logL

--- a/src/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -60,7 +60,7 @@ class GPModel(Model):
         self.useHODLR = useHODLR
         self.nkernels = len(kernel_classes)
         self.flux = lc.flux
-        self.fit = np.ma.ones_like(self.flux)
+        self.fit = np.ma.ones(self.flux.shape)
         self.unc = lc.unc
         self.unc_fit = lc.unc_fit
         self.time = lc.time

--- a/src/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -399,7 +399,7 @@ class GPModel(Model):
             gp = self.setup_GP(chan)
 
             if self.gp_code_name == 'george':
-                gp.compute(self.kernel_inputs[chan][:,good].T, unc_fit)
+                gp.compute(self.kernel_inputs[chan][:, good].T, unc_fit)
                 logL_temp = gp.lnlikelihood(residuals, quiet=True)
             elif self.gp_code_name == 'celerite':
                 kernel_inputs = self.kernel_inputs[chan][0][good]

--- a/src/eureka/S5_lightcurve_fitting/models/LorentzianModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/LorentzianModel.py
@@ -107,7 +107,7 @@ class LorentzianModel(Model):
                 ut[rhs] = (time[rhs]-t0)/params.lor_hwhm_rhs
                 lorentzian[lhs] = 1 + params.lor_amp_lhs/(1 + ut[lhs]**p)
                 baseline = 1 + params.lor_amp_lhs - params.lor_amp_rhs
-                lorentzian[rhs] = baseline + params.lor_amp_rhs/(1 + ut[rhs]**p)
+                lorentzian[rhs] = baseline+params.lor_amp_rhs/(1+ut[rhs]**p)
             elif (params.lor_hwhm is None) and \
                     (params.lor_amp_lhs is None) and \
                     (params.lor_amp_rhs is None):
@@ -128,8 +128,8 @@ class LorentzianModel(Model):
                 lorentzian = 1 + params.lor_amp/(1 + ut**p)
             else:
                 # Unresolvable situation
-                raise Exception("Cannot determine the type of Lorentzian model "
-                                "to fit.  Use one of the following options: "
+                raise Exception("Cannot determine the type of Lorentzian model"
+                                " to fit.  Use one of the following options: "
                                 "1. lor_amp, lor_hwhm; "
                                 "2. lor_amp, lor_hwhm_lhs, lor_hwhm_rhs; "
                                 "3. lor_amp_lhs, lor_amp_rhs, lor_hwhm_lhs, "

--- a/src/eureka/S5_lightcurve_fitting/models/PoetModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/PoetModels.py
@@ -409,7 +409,7 @@ def trnlldsp(z, rprs, u):
                 - u3 * (1. - 4. / 7. * np.sqrt(np.sqrt(x * x * x))) \
                 - u4 * (1. - 4. / 8. * x)
     y[iingress] = 1. - I1star \
-        * (rprs ** 2 * np.arccos((z[iingress] - 1.) / rprs) - (z[iingress] - 1.)
+        * (rprs**2 * np.arccos((z[iingress] - 1.) / rprs) - (z[iingress] - 1.)
            * np.sqrt(rprs ** 2 - (z[iingress] - 1.) ** 2)) / np.pi / Sigma4
 
     # Full transit (except @ z=0)

--- a/src/eureka/S5_lightcurve_fitting/models/PoetModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/PoetModels.py
@@ -167,7 +167,7 @@ class PoetPCModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            light_curve = np.ma.zeros_like(time)
+            light_curve = np.ma.zeros(time.shape)
             for pid in range(self.num_planets):
                 # Initialize planet
                 poet_params = PlanetParams(self, pid, chan)
@@ -195,7 +195,7 @@ class PoetPCModel(Model):
                 if self.force_positivity and np.ma.any(phaseVars < 0):
                     # Returning nans or infs breaks the fits, so this was
                     # the best I could think of
-                    phaseVars = 1e12*np.ma.ones_like(time)
+                    phaseVars = 1e12*np.ma.ones(time.shape)
 
                 # Compute eclipse model
                 if self.eclipse_model is None:

--- a/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
@@ -134,7 +134,7 @@ class SinusoidPhaseCurveModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            light_curve = np.ma.zeros_like(time)
+            light_curve = np.ma.zeros(time.shape)
             for pid in range(self.num_planets):
                 # Initialize model
                 bm_params = PlanetParams(self, pid, chan)
@@ -185,7 +185,7 @@ class SinusoidPhaseCurveModel(Model):
                 if self.force_positivity and np.ma.any(phaseVars < 0):
                     # Returning nans or infs breaks the fits, so this was
                     # the best I could think of
-                    phaseVars = 1e12*np.ma.ones_like(time)
+                    phaseVars = 1e12*np.ma.ones(time.shape)
                 
                 if self.eclipse_model is None:
                     eclipse = 1

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -553,7 +553,7 @@ def plot_chain(samples, lc, meta, freenames, fitter='emcee', burnin=False,
                 if add_legend:
                     axes[i][j].legend(loc=6, bbox_to_anchor=(1.01, 0.5))
                 k += 1
-        fig.tight_layout(h_pad=0.0)
+        fig.get_layout_engine().set(h_pad=0)
 
         if lc.white:
             fname_tag = 'white'

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -294,7 +294,6 @@ def plot_phase_variations(lc, model, meta, fitter, isTitle=True):
                     zorder=10)
 
             # Set nice axis limits
-            sigma = np.ma.std(flux-model_phys)
             max_astro = np.ma.max(model_phys)
             ax.set_ylim(-3*sigma, max_astro+3*sigma)
             ax.set_xlim(np.ma.min(time), np.ma.max(time))

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -104,7 +104,8 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
             binned_time = util.binData_time(time, time, nbin_plot)
             binned_flux = util.binData_time(flux, time, nbin_plot)
             binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
-            binned_normflux = util.binData_time(flux/model_sys - gp, time, nbin_plot)
+            binned_normflux = util.binData_time(flux/model_sys - gp, time,
+                                                nbin_plot)
             binned_res = util.binData_time(residuals, time, nbin_plot)
 
         fig = plt.figure(5101, figsize=(8, 6))

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -94,14 +94,18 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
         # Get binned data and times
         if not hasattr(meta, 'nbin_plot') or meta.nbin_plot is None or \
            meta.nbin_plot > len(time):
-            nbin_plot = len(time)
+            binned_time = time
+            binned_flux = flux
+            binned_unc = unc
+            binned_normflux = flux/model_sys - gp
+            binned_res = residuals
         else:
             nbin_plot = meta.nbin_plot
-        binned_time = util.binData_time(time, time, nbin_plot)
-        binned_flux = util.binData_time(flux, time, nbin_plot)
-        binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
-        binned_normflux = util.binData_time(flux/model_sys-gp, time, nbin_plot)
-        binned_res = util.binData_time(residuals, time, nbin_plot)
+            binned_time = util.binData_time(time, time, nbin_plot)
+            binned_flux = util.binData_time(flux, time, nbin_plot)
+            binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
+            binned_normflux = util.binData_time(flux/model_sys - gp, time, nbin_plot)
+            binned_res = util.binData_time(residuals, time, nbin_plot)
 
         fig = plt.figure(5101, figsize=(8, 6))
         plt.clf()
@@ -124,7 +128,7 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
 
         ax[2].errorbar(binned_time, binned_res*1e6, yerr=binned_unc*1e6,
                        fmt='.', color='w', ecolor=color, mec=color)
-        ax[2].plot(time, np.zeros_like(time), color='0.3', zorder=10)
+        ax[2].axhline(0, color='0.3', zorder=10)
         ax[2].set_ylabel('Residuals (ppm)', size=14)
         ax[2].set_xlabel(str(lc.time_units), size=14)
 
@@ -220,15 +224,16 @@ def plot_phase_variations(lc, model, meta, fitter, isTitle=True):
             new_timet = new_time
 
         # Get binned data and times
-        if not hasattr(meta, 'nbin_plot') or meta.nbin_plot is None:
-            nbin_plot = 100
-        elif meta.nbin_plot > len(time):
-            nbin_plot = len(time)
+        if not hasattr(meta, 'nbin_plot') or not meta.nbin_plot or \
+           meta.nbin_plot > len(time):
+            binned_time = time
+            binned_flux = flux
+            binned_unc = unc
         else:
             nbin_plot = meta.nbin_plot
-        binned_time = util.binData_time(time, time, nbin_plot)
-        binned_flux = util.binData_time(flux, time, nbin_plot)
-        binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
+            binned_time = util.binData_time(time, time, nbin_plot)
+            binned_flux = util.binData_time(flux, time, nbin_plot)
+            binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
 
         # Setup the figure
         fig = plt.figure(5104, figsize=(8, 6))
@@ -252,7 +257,7 @@ def plot_phase_variations(lc, model, meta, fitter, isTitle=True):
         sigma = np.ma.mean(binned_unc)
         max_astro = np.ma.max((model_phys-1))
         ax.set_ylim(-6*sigma, max_astro+6*sigma)
-        ax.set_xlim(np.min(time), np.max(time))
+        ax.set_xlim(np.ma.min(time), np.ma.max(time))
 
         # Save/show the figure
         if lc.white:
@@ -291,7 +296,7 @@ def plot_phase_variations(lc, model, meta, fitter, isTitle=True):
             sigma = np.ma.std(flux-model_phys)
             max_astro = np.ma.max(model_phys)
             ax.set_ylim(-3*sigma, max_astro+3*sigma)
-            ax.set_xlim(np.min(time), np.max(time))
+            ax.set_xlim(np.ma.min(time), np.ma.max(time))
             # Save/show the figure
             if lc.white:
                 fname_tag = 'white'
@@ -350,11 +355,11 @@ def plot_rms(lc, model, meta, fitter):
         else:
             time = lc.time
 
-        residuals = flux - model_lc
-        residuals = residuals[np.argsort(time)]
+        residuals = np.ma.masked_invalid(flux-model_lc)
+        residuals = residuals[np.ma.argsort(time)]
 
-        # Remove NaNs
-        residuals = residuals[~np.isnan(residuals)]
+        # Remove masked values
+        residuals = residuals[~np.ma.getmaskarray(residuals)]
         # Compute RMS range
         maxbins = residuals.size//10
         if maxbins < 2:
@@ -382,15 +387,13 @@ def plot_rms(lc, model, meta, fitter):
                 label='Gaussian Std. Err.', zorder=1)
 
         # Format the main axes
-        ax.set_xlim(0.95, binsz[-1] * 2)
-        ax.set_ylim(stderr[-1] / normfactor / 2., stderr[0] / normfactor * 2.)
         ax.set_xlabel("Bin Size (N frames)", fontsize=14)
         ax.set_ylabel("RMS (ppm)", fontsize=14)
         ax.tick_params(axis='both', labelsize=12)
         ax.legend(loc=1)
 
         # Add second x-axis using time instead of N-binned
-        dt = (time[1]-time[0])*24*3600
+        dt = np.ma.min(np.ma.diff(time))*24*3600
 
         def t_N(N):
             return N*dt
@@ -664,7 +667,7 @@ def plot_res_distr(lc, model, meta, fitter):
         plt.clf()
 
         flux = np.ma.copy(lc.flux)
-        unc = np.ma.copy(np.array(lc.unc_fit))
+        unc = np.ma.copy(lc.unc_fit)
         model_lc = np.ma.copy(model_eval)
 
         if lc.share or meta.multwhite:
@@ -674,7 +677,8 @@ def plot_res_distr(lc, model, meta, fitter):
 
         residuals = flux - model_lc
         hist_vals = residuals/unc
-        hist_vals[~np.isfinite(hist_vals)] = np.nan  # Mask out any infinities
+        # Mask out any infinities or nans
+        hist_vals = np.ma.masked_invalid(hist_vals)
 
         n, bins, patches = plt.hist(hist_vals, alpha=0.5, color='b',
                                     edgecolor='b', lw=1)
@@ -768,7 +772,7 @@ def plot_GP_components(lc, model, meta, fitter, isTitle=True):
 
         ax[2].errorbar(time, residuals*1e6, yerr=unc*1e6, fmt='.',
                        color='w', ecolor=color, mec=color)
-        ax[2].plot(time, np.zeros_like(time), color='0.3', zorder=10)
+        ax[2].axhline(0, color='0.3', zorder=10)
         ax[2].set_ylabel('Residuals (ppm)', size=14)
         ax[2].set_xlabel(str(lc.time_units), size=14)
 

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -232,7 +232,6 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
                 time_units = lc.data.attrs['time_units']+f' - {offset}'
             else:
                 time_units = lc.data.attrs['time_units']
-            meta.time = lc.time.values
             # Record units for Stage 6
             meta.time_units = time_units
             meta.wave_units = lc.data.attrs['wave_units']
@@ -247,7 +246,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
                             getattr(lc, centroid_param).values))
                 else:
                     centroid_param_list.append(
-                        np.zeros_like(lc.time.values))
+                        np.ma.zeros_like(lc.time.values))
             xpos, xwidth, ypos, ywidth = centroid_param_list
 
             # make citations for current stage
@@ -373,13 +372,14 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
 
                 for pi in range(len(meta.inputdirlist)+1):
                     mask = lc_whites[pi].mask.values[0, :]
+                    time_temp = lc_whites[pi].time.values - offset
+                    time_temp = np.ma.masked_where(mask, time_temp)
                     flux_temp = np.ma.masked_where(
                         mask, lc_whites[pi].data.values[0, :])
                     err_temp = np.ma.masked_where(
                         mask, lc_whites[pi].err.values[0, :])
                     flux_temp, err_temp = util.normalize_spectrum(
-                        meta, flux_temp, err_temp)
-                    time_temp = lc_whites[pi].time.values - offset
+                        meta, flux_temp, err_temp, mask)
                     flux = np.ma.append(flux, flux_temp)
                     flux_err = np.ma.append(flux_err, err_temp)
                     time = np.ma.append(time, time_temp)
@@ -387,18 +387,26 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
                     if hasattr(lc_whites[pi], 'centroid_x'):
                         xpos_temp = np.ma.masked_invalid(
                             lc_whites[pi].centroid_x.values)
-                        xwidth_temp = np.ma.masked_invalid(
-                            lc_whites[pi].centroid_sx.values)
+                        xpos_temp = np.ma.masked_where(mask, xpos_temp)
                     else:
                         xpos_temp = None
+                    if hasattr(lc_whites[pi], 'centroid_x'):
+                        xwidth_temp = np.ma.masked_invalid(
+                            lc_whites[pi].centroid_sx.values)
+                        xwidth_temp = np.ma.masked_where(mask, xwidth_temp)
+                    else:
                         xwidth_temp = None
                     if hasattr(lc_whites[pi], 'centroid_y'):
                         ypos_temp = np.ma.masked_invalid(
                             lc_whites[pi].centroid_y.values)
-                        ywidth_temp = np.ma.masked_invalid(
-                            lc_whites[pi].centroid_sy.values)
+                        ypos_temp = np.ma.masked_where(mask, ypos_temp)
                     else:
                         ypos_temp = None
+                    if hasattr(lc_whites[pi], 'centroid_y'):
+                        ywidth_temp = np.ma.masked_invalid(
+                            lc_whites[pi].centroid_sy.values)
+                        ywidth_temp = np.ma.masked_where(mask, ywidth_temp)
+                    else:
                         ywidth_temp = None
 
                     xpos = np.ma.append(xpos, xpos_temp)
@@ -462,13 +470,14 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
                                               lc.data.values[channel, :])
                     flux_err = np.ma.masked_where(mask,
                                                   lc.err.values[channel, :])
+                    time_temp = np.ma.masked_where(mask, time)
 
                     # Normalize flux and uncertainties to avoid large
                     # flux values
                     flux, flux_err = util.normalize_spectrum(meta, flux,
                                                              flux_err)
 
-                    meta, params = fit_channel(meta, time, flux, channel,
+                    meta, params = fit_channel(meta, time_temp, flux, channel,
                                                flux_err, eventlabel, params,
                                                log, longparamlist, time_units,
                                                paramtitles, chanrng, ld_coeffs,
@@ -1074,8 +1083,15 @@ def make_longparamlist(meta, params, chanrng):
             longparamlist[0].append(param)
             for c in np.arange(nspecchan-1):
                 title = param+'_'+str(c+1)
-                params.__setattr__(title, params.dict[param])
-                longparamlist[c+1].append(title)
+                if title in tlist:
+                    # The user specifically set this channel's parameter
+                    longparamlist[c+1].append(title)
+                    # Remove this parameter from tlist so we don't set it twice
+                    tlist.remove(title)
+                else:
+                    # Set this parameter based on channel 0's parameter
+                    params.__setattr__(title, params.dict[param])
+                    longparamlist[c+1].append(title)
         elif 'shared' in params.dict[param]:
             for c in np.arange(nspecchan):
                 longparamlist[c].append(param)

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -246,7 +246,7 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
                             getattr(lc, centroid_param).values))
                 else:
                     centroid_param_list.append(
-                        np.ma.zeros_like(lc.time.values))
+                        np.ma.zeros(lc.time.values.shape))
             xpos, xwidth, ypos, ywidth = centroid_param_list
 
             # make citations for current stage

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -736,10 +736,12 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
         # Nest any transit and/or eclipse models inside of the
         # phase curve model
         if 'batman_tr' in model_names:
-            t_model = modellist.pop(np.where(model_names == 'batman_tr')[0][0])
+            t_model = modellist.pop(
+                np.where(model_names == 'batman_tr')[0][0])
             model_names = np.array([model.name for model in modellist])
         if 'batman_ecl' in model_names:
-            e_model = modellist.pop(np.where(model_names == 'batman_ecl')[0][0])
+            e_model = modellist.pop(
+                np.where(model_names == 'batman_ecl')[0][0])
             model_names = np.array([model.name for model in modellist])
         # Check if should enforce positivity
         if not hasattr(meta, 'force_positivity'):

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -1173,9 +1173,9 @@ def load_model(meta, log, x_unit):
         if model_y_param != y_param:
             # This model is not relevant for this plot, so skipping it
             log.writelog(f'The model_y_param ({meta.model_y_param}) does not '
-                         f'match the current y_param ({meta.y_param}), so not'
+                         f'match the current y_param ({meta.y_param}), so not '
                          'using the model for this plot')
-            return meta, None, None
+            return None, None
 
     model_path = os.path.join(meta.topdir, *meta.model_spectrum.split(os.sep))
     model_x, model_y = np.loadtxt(model_path, delimiter=meta.model_delimiter).T
@@ -1184,11 +1184,13 @@ def load_model(meta, log, x_unit):
     model_x_unit = model_x_unit.to(x_unit, equivalencies=units.spectral())
     model_x *= model_x_unit
     # Figure out if model needs to be converted to Rp/Rs
-    sqrt_model = ((meta.param == 'rp^2' or meta.param == 'rprs^2') and 
-                  meta.model_y_param != meta.y_param)
+    sqrt_model = ((meta.model_y_param == 'rp^2'
+                   or meta.model_y_param == 'rprs^2')
+                  and meta.model_y_param != meta.y_param)
     # Figure out if model needs to be converted to (Rp/Rs)^2
-    sq_model = ((meta.param == 'rp' or meta.param == 'rprs') and 
-                meta.model_y_param != meta.y_param)
+    sq_model = ((meta.model_y_param == 'rp'
+                 or meta.model_y_param == 'rprs')
+                and meta.model_y_param != meta.y_param)
     if sqrt_model:
         model_y = np.sqrt(model_y)
     elif sq_model:
@@ -1206,7 +1208,7 @@ def load_model(meta, log, x_unit):
     if meta.model_y_scalar != 1:
         model_y *= meta.model_y_scalar
 
-    return model_x, model_y
+    return model_x, model_y*meta.y_scalar
 
 
 def save_table(meta, log):

--- a/tests/MIRI_ecfs/s5_fit_par.epf
+++ b/tests/MIRI_ecfs/s5_fit_par.epf
@@ -42,6 +42,9 @@ AmpSin1		0.0119516726947867	'free'			-1				1			U
 c0			0.998133337177571	'free'			1				0.05		N
 r0			-0.124315778343348	'free' 			-0.12			0.05		N
 r1			35.5170488452062	'free' 			35 				20			N
+# Drift model variables
+ypos		0.01				'free'			0.01			1			N
+xpos		0.004				'free'			0.004			1			N
 # -----------
 # ** White noise **
 # Use scatter_mult to fit a multiplier to the expected noise level from Stage 3 (recommended)

--- a/tests/Photometry_NIRCam_ecfs/S5_Photometry_NIRCam.ecf
+++ b/tests/Photometry_NIRCam_ecfs/S5_Photometry_NIRCam.ecf
@@ -2,15 +2,15 @@
 
 ncpu            6 # The number of CPU threads to use when running emcee or dynesty in parallel
 
-allapers        False # Run S5 on all of the apertures considered in S4? Otherwise will use newest output in the inputdir
+allapers        True # Run S5 on all of the apertures considered in S4? Otherwise will use newest output in the inputdir
 rescale_err     False    # Rescale uncertainties to have reduced chi-squared of unity
-fit_par         ./s5_fit_par.epf # What fitting epf do you want to use?
-verbose         True # If True, more details will be printed about steps
-fit_method      [dynesty] #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
-run_myfuncs     [batman_tr,batman_ecl,sinusoid_pc,expramp,polynomial,xpos,ypos] #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, polynomial, step, and GP (can list multiple types separated by commas)
+fit_par         ./S5_fit_par.epf # What fitting epf do you want to use?
+verbose         False # If True, more details will be printed about steps
+fit_method      [lsq] #options are: lsq, emcee, dynesty (can list multiple types separated by commas)
+run_myfuncs     [batman_tr, polynomial, xpos, ypos] #options are: batman_tr, batman_ecl, sinusoid_pc, expramp, polynomial, step, and GP (can list multiple types separated by commas)
 
 # Manual clipping in time
-manual_clip     None  # A list of lists specifying the start and end integration numbers for manual removal.
+manual_clip     None   # A list of lists specifying the start and end integration numbers for manual removal.
 
 # Limb darkening controls
 # IMPORTANT: limb-darkening coefficients are not automatically fixed then, change to 'fixed' in .epf file whether they should be fixed or fitted!
@@ -18,17 +18,12 @@ use_generate_ld  None  # use the generated limb-darkening coefficients from Stag
 ld_file          None  # Fully qualified path to the location of a limb darkening file that you want to use
 ld_file_white    None  # Fully qualified path to the location of a limb darkening file that you want to use for the white-light light curve (required if ld_file is not None and any EPF parameters are set to white_free or white_fixed).
 
-# General fitter
-old_fitparams   None # filename relative to topdir that points to a fitparams csv to resume where you left off (set to None to start from scratch)
-
-#dynesty
-run_nlive       'min' # Must be > ndim * (ndim + 1) // 2
-run_bound       'multi'
-run_sample      'auto'
-run_tol         10 # For testing, set to something dynesty can get to quickly
+#lsq
+lsq_method      Powell # The scipy.optimize.minimize optimization method to use
+lsq_tol         1e-6 # The tolerance for the scipy.optimize.minimize optimization method
 
 # Plotting controls
-interp          False   # Should astrophysical model be interpolated (useful for uneven sampling like that from HST)
+interp          False # Should astrophysical model be interpolated (useful for uneven sampling like that from HST)
 
 # Diagnostics
 isplots_S5      5 # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
@@ -40,5 +35,5 @@ hide_plots      True # If True, plots will automatically be closed rather than p
 topdir          ../tests
 
 # Directories relative to project dir
-inputdir        /data/JWST-Sim/MIRI/Stage4/
-outputdir       /data/JWST-Sim/MIRI/Stage5/
+inputdir        /data/Photometry/NIRCam/Stage4/    # The folder containing the outputs from Eureka!'s S3 or JWST's S3 pipeline (will be overwritten if calling S3 and S4 sequentially)
+outputdir       /data/Photometry/NIRCam/Stage5/

--- a/tests/Photometry_NIRCam_ecfs/S5_fit_par.epf
+++ b/tests/Photometry_NIRCam_ecfs/S5_fit_par.epf
@@ -7,41 +7,37 @@
 # If U/LU, PriorPar1 and PriorPar2 represent upper and lower limits of the parameter/log(the parameter).
 # If N, PriorPar1 is the mean and PriorPar2 is the standard deviation of a Gaussian prior.
 #-------------------------------------------------------------------------------------------------------
-rp			0.184157029967815	'free'			0.19			0.05		N
-fp			0.00721333946967835	'free'			0.008000		0.006000	N
+# ------------------
+# ** Transit/eclipse parameters **
+# ------------------
+rp			0.16			'free'			0.05			0.3				U
 # ------------------
 # Orbital parameters
 # ------------------
-per			0.766894378762		'free'			0.7668944		0.0000003	N	
-t0   		0.520935022161196	'free'			0.5209350221611 0.0001		N
-time_offset	0					'independent'
-inc  		79.0448701805676	'free'			79.044870180567	1			N	# Exoplanet Archive value for b is seemingly not helpful
-a    		4.42519793519358	'free'			4.447	 		0.132		N
-ecc  		0.0	 				'fixed' 		0 				1			U
-w    		90.					'fixed' 		0 				180			U
+per			0.813473978		'free'			0.813473978		0.000000035		N
+t0   		55528.353027	'free'			55528.34		55528.36		U
+time_offset	0				'independent'
+inc  		82.109	 		'free'			82.109			0.088			N
+a    		4.97			'free'			4.97			0.14			N
+ecc  		0.0	 			'fixed' 		0 				1				U
+w    		90.				'fixed' 		0 				180				U
 # -------------------------
+# ** Limb darkening parameters **
 # Choose limb_dark from ['uniform', 'linear', 'quadratic', 'kipping2013', 'squareroot', 'logarithmic', 'exponential','3-parameter', '4-parameter']
 # When using generated limb-darkening coefficients from exotic-ld choose from ['linear', 'quadratic', '3-parameter', '4-parameter']
 # -------------------------
-limb_dark	'quadratic' 		'independent'
-u1			0.					'free'			-1				1			U
-u2			0.					'free'			-1				1			U
-# ----------------------
-# Phase curve parameters
-# ----------------------
-Y10			0.37378569100333	'free'			0				1			U
-Y11			0.0119516726947867	'free'			-1				1			U
+limb_dark	'kipping2013' 	'independent'
+u1			0.3				'free'			0				1				U
+u2			0.1				'free'			0				1				U
 # --------------------
-# Systematic variables
+# ** Systematic variables **
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
 # Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)
 # --------------------
-c0			0.998133337177571	'free'			1				0.05		N
-r0			-0.124315778343348	'free' 			-0.12			0.05		N
-r1			35.5170488452062	'free' 			35 				20			N
+c0			1.009			'free'			0.95			1.05			U
 # Drift model variables
 ypos		0.01				'free'			0.01			1			N
 xpos		0.004				'free'			0.004			1			N
@@ -50,9 +46,5 @@ xpos		0.004				'free'			0.004			1			N
 # Use scatter_mult to fit a multiplier to the expected noise level from Stage 3 (recommended)
 # Use scatter_ppm to fit the noise level in ppm
 # -----------
-scatter_mult	1				'free'			0.5				2			U
-# ---------------------------------------
-# Light travel time correction parameters
-# ---------------------------------------
-Rs			0.697				'independent'
-Ms			0.66				'independent'
+# scatter_mult 1.1            'free'         1            0.1          N
+# scatter_ppm  500            'free'         500          100          N


### PR DESCRIPTION
Fixing new POET bugs and old bugs

Old bugs include issues with multwhite fits, masked values, and nbin_plot dealing with nbin_plot=len(time) in the presence of masked values.

New POET bugs include improperly handling multi-channel (or multwhite) fits (because only the values for channel 0 were ever used), and a broken alias between fp and fpfs.

Also fixing a bug in S6 related to load_model function.