### PR TITLE
Updating environment.yml files for Apple M2 computers

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
     - batman-package
     - bokeh[version='<3.0']
     - ccdproc
-    - celerite2 # Needed for GP
     - corner
     - dynesty[version='>1.0'] # Lower limit needed for specific arguments
     - emcee[version='>3.0.0'] # Lower limit needed for specific arguments
@@ -20,7 +19,6 @@ dependencies:
     - jupyter
     - lmfit
     - matplotlib[version='>=3.6'] # Lower limit needed for set_layout_engine()
-    - mc3 # Needed for uncertainties in the Allan variance plots in S5
     - nbsphinx # Needed for documentation
     - numpy[version='>=1.20.0,<=1.23'] # Upper limit needed for Apple silicon
     - numpydoc # Needed for documentation
@@ -37,10 +35,12 @@ dependencies:
     - tqdm
     - pip:
         - astraeus@git+https://github.com/kevin218/Astraeus@main
+        - celerite2 # Needed for GP
         - crds
         - exotic-ld==3 # Lower limit needed for updated JWST sensitivity files, upper limit needed for breaking changes
         - image_registration@git+https://github.com/keflavich/image_registration@master # Need GitHub version to avoid np.float issue
         - jwst==1.11.4
+        - mc3 # Needed for uncertainties in the Allan variance plots in S5
         - myst-parser # Needed for documentation
         - setuptools_scm # Needed for version number
         - sphinx-rtd-theme # Needed for documentation

--- a/environment_pymc3.yml
+++ b/environment_pymc3.yml
@@ -9,7 +9,6 @@ dependencies:
     - batman-package
     - bokeh[version='<3.0']
     - ccdproc
-    - celerite2 # Needed for GP
     - corner
     - dynesty[version='>1.0'] # Lower limit needed for specific arguments
     - emcee[version='>3.0.0'] # Lower limit needed for specific arguments
@@ -21,7 +20,6 @@ dependencies:
     - jupyter
     - lmfit
     - matplotlib[version='>=3.6'] # Lower limit needed for set_layout_engine()
-    - mc3 # Needed for uncertainties in the Allan variance plots in S5
     - mkl-service
     - nbsphinx # Needed for documentation
     - numpy[version='>=1.20.0,<1.22'] # Upper limit needed for Apple silicon and for theano, starry, and pymc3
@@ -39,11 +37,13 @@ dependencies:
     - tqdm
     - pip:
         - astraeus@git+https://github.com/kevin218/Astraeus@main
+        - celerite2 # Needed for GP
         - crds
         - exoplanet
         - exotic-ld==3 # Lower limit needed for updated JWST sensitivity files, upper limit needed for breaking changes
         - image_registration@git+https://github.com/keflavich/image_registration@master # Need GitHub version to avoid np.float issue
         - jwst==1.11.4
+        - mc3 # Needed for uncertainties in the Allan variance plots in S5
         - myst-parser # Needed for documentation
         - opencv-python-headless<4.8 # Upper limit needed for numpy<1.22
         - pymc3


### PR DESCRIPTION
Installing celerite2 and mc3 through conda on Apple M2 computers apparently fails (#635) but works when installing them through pip. This PR applies that small tweak to environment.yml and environment_pymc3.yml and resolves #635