### PR TITLE
Adding Hexagonal photometry apertures

### DIFF
--- a/demos/JWST/S3_nircam_photometry_template.ecf
+++ b/demos/JWST/S3_nircam_photometry_template.ecf
@@ -28,6 +28,7 @@ ctr_cutout_size      5                # Cutoff size all around the centroid afte
 oneoverf_corr        median           # Options: None, meanerr, median
 oneoverf_dist        350              # How many pixels away from the centroid should be considered as background? (used for 1/f correction)
 skip_apphot_bg       False            # Skips the background subtraction during the aperture photometry step
+aperture_shape       circle           # Shape of extraction aperture: options are 'circle' or 'hexagon'
 photap               65               # Size of photometry aperture in pixels
 skyin                70               # Inner sky annulus edge, in pixels
 skywidth             20               # Width of the sky annulus, in pixels

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -565,13 +565,17 @@ skip_apphot_bg
 ''''''''''''''
 Only used for photometry analyses. Skips the background subtraction in the aperture photometry routine. If the user does the 1/f noise subtraction during S3, the code will subtract the background from each amplifier region. The aperture photometry code will again subtract a background flux from the target flux by calculating the flux in an annulus in the background. If the user wants to skip this background subtraction by setting an background annulus, skip_apphot_bg has to be set to True.
 
+aperture_shape
+''''''''''''''
+Only used for photometry analyses. Specifies the shape of the extraction aperture, either 'circle' for circular apertures, or 'hexagon' for hexagonal apertures, to better match the shape of the JWST primary mirror for defocused NIRCam photometry.
+
 photap
 ''''''
-Only used for photometry analyses. Size of photometry aperture in pixels. The shape of the aperture is a circle. If the center of a pixel is not included within the aperture, it is being considered. If you want to try multiple values sequentially, you can provide a list in the format [Start, Stop, Step]; this will give you sizes ranging from Start to Stop (inclusively) in steps of size Step. For example, [10,14,2] tries [10,12,14], but [10,15,2] still tries [10,12,14]. If skyin and/or skywidth are also lists, all combinations of the three will be attempted.
+Only used for photometry analyses. Size of photometry aperture in pixels. If aperture_shape is 'circle', then photap is the radius of the circle. If aperture_shape is 'hexagon', then photap is the radius of the circle circumscribing the hexagon. If the center of a pixel is not included within the aperture, it is being considered. If you want to try multiple values sequentially, you can provide a list in the format [Start, Stop, Step]; this will give you sizes ranging from Start to Stop (inclusively) in steps of size Step. For example, [10,14,2] tries [10,12,14], but [10,15,2] still tries [10,12,14]. If skyin and/or skywidth are also lists, all combinations of the three will be attempted.
 
 skyin
 '''''
-Only used for photometry analyses. Inner sky annulus edge, in pixels. If you want to try multiple values sequentially, you can provide a list in the format [Start, Stop, Step]; this will give you sizes ranging from Start to Stop (inclusively) in steps of size Step. For example, [10,14,2] tries [10,12,14], but [10,15,2] still tries [10,12,14]. If photap and/or skywidth are also lists, all combinations of the three will be attempted.
+Only used for photometry analyses. Inner sky annulus edge, in pixels. If aperture_shape is 'circle', then skyin is the radius of the circle. If aperture_shape is 'hexagon', then skyin is the radius of the circle circumscribing the hexagon. If you want to try multiple values sequentially, you can provide a list in the format [Start, Stop, Step]; this will give you sizes ranging from Start to Stop (inclusively) in steps of size Step. For example, [10,14,2] tries [10,12,14], but [10,15,2] still tries [10,12,14]. If photap and/or skywidth are also lists, all combinations of the three will be attempted.
 
 skywidth
 ''''''''

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -1116,6 +1116,10 @@ def phot_2d_frame(data, meta, m, i):
             ap3 = plt.Circle((centroid_x, centroid_y), meta.skyout, color='w',
                              fill=False, lw=4, alpha=0.8)
 
+        plt.gca().add_patch(ap1)
+        plt.gca().add_patch(ap2)
+        plt.gca().add_patch(ap3)
+
         add_colorbar(im, label='Flux (electrons)')
         xlim_min = max(0, centroid_x - meta.skyout - 10)
         xlim_max = min(centroid_x + meta.skyout + 10, flux.shape[1])

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -1000,8 +1000,10 @@ def phot_2d_frame(data, meta, m, i):
     if meta.aperture_shape == "hexagon":
         # to make a hexagon, make the vertices and add them into a path
         # need to add extraneous vertex to close path, for some reason
-        xvert = centroid_x.data.tolist() - meta.photap*np.sin(2*np.pi*np.arange(7)/6)
-        yvert = centroid_y.data.tolist() + meta.photap*np.cos(2*np.pi*np.arange(7)/6)
+        xvert = centroid_x.data.tolist() - meta.photap*np.sin(
+            2*np.pi*np.arange(7)/6)
+        yvert = centroid_y.data.tolist() + meta.photap*np.cos(
+            2*np.pi*np.arange(7)/6)
         hex1 = Path(np.vstack((xvert, yvert)).T)
 
         # make patch of hexagon
@@ -1009,16 +1011,20 @@ def phot_2d_frame(data, meta, m, i):
                                 fill=False, lw=3, alpha=0.7, 
                                 label='target aperture')
         
-        xvert = centroid_x.data.tolist() - meta.skyin*np.sin(2*np.pi*np.arange(7)/6)
-        yvert = centroid_y.data.tolist() + meta.skyin*np.cos(2*np.pi*np.arange(7)/6)
+        xvert = centroid_x.data.tolist() - meta.skyin*np.sin(
+            2*np.pi*np.arange(7)/6)
+        yvert = centroid_y.data.tolist() + meta.skyin*np.cos(
+            2*np.pi*np.arange(7)/6)
         hex2 = Path(np.vstack((xvert, yvert)).T)
 
         ap2 = patches.PathPatch(hex2, color='w',
                                 fill=False, lw=4, alpha=0.8, 
                                 label='sky aperture')
         
-        xvert = centroid_x.data.tolist() - meta.skyout*np.sin(2*np.pi*np.arange(7)/6)
-        yvert = centroid_y.data.tolist() + meta.skyout*np.cos(2*np.pi*np.arange(7)/6)
+        xvert = centroid_x.data.tolist() - meta.skyout*np.sin(
+            2*np.pi*np.arange(7)/6)
+        yvert = centroid_y.data.tolist() + meta.skyout*np.cos(
+            2*np.pi*np.arange(7)/6)
         hex3 = Path(np.vstack((xvert, yvert)).T)
 
         ap3 = patches.PathPatch(hex3, color='w',
@@ -1067,8 +1073,10 @@ def phot_2d_frame(data, meta, m, i):
         # Plot proper aperture shapes
         if meta.aperture_shape == "hexagon":
             # to make a hexagon, make the vertices and add them into a path
-            xvert = centroid_x.data.tolist() - meta.photap*np.sin(2*np.pi*np.arange(7)/6)
-            yvert = centroid_y.data.tolist() + meta.photap*np.cos(2*np.pi*np.arange(7)/6)
+            xvert = centroid_x.data.tolist() - meta.photap*np.sin(
+                2*np.pi*np.arange(7)/6)
+            yvert = centroid_y.data.tolist() + meta.photap*np.cos(
+                2*np.pi*np.arange(7)/6)
             hex1 = Path(np.vstack((xvert, yvert)).T)
 
             # make patch of hexagon
@@ -1077,8 +1085,10 @@ def phot_2d_frame(data, meta, m, i):
                                     label='target aperture')
             
             # to make a hexagon, make the vertices and add them into a path
-            xvert = centroid_x.data.tolist() - meta.skyin*np.sin(2*np.pi*np.arange(7)/6)
-            yvert = centroid_y.data.tolist() + meta.skyin*np.cos(2*np.pi*np.arange(7)/6)
+            xvert = centroid_x.data.tolist() - meta.skyin*np.sin(
+                2*np.pi*np.arange(7)/6)
+            yvert = centroid_y.data.tolist() + meta.skyin*np.cos(
+                2*np.pi*np.arange(7)/6)
             hex2 = Path(np.vstack((xvert, yvert)).T)
 
             # make patch of hexagon
@@ -1087,8 +1097,10 @@ def phot_2d_frame(data, meta, m, i):
                                     label='sky aperture')
             
             # to make a hexagon, make the vertices and add them into a path
-            xvert = centroid_x.data.tolist() - meta.skyout*np.sin(2*np.pi*np.arange(7)/6)
-            yvert = centroid_y.data.tolist() + meta.skyout*np.cos(2*np.pi*np.arange(7)/6)
+            xvert = centroid_x.data.tolist() - meta.skyout*np.sin(
+                2*np.pi*np.arange(7)/6)
+            yvert = centroid_y.data.tolist() + meta.skyout*np.cos(
+                2*np.pi*np.arange(7)/6)
             hex3 = Path(np.vstack((xvert, yvert)).T)
 
             # make patch of hexagon

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -6,6 +6,8 @@ import scipy.interpolate as spi
 import scipy.stats as stats
 from scipy.interpolate import interp1d
 from matplotlib.colors import LogNorm
+import matplotlib.patches as patches
+from matplotlib.path import Path
 from mpl_toolkits import axes_grid1
 import imageio
 
@@ -968,6 +970,8 @@ def phot_2d_frame(data, meta, m, i):
 
     - 2022-08-02 Sebastian Zieba
         Initial version
+    - 2024-04-06 Yoni Brande
+        Added hexagonal aperture plotting
     """
     plt.figure(3306, figsize=(8, 8))
     plt.clf()
@@ -992,15 +996,46 @@ def phot_2d_frame(data, meta, m, i):
     plt.ylabel('y pixels')
     plt.xlabel('x pixels')
 
-    circle1 = plt.Circle((centroid_x, centroid_y), meta.photap, color='r',
+    # Plot proper aperture shapes
+    if meta.aperture_shape == "hexagon":
+        # to make a hexagon, make the vertices and add them into a path
+        # need to add extraneous vertex to close path, for some reason
+        xvert = centroid_x.data.tolist() - meta.photap*np.sin(2*np.pi*np.arange(7)/6)
+        yvert = centroid_y.data.tolist() + meta.photap*np.cos(2*np.pi*np.arange(7)/6)
+        hex1 = Path(np.vstack((xvert, yvert)).T)
+
+        # make patch of hexagon
+        ap1 = patches.PathPatch(hex1, color='r',
+                                fill=False, lw=3, alpha=0.7, 
+                                label='target aperture')
+        
+        xvert = centroid_x.data.tolist() - meta.skyin*np.sin(2*np.pi*np.arange(7)/6)
+        yvert = centroid_y.data.tolist() + meta.skyin*np.cos(2*np.pi*np.arange(7)/6)
+        hex2 = Path(np.vstack((xvert, yvert)).T)
+
+        ap2 = patches.PathPatch(hex2, color='w',
+                                fill=False, lw=4, alpha=0.8, 
+                                label='sky aperture')
+        
+        xvert = centroid_x.data.tolist() - meta.skyout*np.sin(2*np.pi*np.arange(7)/6)
+        yvert = centroid_y.data.tolist() + meta.skyout*np.cos(2*np.pi*np.arange(7)/6)
+        hex3 = Path(np.vstack((xvert, yvert)).T)
+
+        ap3 = patches.PathPatch(hex3, color='w',
+                                fill=False, lw=4, alpha=0.8)
+    else:
+        # circular apertures
+        ap1 = plt.Circle((centroid_x, centroid_y), meta.photap, color='r',
                          fill=False, lw=3, alpha=0.7, label='target aperture')
-    circle2 = plt.Circle((centroid_x, centroid_y), meta.skyin, color='w',
+        ap2 = plt.Circle((centroid_x, centroid_y), meta.skyin, color='w',
                          fill=False, lw=4, alpha=0.8, label='sky aperture')
-    circle3 = plt.Circle((centroid_x, centroid_y), meta.skyout, color='w',
+        ap3 = plt.Circle((centroid_x, centroid_y), meta.skyout, color='w',
                          fill=False, lw=4, alpha=0.8)
-    plt.gca().add_patch(circle1)
-    plt.gca().add_patch(circle2)
-    plt.gca().add_patch(circle3)
+        
+    plt.gca().add_patch(ap1)
+    plt.gca().add_patch(ap2)
+    plt.gca().add_patch(ap3)
+
     add_colorbar(im, label='Flux (electrons)')
     plt.xlim(0, flux.shape[1])
     plt.ylim(0, flux.shape[0])
@@ -1029,17 +1064,45 @@ def phot_2d_frame(data, meta, m, i):
         plt.ylabel('y pixels')
         plt.xlabel('x pixels')
 
-        circle1 = plt.Circle((centroid_x, centroid_y), meta.photap, color='r',
-                             fill=False, lw=3, alpha=0.7,
+        # Plot proper aperture shapes
+        if meta.aperture_shape == "hexagon":
+            # to make a hexagon, make the vertices and add them into a path
+            xvert = centroid_x.data.tolist() - meta.photap*np.sin(2*np.pi*np.arange(7)/6)
+            yvert = centroid_y.data.tolist() + meta.photap*np.cos(2*np.pi*np.arange(7)/6)
+            hex1 = Path(np.vstack((xvert, yvert)).T)
+
+            # make patch of hexagon
+            ap1 = patches.PathPatch(hex1, color='r',
+                                    fill=False, lw=3, alpha=0.7, 
+                                    label='target aperture')
+            
+            # to make a hexagon, make the vertices and add them into a path
+            xvert = centroid_x.data.tolist() - meta.skyin*np.sin(2*np.pi*np.arange(7)/6)
+            yvert = centroid_y.data.tolist() + meta.skyin*np.cos(2*np.pi*np.arange(7)/6)
+            hex2 = Path(np.vstack((xvert, yvert)).T)
+
+            # make patch of hexagon
+            ap2 = patches.PathPatch(hex2, color='w',
+                                    fill=False, lw=4, alpha=0.8, 
+                                    label='sky aperture')
+            
+            # to make a hexagon, make the vertices and add them into a path
+            xvert = centroid_x.data.tolist() - meta.skyout*np.sin(2*np.pi*np.arange(7)/6)
+            yvert = centroid_y.data.tolist() + meta.skyout*np.cos(2*np.pi*np.arange(7)/6)
+            hex3 = Path(np.vstack((xvert, yvert)).T)
+
+            # make patch of hexagon
+            ap3 = patches.PathPatch(hex3, color='w',
+                                    fill=False, lw=4, alpha=0.8)
+        else:
+            # circular apertures
+            ap1 = plt.Circle((centroid_x, centroid_y), meta.photap, color='r',
+                             fill=False, lw=3, alpha=0.7, 
                              label='target aperture')
-        circle2 = plt.Circle((centroid_x, centroid_y), meta.skyin, color='w',
-                             fill=False, lw=4, alpha=0.8,
-                             label='sky aperture')
-        circle3 = plt.Circle((centroid_x, centroid_y), meta.skyout, color='w',
+            ap2 = plt.Circle((centroid_x, centroid_y), meta.skyin, color='w',
+                             fill=False, lw=4, alpha=0.8, label='sky aperture')
+            ap3 = plt.Circle((centroid_x, centroid_y), meta.skyout, color='w',
                              fill=False, lw=4, alpha=0.8)
-        plt.gca().add_patch(circle1)
-        plt.gca().add_patch(circle2)
-        plt.gca().add_patch(circle3)
 
         add_colorbar(im, label='Flux (electrons)')
         xlim_min = max(0, centroid_x - meta.skyout - 10)

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -654,7 +654,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
 
                         # Check if aperture shape has been defined
                         if (not hasattr(meta, 'aperture_shape') 
-                           or meta.aperture_shape is None):
+                                or meta.aperture_shape is None):
                             meta.aperture_shape = 'circle'
 
                         # Calculate flux in aperture and subtract

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -652,6 +652,11 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                         if meta.interp_method is not None:
                             util.interp_masked(data, meta, i, log)
 
+                        # Check if aperture shape has been defined
+                        if (not hasattr(meta, 'aperture_shape') 
+                           or meta.aperture_shape is None):
+                            meta.aperture_shape = 'circle'
+
                         # Calculate flux in aperture and subtract
                         # background flux
                         aphot = apphot.apphot(

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -666,7 +666,7 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                             aperr=True, nappix=True, skylev=True,
                             skyerr=True, nskypix=True,
                             nskyideal=True, status=True,
-                            betaper=True)
+                            betaper=True, aperture_shape=meta.aperture_shape)
                         # Save results into arrays
                         (data['aplev'][i], data['aperr'][i],
                             data['nappix'][i], data['skylev'][i],

--- a/src/eureka/lib/apphot.py
+++ b/src/eureka/lib/apphot.py
@@ -10,7 +10,7 @@ def apphot(meta, image, ctr, photap, skyin, skyout, betahw, targpos,
            expand=1, order=1,
            aperr=False, nappix=False, skylev=False, skyerr=False,
            nskypix=False, nskyideal=False, status=False, isbeta=False,
-           betaper=False):
+           betaper=False, aperture_shape=None):
     """
     Perform aperture photometry on the input image.
 
@@ -81,6 +81,9 @@ def apphot(meta, image, ctr, photap, skyin, skyout, betahw, targpos,
         parameter (beta).
     betaper  : Scalar
         Returns aperture size used for beta.
+    aperture_shape : String
+        Specifies shape of the extraction aperture used, currently 
+        only "circle" and "hexagon" are supported.
 
     Returns
     -------
@@ -159,6 +162,10 @@ def apphot(meta, image, ctr, photap, skyin, skyout, betahw, targpos,
         fractional, unexpanded pixels.
     - 21-07-2010: patricio
         Converted to python.
+    - 2024-06-05: Yoni Brande, jbrande@ku.edu
+        Added ability for non-circular apertures with aperture_shape
+        parameter. Currently supporting hexagonal apertures for 
+        eureka!
 
     Examples
     --------
@@ -450,8 +457,13 @@ def apphot(meta, image, ctr, photap, skyin, skyout, betahw, targpos,
 
     # SKY
     # make sky annulus mask
-    skyann = np.bitwise_xor(di.disk(iskyout, ictr, isz),
-                            di.disk(iskyin, ictr, isz))
+    if aperture_shape == "hexagon":
+        skyann = np.bitwise_xor(di.hex(iskyout, ictr, isz),
+                                di.hex(iskyin, ictr, isz))
+    else:
+        skyann = np.bitwise_xor(di.disk(iskyout, ictr, isz),
+                                di.disk(iskyin, ictr, isz))
+
     skymask = skyann * imask * np.isfinite(iimage)  # flag NaNs to eliminate
     # from nskypix
 
@@ -461,9 +473,17 @@ def apphot(meta, image, ctr, photap, skyin, skyout, betahw, targpos,
     szsky = (int(np.ceil(iskyout)) * 2 + 3) * np.array([1, 1], dtype=int)
     ctrsky = (ictr % 1.0) + np.ceil(iskyout) + 1.0
     # nskyideal = all pixels in sky
-    ret[nskyideal] = (np.sum(np.bitwise_xor(di.disk(iskyout, ctrsky, szsky),
-                                            di.disk(iskyin, ctrsky, szsky)))
-                      / iexpand**2.0)
+    if aperture_shape == "hexagon":
+        ret[nskyideal] = (np.sum(
+                          np.bitwise_xor(di.hex(iskyout, ctrsky, szsky),
+                                         di.hex(iskyin, ctrsky, szsky))) 
+                          / iexpand**2.0)
+    else:
+        ret[nskyideal] = (np.sum(
+                          np.bitwise_xor(di.disk(iskyout, ctrsky, szsky),
+                                         di.disk(iskyin, ctrsky, szsky))) 
+                          / iexpand**2.0)
+
     if ret[nskypix] < iskyfrac * ret[nskyideal]:
         status |= statsky
 
@@ -531,7 +551,10 @@ def apphot(meta, image, ctr, photap, skyin, skyout, betahw, targpos,
 
     # APERTURE
     # make aperture mask, extract data and mask
-    apmask, dstatus = di.disk(iphotap, ictr, isz, status=True)
+    if aperture_shape == "hexagon":
+        apmask, dstatus = di.hex(iphotap, ictr, isz, status=True)
+    else:        
+        apmask, dstatus = di.disk(iphotap, ictr, isz, status=True)
     if dstatus:  # is the aperture fully on the image?
         status |= statap
 

--- a/src/eureka/lib/disk.py
+++ b/src/eureka/lib/disk.py
@@ -1,4 +1,5 @@
 import numpy as np
+from matplotlib.path import Path
 
 
 def disk(r, ctr, size, status=False):
@@ -54,6 +55,68 @@ def disk(r, ctr, size, status=False):
 
     # return mask disk (and status if requested)
     ret = fdisk <= r**2.0
+    if status:
+        ret = ret, retstatus
+    return ret
+
+
+def hex(r, ctr, size, status=False):
+    """
+    This function returns a byte array containing a hexagon.
+
+    The hexagon is centered at (ctr[0], ctr[1]), and is circumscribed by a 
+    circle of radius r. The array is (size[0], size[1]) in size and has byte 
+    type. Pixel values of 1 indicate that the center of a pixel is within r 
+    of (ctr[0], ctr[1]). Pixel values of 0 indicate the opposite. The center 
+    of each pixel is the integer position of that pixel.
+
+    Parameters
+    ----------
+    r : float
+        The radius of the circle circumscribing the hexagon.
+    ctr : tuple, list, or array
+        The x,y position of the center of the hexagon, 2-element vector.
+    size : tuple, list, or array
+        The x,y size of the output array, 2-element vector.
+    status : bool; optional
+        If True, return the status optional output.
+
+    Returns
+    -------
+    ret : ndarray
+        A boolean array where False if outside the hexagon or True if inside
+        the hexagon.
+    retstatus : int; optional
+        Set to 1 if any part of the hexagon is outside the image boundaries.
+        Only returned if status==True.
+
+    Notes
+    -----
+    History:
+        - 2024-06-05: Yoni Brande, jbrande@ku.edu
+        Initial version, adapted from a snippet by Ian Crossfield
+    """
+
+    # check if hex is off image (same check as disk, for now)
+    retstatus = int(ctr[0] - r < 0 or ctr[0] + r > size[0]-1 or
+                    ctr[1] - r < 0 or ctr[1] + r > size[1]-1)
+    
+    # make hexagon, oriented like the JWST mirrors (corner vertex at 12:00)
+    yvert = ctr[1] + r*np.cos(2*np.pi*np.arange(6)/6)
+    xvert = ctr[0] - r*np.sin(2*np.pi*np.arange(6)/6)
+    hexverts = np.vstack((xvert, yvert)).T
+
+    # use matplotlib Path to make hexagon
+    poly_path = Path(hexverts)
+
+    # get list of coordinates for each pixel in image
+    ind = np.indices(size)
+    coors = np.hstack((ind[0].reshape(-1, 1), ind[1].reshape(-1, 1))) 
+    
+    # use matplotlib.path to do easy masking
+    ret = poly_path.contains_points(coors).reshape(size[0], size[1])
+
+    # return mask disk (and status if requested)
     if status:
         ret = ret, retstatus
     return ret

--- a/src/eureka/lib/disk.py
+++ b/src/eureka/lib/disk.py
@@ -66,8 +66,8 @@ def hex(r, ctr, size, status=False):
 
     The hexagon is centered at (ctr[0], ctr[1]), and is circumscribed by a 
     circle of radius r. The array is (size[0], size[1]) in size and has byte 
-    type. Pixel values of 1 indicate that the center of a pixel is within r 
-    of (ctr[0], ctr[1]). Pixel values of 0 indicate the opposite. The center 
+    type. Pixel values of 1 indicate that the center of a pixel is within the 
+    hexagonal aperture. Pixel values of 0 indicate the opposite. The center 
     of each pixel is the integer position of that pixel.
 
     Parameters

--- a/tests/Photometry_NIRCam_ecfs/S3_Photometry_NIRCam.ecf
+++ b/tests/Photometry_NIRCam_ecfs/S3_Photometry_NIRCam.ecf
@@ -26,6 +26,7 @@ ctr_cutout_size  7           # Cutoff size all around the centroid after the coa
 oneoverf_corr    median      # Options: None, meanerr, median
 oneoverf_dist    300         # How many pixels away from the centroid should be considered as background? (used for 1/f correction)
 skip_apphot_bg   True        # Skips the background subtraction during the aperture photometry step
+aperture_shape   circle      # Shape of extraction aperture: options are 'circle' or 'hexagon'
 photap           60          # Size of photometry aperture in pixels
 skyin            70          # Inner sky annulus edge, in pixels
 skywidth         20          # Width of the sky annulus, in pixels

--- a/tests/Photometry_NIRCam_ecfs/S3_Photometry_NIRCam_hex.ecf
+++ b/tests/Photometry_NIRCam_ecfs/S3_Photometry_NIRCam_hex.ecf
@@ -1,0 +1,49 @@
+# Eureka! Control File for Stage 3: Data Reduction
+
+# Stage 3 Documentation: https://eurekadocs.readthedocs.io/en/latest/ecf.html#stage-3
+
+ncpu            1           # Number of CPUs
+nfiles          1           # The number of data files to analyze simultaneously
+max_memory      0.5         # The maximum fraction of memory you want utilized by read-in frames (this will reduce nfiles if need be)
+suffix          calints     # Data file suffix
+photometry      True        # Set to True if the user wants to analyze a photometric dataset
+
+convert_to_e    True        # Whether or not a conversion to electrons should be performed (can set to False to compute flux-calibrated spectra/photometry)
+
+# Subarray region of interest
+ywindow         [4, 256]     # Vertical axis as seen in DS9
+xwindow         [512, 1536]  # Horizontal axis as seen in DS9
+dqmask          True         # Mask pixels with an odd entry in the DQ array
+
+# Background parameters
+flag_bg         False        # Do outlier rejection along time axis for each individual pixel?
+bg_thresh       [5,5]        # Double-iteration X-sigma threshold for outlier rejection along time axis
+
+# Photometric extraction parameters
+interp_method    linear      # Interpolate bad pixels. Options: None (if no interpolation should be performed), linear, nearest, cubic
+centroid_method  mgmc        # Method used for centroiding. Options: mgmc, fgc
+ctr_cutout_size  7           # Cutoff size all around the centroid after the coarse centroid calculation
+oneoverf_corr    median      # Options: None, meanerr, median
+oneoverf_dist    300         # How many pixels away from the centroid should be considered as background? (used for 1/f correction)
+skip_apphot_bg   True        # Skips the background subtraction during the aperture photometry step
+aperture_shape   hexagon     # Shape of extraction aperture: options are 'circle' or 'hexagon'
+photap           60          # Size of photometry aperture in pixels
+skyin            70          # Inner sky annulus edge, in pixels
+skywidth         20          # Width of the sky annulus, in pixels
+centroid_tech    com         # (mgmc method param) Technique used for centroiding. Options: com, 1dg, 2dg
+gauss_frame      100         # (mgmc method param) Half-width away from second centroid guess to include in centroiding map for gaussian widths. Options: his should be set to something larger than your expected PSF size; ~100 for defocused NIRCam photometry, or ~15 for MIRI photometry.
+
+# Diagnostics
+isplots_S3      3           # Generate few (1), some (3), or many (5) figures (Options: 1 - 5)
+nplots          5           # How many of each type of figure do you want to make per file?
+testing_S3      False       # Boolean, set True to only use last file and generate select figures
+hide_plots      True        # If True, plots will automatically be closed rather than popping up
+save_output     True        # Save outputs for use in S4
+verbose         False       # If True, more details will be printed about steps
+
+# Project directory
+topdir     ../tests
+
+# Directories relative to project dir
+inputdir     /data/Photometry/NIRCam/Stage2/
+outputdir    /data/Photometry/NIRCam/Stage3/

--- a/tests/test_Photometry_NIRCam.py
+++ b/tests/test_Photometry_NIRCam.py
@@ -93,7 +93,8 @@ def test_NIRCam_hex(capsys):
         print("\n\nIMPORTANT: Make sure that any changes to the ecf files "
               "are\nincluded in demo ecf files and documentation "
               "(docs/source/ecf.rst).")
-        print("\nPhotometry NIRCam S3-4 test: ", end='', flush=True)
+        print("\nPhotometry NIRCam S3 hexagonal aperture test: ", 
+              end='', flush=True)
 
     # explicitly define meta variables to be able to run
     # pathdirectory fn locally

--- a/tests/test_Photometry_NIRCam.py
+++ b/tests/test_Photometry_NIRCam.py
@@ -80,3 +80,41 @@ def test_NIRCam(capsys):
     os.system(f"rm -r data{os.sep}Photometry{os.sep}NIRCam{os.sep}Stage3")
     os.system(f"rm -r data{os.sep}Photometry{os.sep}NIRCam{os.sep}Stage4")
     os.system(f"rm -r data{os.sep}Photometry{os.sep}NIRCam{os.sep}Stage5")
+
+
+def test_NIRCam_hex(capsys):
+    # tests hexagonal photometry aperture
+
+    eureka.lib.plots.set_rc(style='eureka', usetex=False, filetype='.png')
+
+    with capsys.disabled():
+        # is able to display any message without failing a test
+        # useful to leave messages for future users who run the tests
+        print("\n\nIMPORTANT: Make sure that any changes to the ecf files "
+              "are\nincluded in demo ecf files and documentation "
+              "(docs/source/ecf.rst).")
+        print("\nPhotometry NIRCam S3-4 test: ", end='', flush=True)
+
+    # explicitly define meta variables to be able to run
+    # pathdirectory fn locally
+    meta = MetaClass()
+    meta.eventlabel = 'Photometry_NIRCam_hex'
+    meta.datetime = time_pkg.strftime('%Y-%m-%d')
+    meta.topdir = f'..{os.sep}tests'
+    ecf_path = f'.{os.sep}Photometry_NIRCam_ecfs{os.sep}'
+
+    reload(s3)
+    s3_spec, s3_meta = s3.reduce(meta.eventlabel, ecf_path=ecf_path)
+
+    # run assertions for S3
+    meta.outputdir_raw = (f'data{os.sep}Photometry{os.sep}NIRCam{os.sep}'
+                          f'Stage3{os.sep}')
+    name = pathdirectory(meta, 'S3', 1, ap=60, bg='70_90')
+    assert os.path.exists(name)
+    assert os.path.exists(name+os.sep+'figs')
+
+    s3_cites = np.union1d(COMMON_IMPORTS[2], ["nircam", "nircam_photometry"])
+    assert np.array_equal(s3_meta.citations, s3_cites)
+
+    # remove temporary files
+    os.system(f"rm -r data{os.sep}Photometry{os.sep}NIRCam{os.sep}Stage3")


### PR DESCRIPTION
This pull request adds in hexagonal apertures to the NIRCam photometry modes, since the defocused image is hexagonal (like the observatory main mirror), and not circular. Thanks to Ian for hacking on this in five minutes and coming up with something twice as fast as what I'd come up with.

This ended up being easy, just a drop-in replacement for the disk routine, and an added ECF parameter `aperture_shape` to control whether we're using circles or hexagons. This seems like it works as-is, but I haven't exhaustively tested it yet. I've also generalized the plotting code slightly to take advantage of this, and it looks like we get proper apertures in plot 3306 now.