### PR TITLE
Adding _ch to channel tag and _pl to planet tag in S5 variable names

### DIFF
--- a/src/eureka/S1_detector_processing/update_saturation.py
+++ b/src/eureka/S1_detector_processing/update_saturation.py
@@ -71,7 +71,7 @@ def update_sat(input_model, log, meta):
         for i in range(ngrp-1):
             new_sat_mask[i, :, :] += new_sat_mask[i+1, :, :]
 
-    # If flags in the first group, raise a warning that columns will not be used
+    # If flags in the first group, raise warning that columns will not be used
     if np.count_nonzero(new_sat_mask[0]) > 0:
         log.writelog('  WARNING:')
         log.writelog('    Saturation found in the first group.')
@@ -93,7 +93,8 @@ def update_sat(input_model, log, meta):
     # Saturation flagging conditions
     # Where our saturation mask is True and dq is not already flagged
     condition = np.where((new_sat_mask) & (input_model.groupdq == 0))
-    full_saturation = np.where((new_sat_mask[0,:,:]==True) & (input_model.groupdq == 0))
+    full_saturation = np.where(new_sat_mask[0, :, :] &
+                               (input_model.groupdq == 0))
     # Now update the groupdq map
     input_model.groupdq[condition] = sat_flag
     input_model.groupdq[full_saturation] = do_not_use_flag

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/CentroidModel.py
@@ -54,7 +54,7 @@ class CentroidModel(PyMC3Model):
                     # of the original time axis
                     trim1, trim2 = get_trim(self.nints, chan)
                     centroid = self.centroid[trim1:trim2]
-                    self.centroid_local[trim1:trim2] = centroid - centroid.mean()
+                    self.centroid_local[trim1:trim2] = centroid-centroid.mean()
             else:
                 self.centroid_local = self.centroid - self.centroid.mean()
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/CentroidModel.py
@@ -33,7 +33,7 @@ class CentroidModel(PyMC3Model):
         self.axis = kwargs.get('axis')
         self.centroid = kwargs.get('centroid')
 
-        self.coeff_keys = [f'{self.axis}_{c}' if c > 0 else self.axis
+        self.coeff_keys = [f'{self.axis}_ch{c}' if c > 0 else self.axis
                            for c in range(self.nchannel_fitted)]
 
     @property

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/CentroidModel.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("theano.tensor.opt")
 logger.setLevel(logging.ERROR)
 
 from . import PyMC3Model
-from ...lib.split_channels import split
+from ...lib.split_channels import split, get_trim
 
 
 class CentroidModel(PyMC3Model):
@@ -48,13 +48,13 @@ class CentroidModel(PyMC3Model):
         if self.centroid is not None:
             # Convert to local centroid
             if self.multwhite:
-                self.centroid_local = []
+                self.centroid_local = np.ma.zeros(self.centroid.shape)
                 for chan in self.fitted_channels:
                     # Split the arrays that have lengths
                     # of the original time axis
-                    centroid = split([self.centroid, ], self.nints, chan)[0]
-                    self.centroid_local.extend(centroid - centroid.mean())
-                self.centroid_local = np.array(self.centroid_local)
+                    trim1, trim2 = get_trim(self.nints, chan)
+                    centroid = self.centroid[trim1:trim2]
+                    self.centroid_local[trim1:trim2] = centroid - centroid.mean()
             else:
                 self.centroid_local = self.centroid - self.centroid.mean()
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/ExpRampModel.py
@@ -98,7 +98,7 @@ class ExpRampModel(PyMC3Model):
                         ramp_coeffs[c][i] = getattr(model, f'r{i}')
                     else:
                         ramp_coeffs[c][i] = getattr(model,
-                                                    f'r{i}_{chan}')
+                                                    f'r{i}_ch{chan}')
                 except AttributeError:
                     pass
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/ExpRampModel.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("theano.tensor.opt")
 logger.setLevel(logging.ERROR)
 
 from . import PyMC3Model
-from ...lib.split_channels import split
+from ...lib.split_channels import split, get_trim
 
 
 class ExpRampModel(PyMC3Model):
@@ -37,17 +37,17 @@ class ExpRampModel(PyMC3Model):
     @time.setter
     def time(self, time_array):
         """A setter for the time."""
-        self._time = time_array
+        self._time = np.ma.masked_invalid(time_array)
         if self.time is not None:
             # Convert to local time
             if self.multwhite:
-                self.time_local = []
+                self.time_local = np.ma.zeros(self.time.shape)
                 for chan in self.fitted_channels:
                     # Split the arrays that have lengths
                     # of the original time axis
-                    time = split([self.time, ], self.nints, chan)[0]
-                    self.time_local.extend(time - time[0])
-                self.time_local = np.array(self.time_local)
+                    trim1, trim2 = get_trim(self.nints, chan)
+                    time = self.time[trim1:trim2]
+                    self.time_local[trim1:trim2] = time - time[0]
             else:
                 self.time_local = self.time - self.time[0]
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/GPModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/GPModel.py
@@ -52,7 +52,6 @@ class GPModel(PyMC3Model):
         self.kernel_inputs = None
         self.nkernels = len(kernel_classes)
         self.flux = lc.flux
-        self.fit = np.ones_like(self.flux)
         self.unc = lc.unc
         self.unc_fit = lc.unc_fit
         self.time = lc.time
@@ -82,7 +81,7 @@ class GPModel(PyMC3Model):
             if chan == 0:
                 chankey = ''
             else:
-                chankey = f'_{chan}'
+                chankey = f'_ch{chan}'
 
             for i, par in enumerate(['A', 'm']):
                 for k in range(self.nkernels):
@@ -150,18 +149,18 @@ class GPModel(PyMC3Model):
                 flux, unc_fit = split([self.flux, self.unc_fit],
                                       self.nints, chan)
                 if channel is None:
-                    fit = split([fit_lc, ], self.nints, chan)[0]
+                    fit_lc_temp = split([fit_lc, ], self.nints, chan)[0]
                 else:
                     # If only a specific channel is being evaluated, then only
                     # that channel's fitted mode will be passed in
-                    fit = fit_lc
+                    fit_lc_temp = fit_lc
             else:
                 chan = 0
                 # get flux and uncertainties for current channel
                 flux = self.flux
-                fit = fit_lc
+                fit_lc_temp = fit_lc
                 unc_fit = self.unc_fit
-            residuals = np.ma.masked_invalid(flux-fit)
+            residuals = np.ma.masked_invalid(flux-fit_lc_temp)
             if self.multwhite:
                 time = split([self.time, ], self.nints, chan)[0]
             else:
@@ -176,7 +175,7 @@ class GPModel(PyMC3Model):
             if chan == 0:
                 chankey = ''
             else:
-                chankey = f'_{chan}'
+                chankey = f'_ch{chan}'
 
             for i, par in enumerate(['A', 'm']):
                 for k in range(self.nkernels):

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/HSTRampModel.py
@@ -99,7 +99,7 @@ class HSTRampModel(PyMC3Model):
                         hst_coeffs[c][i] = getattr(model, f'h{i}')
                     else:
                         hst_coeffs[c][i] = getattr(model,
-                                                   f'h{i}_{chan}')
+                                                   f'h{i}_ch{chan}')
                 except AttributeError:
                     pass
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/HSTRampModel.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("theano.tensor.opt")
 logger.setLevel(logging.ERROR)
 
 from . import PyMC3Model
-from ...lib.split_channels import split
+from ...lib.split_channels import split, get_trim
 
 
 class HSTRampModel(PyMC3Model):
@@ -38,17 +38,17 @@ class HSTRampModel(PyMC3Model):
     @time.setter
     def time(self, time_array):
         """A setter for the time."""
-        self._time = time_array
+        self._time = np.ma.masked_invalid(time_array)
         if self.time is not None:
             # Convert to local time
             if self.multwhite:
-                self.time_local = []
+                self.time_local = np.ma.zeros(self.time.shape)
                 for chan in self.fitted_channels:
                     # Split the arrays that have lengths
                     # of the original time axis
-                    time = split([self.time, ], self.nints, chan)[0]
-                    self.time_local.extend(time - time[0])
-                self.time_local = np.array(self.time_local)
+                    trim1, trim2 = get_trim(self.nints, chan)
+                    time = self.time[trim1:trim2]
+                    self.time_local[trim1:trim2] = time - time[0]
             else:
                 self.time_local = self.time - self.time[0]
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PolynomialModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PolynomialModel.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("theano.tensor.opt")
 logger.setLevel(logging.ERROR)
 
 from . import PyMC3Model
-from ...lib.split_channels import split
+from ...lib.split_channels import split, get_trim
 
 
 class PolynomialModel(PyMC3Model):
@@ -37,17 +37,17 @@ class PolynomialModel(PyMC3Model):
     @time.setter
     def time(self, time_array):
         """A setter for the time."""
-        self._time = time_array
+        self._time = np.ma.masked_invalid(time_array)
         if self.time is not None:
             # Convert to local time
             if self.multwhite:
-                self.time_local = []
+                self.time_local = np.ma.zeros(self.time.shape)
                 for chan in self.fitted_channels:
                     # Split the arrays that have lengths
                     # of the original time axis
-                    time = split([self.time, ], self.nints, chan)[0]
-                    self.time_local.extend(time - time.mean())
-                self.time_local = np.array(self.time_local)
+                    trim1, trim2 = get_trim(self.nints, chan)
+                    time = self.time[trim1:trim2]
+                    self.time_local[trim1:trim2] = time - time.mean()
             else:
                 self.time_local = self.time - self.time.mean()
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PolynomialModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PolynomialModel.py
@@ -97,7 +97,7 @@ class PolynomialModel(PyMC3Model):
                         poly_coeffs[c][i] = getattr(model, f'c{i}')
                     else:
                         poly_coeffs[c][i] = getattr(model,
-                                                    f'c{i}_{chan}')
+                                                    f'c{i}_ch{chan}')
                 except AttributeError:
                     pass
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -207,6 +207,11 @@ class PyMC3Model:
             getattr(self.parameters, arg).value = val
             setattr(self.fit, arg, val)
 
+        if hasattr(self.fit, 'ecosw') and hasattr(self.fit, 'esinw'):
+            # ecosw and esinw are defined; convert them to ecc and w
+            self.fit.ecc = np.sqrt(self.fit.ecosw**2 + self.fit.esinw**2)
+            self.fit.w = np.arctan2(self.fit.esinw, self.fit.ecosw)*180/np.pi
+
     def setup(self, **kwargs):
         """A placeholder function to do any additional setup.
         """

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -205,8 +205,7 @@ class PyMC3Model:
             # For now, the dict and Parameter are separate
             self.parameters.dict[arg][0] = val
             getattr(self.parameters, arg).value = val
-        for val, key in zip(newparams, self.freenames):
-            setattr(self.fit, key, val)
+            setattr(self.fit, arg, val)
 
     def setup(self, **kwargs):
         """A placeholder function to do any additional setup.
@@ -454,7 +453,7 @@ class CompositePyMC3Model(PyMC3Model):
         with self.model:
             if hasattr(self.model, 'scatter_ppm'):
                 for c in range(self.nchannel_fitted):
-                    if c == 0 or self.parameters.scatter_mult.ptype == 'fixed':
+                    if c == 0:
                         parname_temp = 'scatter_ppm'
                     else:
                         parname_temp = 'scatter_ppm_ch'+str(c)
@@ -473,7 +472,7 @@ class CompositePyMC3Model(PyMC3Model):
             if hasattr(self.model, 'scatter_mult'):
                 # Fitting the noise level as a multiplier
                 for c in range(self.nchannel_fitted):
-                    if c == 0 or self.parameters.scatter_mult.ptype == 'fixed':
+                    if c == 0:
                         parname_temp = 'scatter_mult'
                     else:
                         parname_temp = 'scatter_mult_ch'+str(c)
@@ -513,9 +512,9 @@ class CompositePyMC3Model(PyMC3Model):
                     if self.nchannel_fitted > 1:
                         chan = self.fitted_channels[c]
                         # get flux and uncertainties for current channel
-                        flux, unc_fit = split([self.flux, self.scatter_array],
-                                              self.nints, chan)
-                        fit = split([full_fit, ], self.nints, chan)[0]
+                        flux, unc_fit, fit = split(
+                            [self.flux, self.scatter_array, full_fit],
+                            self.nints, chan)
                     else:
                         chan = 0
                         # get flux and uncertainties for current channel
@@ -564,14 +563,19 @@ class CompositePyMC3Model(PyMC3Model):
         else:
             nchan = 1
 
+        if eval:
+            lib = np.ma
+        else:
+            lib = tt
+
         if self.multwhite:
             time = self.time
             if channel is not None:
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, channel)[0]
-            flux = np.ones(len(time))
+            flux = lib.ones(len(time))
         else:
-            flux = np.ones(len(self.time)*nchan)
+            flux = lib.ones(len(self.time)*nchan)
 
         # Evaluate flux of each component
         for component in self.components:
@@ -615,14 +619,19 @@ class CompositePyMC3Model(PyMC3Model):
         else:
             nchan = 1
 
+        if eval:
+            lib = np.ma
+        else:
+            lib = tt
+
         if self.multwhite:
             time = self.time
             if channel is not None:
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, channel)[0]
-            flux = np.ones(len(time))
+            flux = lib.ones(len(time))
         else:
-            flux = np.ones(len(self.time)*nchan)
+            flux = lib.ones(len(self.time)*nchan)
 
         # Evaluate flux at each model
         for component in self.components:
@@ -665,14 +674,19 @@ class CompositePyMC3Model(PyMC3Model):
         else:
             nchan = 1
 
+        if eval:
+            lib = np.ma
+        else:
+            lib = tt
+
         if self.multwhite:
             time = self.time
             if channel is not None:
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, channel)[0]
-            flux = np.zeros(len(time))
+            flux = lib.zeros(len(time))
         else:
-            flux = np.zeros(len(self.time)*nchan)
+            flux = lib.zeros(len(self.time)*nchan)
 
         # Evaluate flux
         for component in self.components:
@@ -718,6 +732,11 @@ class CompositePyMC3Model(PyMC3Model):
             nchan = 1
             channels = [channel]
 
+        if eval:
+            lib = np.ma
+        else:
+            lib = tt
+
         if interp:
             if self.multwhite:
                 new_time = []
@@ -748,9 +767,9 @@ class CompositePyMC3Model(PyMC3Model):
 
         # Setup the flux array
         if self.multwhite:
-            flux = np.ones(len(new_time))
+            flux = lib.ones(len(new_time))
         else:
-            flux = np.ones(len(new_time)*nchan)
+            flux = lib.ones(len(new_time)*nchan)
 
         # Evaluate flux at each model
         for component in self.components:

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/SinusoidPhaseCurve.py
@@ -144,11 +144,11 @@ class SinusoidPhaseCurveModel(PyMC3Model):
             # Compute orbital phase
             if model.ecc == 0.:
                 # the planet is on a circular orbit
-                t = self.time - model.t0 - model.per/2.
+                t = time - model.t0 - model.per/2.
                 phi = 2.*np.pi/model.per*t
             else:
                 # the planet is on an eccentric orbit
-                anom = true_anomaly(model, lib, self.time)
+                anom = true_anomaly(model, lib, time)
                 phi = anom + model.w*np.pi/180. + np.pi/2.
 
             for order in range(1, self.maxOrder+1):

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/SinusoidPhaseCurve.py
@@ -155,7 +155,7 @@ class SinusoidPhaseCurveModel(PyMC3Model):
                 if self.nchannel_fitted == 1 or chan == 0:
                     suffix = ''
                 else:
-                    suffix = f'_{chan}'
+                    suffix = f'_ch{chan}'
                 AmpCos = getattr(model, f'AmpCos{order}{suffix}', 0)
                 AmpSin = getattr(model, f'AmpSin{order}{suffix}', 0)
                 phaseVars += (AmpCos*(lib.cos(order*phi)-1.) +

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
@@ -111,9 +111,9 @@ class StarryModel(PyMC3Model):
         self.rps = []
         for c in range(self.nchannel_fitted):
             # To save ourselves from tonnes of getattr lines, let's make a
-            # new object without the _c parts of the parnames
+            # new object without the _ch# parts of the parnames
             # For example, this way we can do `temp.u1` rather than
-            # `getattr(self.model, 'u1_'+c)`.
+            # `getattr(self.model, 'u1_ch'+c)`.
             temp = temp_class()
             for key in self.paramtitles:
                 ptype = getattr(self.parameters, key).ptype
@@ -122,7 +122,7 @@ class StarryModel(PyMC3Model):
                     # Remove the _c part of the parname but leave any
                     # other underscores intact
                     setattr(temp, key, getattr(self.model,
-                                               key+'_'+str(c)))
+                                               key+'_ch'+str(c)))
                 else:
                     setattr(temp, key, getattr(self.model, key))
 
@@ -293,9 +293,9 @@ class StarryModel(PyMC3Model):
         self.fit_rps = []
         for c in range(self.nchannel_fitted):
             # To save ourselves from tonnes of getattr lines, let's make a
-            # new object without the _c parts of the parnames
+            # new object without the _ch# parts of the parnames
             # For example, this way we can do `temp.u1` rather than
-            # `getattr(self.model, 'u1_'+c)`.
+            # `getattr(self.fit, 'u1_ch'+c)`.
             temp = temp_class()
             for key in self.paramtitles:
                 ptype = getattr(self.parameters, key).ptype
@@ -303,7 +303,7 @@ class StarryModel(PyMC3Model):
                         and c > 0):
                     # Remove the _c part of the parname but leave any
                     # other underscores intact
-                    setattr(temp, key, getattr(self.fit, key+'_'+str(c)))
+                    setattr(temp, key, getattr(self.fit, key+'_ch'+str(c)))
                 else:
                     setattr(temp, key, getattr(self.fit, key))
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
@@ -115,16 +115,14 @@ class StarryModel(PyMC3Model):
             # For example, this way we can do `temp.u1` rather than
             # `getattr(self.model, 'u1_ch'+c)`.
             temp = temp_class()
-            for key in self.paramtitles:
-                ptype = getattr(self.parameters, key).ptype
-                if (ptype not in ['fixed', 'independent']
-                        and c > 0):
-                    # Remove the _c part of the parname but leave any
+            for key in self.model.named_vars.keys():
+                channum = key.split('_ch')[-1].split('_')[0]
+                if ((channum.isnumeric() and int(channum) == c)
+                        or not channum.isnumeric()):
+                    # Remove the _ch part of the parname but leave any
                     # other underscores intact
-                    setattr(temp, key, getattr(self.model,
-                                               key+'_ch'+str(c)))
-                else:
-                    setattr(temp, key, getattr(self.model, key))
+                    name = key.split('_ch')[0]
+                    setattr(temp, name, getattr(self.model, key))
 
             # Solve Keplerian orbital period equation for system mass
             # (otherwise starry is going to mess with P or a...)
@@ -297,15 +295,14 @@ class StarryModel(PyMC3Model):
             # For example, this way we can do `temp.u1` rather than
             # `getattr(self.fit, 'u1_ch'+c)`.
             temp = temp_class()
-            for key in self.paramtitles:
-                ptype = getattr(self.parameters, key).ptype
-                if (ptype not in ['fixed', 'independent', 'shared']
-                        and c > 0):
-                    # Remove the _c part of the parname but leave any
+            for key in self.fit.__dict__.keys():
+                channum = key.split('_ch')[-1].split('_')[0]
+                if ((channum.isnumeric() and int(channum) == c)
+                        or not channum.isnumeric()):
+                    # Remove the _ch part of the parname but leave any
                     # other underscores intact
-                    setattr(temp, key, getattr(self.fit, key+'_ch'+str(c)))
-                else:
-                    setattr(temp, key, getattr(self.fit, key))
+                    name = key.split('_ch')[0]
+                    setattr(temp, name, getattr(self.fit, key))
 
             # Solve Keplerian orbital period equation for system mass
             # (otherwise starry is going to mess with P or a...)

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StepModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StepModel.py
@@ -77,9 +77,9 @@ class StepModel(PyMC3Model):
                         steps[c][i] = getattr(model, f'step{i}')
                         steptimes[c][i] = getattr(model, f'steptime{i}')
                     else:
-                        steps[c][i] = getattr(model, f'step{i}_{chan}')
+                        steps[c][i] = getattr(model, f'step{i}_ch{chan}')
                         steptimes[c][i] = getattr(model,
-                                                  f'steptime{i}_{chan}')
+                                                  f'steptime{i}_ch{chan}')
                 except AttributeError:
                     pass
 

--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -285,10 +285,9 @@ def emceefitter(lc, model, meta, log, **kwargs):
         +/- 1 sigma, all params
     """
     # Group the different variable types
-    freenames, freepars, prior1, prior2, priortype, indep_vars = \
+    freenames = lc.freenames
+    freepars, prior1, prior2, priortype, indep_vars = \
         group_variables(model)
-    if hasattr(meta, 'old_fitparams') and meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
     ndim = len(freenames)
 
     if hasattr(meta, 'old_chain') and meta.old_chain is not None:
@@ -339,8 +338,9 @@ def emceefitter(lc, model, meta, log, **kwargs):
                                     args=(lc, model, prior1, prior2,
                                           priortype, freenames),
                                     pool=pool)
-    log.writelog('Running emcee burn-in...')
+    log.writelog('Running emcee sampler...')
     sampler.run_mcmc(pos, meta.run_nsteps, progress=True)
+    # log.writelog('Running emcee burn-in...')
     # state = sampler.run_mcmc(pos, meta.run_nsteps, progress=True)
     # # Log some details about the burn-in phase
     # acceptance_fraction = np.mean(sampler.acceptance_fraction)
@@ -778,10 +778,9 @@ def dynestyfitter(lc, model, meta, log, **kwargs):
         +/- 1 sigma, all params
     """
     # Group the different variable types
-    freenames, freepars, prior1, prior2, priortype, indep_vars = \
+    freenames = lc.freenames
+    freepars, prior1, prior2, priortype, indep_vars = \
         group_variables(model)
-    if hasattr(meta, 'old_fitparams') and meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
 
     # DYNESTY
     nlive = meta.run_nlive  # number of live points
@@ -970,9 +969,10 @@ def lmfitter(lc, model, meta, log, **kwargs):
     # TODO: Do something so that duplicate param names can all be handled
     # (e.g. two Polynomail models with c0). Perhaps append something to the
     # parameter name like c0_1 and c0_2?)
+    freenames = lc.freenames
 
     # Group the different variable types
-    param_list, freenames, indep_vars = group_variables_lmfit(model)
+    param_list, indep_vars = group_variables_lmfit(model)
 
     # Add the time as an independent variable
     indep_vars['time'] = lc.time

--- a/src/eureka/S5_lightcurve_fitting/gradient_fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/gradient_fitters.py
@@ -8,7 +8,7 @@ except:
     pass
 from astropy import table
 
-from .likelihood import computeRedChiSq
+from .likelihood import computeRedChiSq, update_uncertainty
 from . import plots_s5 as plots
 from .fitters import group_variables, load_old_fitparams, save_fit
 from ..lib.split_channels import get_trim
@@ -47,15 +47,14 @@ def exoplanetfitter(lc, model, meta, log, calling_function='exoplanet',
         Initial version.
     """
     # Group the different variable types
-    freenames, freepars, prior1, prior2, priortype, indep_vars = \
-        group_variables(model)
+    freepars = group_variables(model)[0]
     if hasattr(meta, 'old_fitparams') and meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
+        freepars = load_old_fitparams(meta, log, lc.channel, lc.freenames)
 
     model.setup(lc.time, lc.flux, lc.unc)
 
     start = {}
-    for name, val in zip(freenames, freepars):
+    for name, val in zip(lc.freenames, freepars):
         start[name] = val
     model.update(freepars)
 
@@ -73,39 +72,24 @@ def exoplanetfitter(lc, model, meta, log, calling_function='exoplanet',
         map_soln = pmx.optimize(start=start)
 
     # Get the best fit params
-    fit_params = np.array([map_soln[name] for name in freenames])
+    fit_params = np.array([map_soln[name] for name in lc.freenames])
     model.update(fit_params)
+    lc.unc_fit = update_uncertainty(fit_params, lc.nints, lc.unc, lc.freenames,
+                                    lc.nchannel_fitted)
 
-    if "scatter_ppm" in freenames:
-        ind = [i for i in np.arange(len(freenames))
-               if freenames[i][0:11] == "scatter_ppm"]
-        for chan in range(len(ind)):
-            trim1, trim2 = get_trim(meta.nints, chan)
-            lc.unc_fit[trim1:trim2] = fit_params[ind[chan]]*1e-6
-    elif "scatter_mult" in freenames:
-        ind = [i for i in np.arange(len(freenames))
-               if freenames[i][0:12] == "scatter_mult"]
-        if not hasattr(lc, 'unc_fit'):
-            lc.unc_fit = copy.deepcopy(lc.unc)
-        for chan in range(len(ind)):
-            trim1, trim2 = get_trim(meta.nints, chan)
-            lc.unc_fit[trim1:trim2] = fit_params[ind[chan]]*lc.unc[trim1:trim2]
-    else:
-        lc.unc_fit = lc.unc
-
-    t_results = table.Table([freenames, fit_params],
+    t_results = table.Table([lc.freenames, fit_params],
                             names=("Parameter", "Mean"))
 
     # Save the fit ASAP
-    save_fit(meta, lc, model, calling_function, t_results, freenames)
+    save_fit(meta, lc, model, calling_function, t_results, lc.freenames)
 
     # Compute reduced chi-squared
-    chi2red = computeRedChiSq(lc, log, model, meta, freenames)
+    chi2red = computeRedChiSq(lc, log, model, meta, lc.freenames)
 
     log.writelog('\nEXOPLANET RESULTS:')
-    for i in range(len(freenames)):
-        if 'scatter_mult' in freenames[i]:
-            chan = freenames[i].split('_')[-1]
+    for i in range(len(lc.freenames)):
+        if 'scatter_mult' in lc.freenames[i]:
+            chan = lc.freenames[i].split('_ch')[-1].split('_')[0]
             if chan.isnumeric():
                 chan = int(chan)
             else:
@@ -113,9 +97,9 @@ def exoplanetfitter(lc, model, meta, log, calling_function='exoplanet',
             trim1, trim2 = get_trim(meta.nints, chan)
             unc = np.ma.median(lc.unc[trim1:trim2])
             scatter_ppm = 1e6*fit_params[i]*unc
-            log.writelog(f'{freenames[i]}: {fit_params[i]}; {scatter_ppm} ppm')
+            log.writelog(f'{lc.freenames[i]}: {fit_params[i]}; {scatter_ppm} ppm')
         else:
-            log.writelog(f'{freenames[i]}: {fit_params[i]}')
+            log.writelog(f'{lc.freenames[i]}: {fit_params[i]}')
     log.writelog('')
 
     # Plot fit
@@ -127,7 +111,8 @@ def exoplanetfitter(lc, model, meta, log, calling_function='exoplanet',
         plots.plot_GP_components(lc, model, meta, fitter=calling_function)
 
     # Zoom in on phase variations
-    if (meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames or
+    if (meta.isplots_S5 >= 1 and ('Y10' in lc.freenames or
+                                  'Y11' in lc.freenames or
                                   'sinusoid_pc' in meta.run_myfuncs)):
         plots.plot_phase_variations(lc, model, meta, fitter=calling_function)
 
@@ -177,16 +162,15 @@ def nutsfitter(lc, model, meta, log, **kwargs):
         Initial version.
     """
     # Group the different variable types
-    freenames, freepars, prior1, prior2, priortype, indep_vars = \
-        group_variables(model)
+    freepars = group_variables(model)[0]
     if hasattr(meta, 'old_fitparams') and meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
-    ndim = len(freenames)
+        freepars = load_old_fitparams(meta, log, lc.channel, lc.freenames)
+    ndim = len(lc.freenames)
 
     model.setup(lc.time, lc.flux, lc.unc)
 
     start = {}
-    for name, val in zip(freenames, freepars):
+    for name, val in zip(lc.freenames, freepars):
         start[name] = val
     model.update(freepars)
 
@@ -211,11 +195,11 @@ def nutsfitter(lc, model, meta, log, **kwargs):
 
         # Log detailed convergence and sampling statistics
         log.writelog('\nPyMC3 sampling statistics:', mute=(not meta.verbose))
-        log.writelog(pm.summary(trace, var_names=freenames),
+        log.writelog(pm.summary(trace, var_names=lc.freenames),
                      mute=(not meta.verbose))
         log.writelog('', mute=(not meta.verbose))
 
-    samples = np.hstack([trace[name].reshape(-1, 1) for name in freenames])
+    samples = np.hstack([trace[name].reshape(-1, 1) for name in lc.freenames])
 
     # Record median + percentiles
     q = np.percentile(samples, [16, 50, 84], axis=0)
@@ -224,7 +208,7 @@ def nutsfitter(lc, model, meta, log, **kwargs):
     errs = np.std(samples, axis=0)
 
     # Create table of results
-    t_results = table.Table([freenames, mean_params, q[0]-q[1], q[2]-q[1],
+    t_results = table.Table([lc.freenames, mean_params, q[0]-q[1], q[2]-q[1],
                              q[0], fit_params, q[2]],
                             names=("Parameter", "Mean", "-1sigma", "+1sigma",
                                    "16th", "50th", "84th"))
@@ -233,34 +217,19 @@ def nutsfitter(lc, model, meta, log, **kwargs):
     lower_errs = q[1]-q[0]
 
     model.update(fit_params)
-    model.errs = dict(zip(freenames, errs))
-    if "scatter_ppm" in freenames:
-        ind = [i for i in np.arange(len(freenames))
-               if freenames[i][0:11] == "scatter_ppm"]
-        for chan in range(len(ind)):
-            trim1, trim2 = get_trim(meta.nints, chan)
-            lc.unc_fit[trim1:trim2] = fit_params[ind[chan]]*1e-6
-    elif "scatter_mult" in freenames:
-        ind = [i for i in np.arange(len(freenames))
-               if freenames[i][0:12] == "scatter_mult"]
-        if not hasattr(lc, 'unc_fit'):
-            lc.unc_fit = copy.deepcopy(lc.unc)
-        for chan in range(len(ind)):
-            trim1, trim2 = get_trim(meta.nints, chan)
-            lc.unc_fit[trim1:trim2] = fit_params[ind[chan]]*lc.unc[trim1:trim2]
-    else:
-        lc.unc_fit = lc.unc
+    lc.unc_fit = update_uncertainty(fit_params, lc.nints, lc.unc, lc.freenames,
+                                    lc.nchannel_fitted)
 
     # Save the fit ASAP so plotting errors don't make you lose everything
-    save_fit(meta, lc, model, 'nuts', t_results, freenames, samples)
+    save_fit(meta, lc, model, 'nuts', t_results, lc.freenames, samples)
 
     # Compute reduced chi-squared
-    chi2red = computeRedChiSq(lc, log, model, meta, freenames)
+    chi2red = computeRedChiSq(lc, log, model, meta, lc.freenames)
 
     log.writelog('\nPYMC3 NUTS RESULTS:')
     for i in range(ndim):
-        if 'scatter_mult' in freenames[i]:
-            chan = freenames[i].split('_')[-1]
+        if 'scatter_mult' in lc.freenames[i]:
+            chan = lc.freenames[i].split('_ch')[-1].split('_')[0]
             if chan.isnumeric():
                 chan = int(chan)
             else:
@@ -270,11 +239,11 @@ def nutsfitter(lc, model, meta, log, **kwargs):
             scatter_ppm = 1e6*fit_params[i]*unc
             scatter_ppm_upper = 1e6*upper_errs[i]*unc
             scatter_ppm_lower = 1e6*lower_errs[i]*unc
-            log.writelog(f'{freenames[i]}: {fit_params[i]} (+{upper_errs[i]},'
+            log.writelog(f'{lc.freenames[i]}: {fit_params[i]} (+{upper_errs[i]},'
                          f' -{lower_errs[i]}); {scatter_ppm} '
                          f'(+{scatter_ppm_upper}, -{scatter_ppm_lower}) ppm')
         else:
-            log.writelog(f'{freenames[i]}: {fit_params[i]} (+{upper_errs[i]},'
+            log.writelog(f'{lc.freenames[i]}: {fit_params[i]} (+{upper_errs[i]},'
                          f' -{lower_errs[i]})')
     log.writelog('')
 
@@ -287,7 +256,8 @@ def nutsfitter(lc, model, meta, log, **kwargs):
         plots.plot_GP_components(lc, model, meta, fitter='nuts')
 
     # Zoom in on phase variations
-    if (meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames or
+    if (meta.isplots_S5 >= 1 and ('Y10' in lc.freenames or
+                                  'Y11' in lc.freenames or
                                   'sinusoid_pc' in meta.run_myfuncs)):
         plots.plot_phase_variations(lc, model, meta, fitter='nuts')
 
@@ -300,10 +270,10 @@ def nutsfitter(lc, model, meta, log, **kwargs):
         plots.plot_res_distr(lc, model, meta, fitter='nuts')
 
         # Plot trace evolution
-        plots.plot_trace(trace, model, lc, freenames, meta)
+        plots.plot_trace(trace, model, lc, lc.freenames, meta)
 
     if meta.isplots_S5 >= 5:
-        plots.plot_corner(samples, lc, meta, freenames, fitter='nuts')
+        plots.plot_corner(samples, lc, meta, lc.freenames, fitter='nuts')
 
     # Make a new model instance
     model.chi2red = chi2red

--- a/src/eureka/S5_lightcurve_fitting/lightcurve.py
+++ b/src/eureka/S5_lightcurve_fitting/lightcurve.py
@@ -160,12 +160,6 @@ class LightCurve(m.Model):
         - Dec 29, 2021 Taylor Bell
             Updated documentation and reduced repeated code
         """
-        if fitter not in ['exoplanet', 'nuts']:
-            # Make sure the model is a CompositeModel
-            if not isinstance(model, m.CompositeModel):
-                model = m.CompositeModel([model])
-                model.time = self.time
-
         if fitter == 'lmfit':
             self.fitter_func = fitters.lmfitter
         elif fitter == 'lsq':

--- a/src/eureka/S5_lightcurve_fitting/lightcurve.py
+++ b/src/eureka/S5_lightcurve_fitting/lightcurve.py
@@ -8,12 +8,12 @@ from . import fitters
 from . import gradient_fitters
 from .utils import COLORS, color_gen
 from ..lib import plots, util
-from ..lib.split_channels import split
+from ..lib.split_channels import get_trim, split
 
 
 class LightCurve(m.Model):
     def __init__(self, time, flux, channel, nchannel, log, longparamlist,
-                 parameters, unc=None, time_units='BJD',
+                 parameters, freenames, unc=None, time_units='BJD',
                  name='My Light Curve', share=False, white=False,
                  multwhite=False, nints=[], **kwargs):
         """
@@ -33,9 +33,11 @@ class LightCurve(m.Model):
             The open log in which notes from this step can be added.
         unc : sequence
             The uncertainty on the flux
-        parameters : str or object
-            The orbital parameters of the star/planet system,
-            may be a path to a JSON file or a parameter object.
+        parameters : eureka.lib.readEPF.Parameters
+            The Parameters object containing the fitted parameters
+            and their priors.
+        freenames : list
+            The specific names of all fitted parameters (e.g., including _ch#)
         time_units : str; optional
             The time units.
         name : str; optional
@@ -77,6 +79,7 @@ class LightCurve(m.Model):
         self.nchannel = nchannel
         self.multwhite = multwhite
         self.nints = nints
+        self.freenames = freenames
         if self.share or self.multwhite:
             self.nchannel_fitted = self.nchannel
             self.fitted_channels = np.arange(self.nchannel)
@@ -109,9 +112,20 @@ class LightCurve(m.Model):
         self.unc_fit = np.ma.copy(self.unc)
 
         if hasattr(parameters, 'scatter_mult'):
-            self.unc_fit *= parameters.scatter_mult.value
+            for chan in range(self.nchannel_fitted):
+                trim1, trim2 = get_trim(nints, chan)
+                name = 'scatter_mult'
+                if chan > 0:
+                    name += f'_ch{chan}'
+                self.unc_fit[trim1:trim2] *= getattr(parameters, name).value
         elif hasattr(parameters, 'scatter_ppm'):
-            self.unc_fit[:] = parameters.scatter_ppm.value/1e6
+            for chan in range(self.nchannel_fitted):
+                trim1, trim2 = get_trim(nints, chan)
+                name = 'scatter_ppm'
+                if chan > 0:
+                    name += f'_ch{chan}'
+                self.unc_fit[trim1:trim2] *= \
+                    getattr(parameters, name).value/1e6
 
         # Place to save the fit results
         self.results = []

--- a/src/eureka/S5_lightcurve_fitting/likelihood.py
+++ b/src/eureka/S5_lightcurve_fitting/likelihood.py
@@ -83,7 +83,8 @@ def ln_like(theta, lc, model, freenames):
     """
     model.update(theta)
     model_lc = model.eval()
-    lc.unc_fit = update_uncertainty(theta, lc.nints, lc.unc, freenames, lc.nchannel_fitted)
+    lc.unc_fit = update_uncertainty(theta, lc.nints, lc.unc, freenames,
+                                    lc.nchannel_fitted)
 
     if model.GP:
         ln_like_val = 0

--- a/src/eureka/S5_lightcurve_fitting/likelihood.py
+++ b/src/eureka/S5_lightcurve_fitting/likelihood.py
@@ -5,7 +5,7 @@ from scipy.stats import norm
 from ..lib.split_channels import get_trim
 
 
-def update_uncertainty(theta, nints, unc, freenames):
+def update_uncertainty(theta, nints, unc, freenames, nchannel_fitted):
     """Compute updated uncertainty array when inflating errors during fitting.
 
     Parameters
@@ -18,6 +18,8 @@ def update_uncertainty(theta, nints, unc, freenames):
         The initial guessed uncertainty array.
     freenames : list
         The names of the fitted parameters.
+    nchannel_fitted : int
+        The total number of fitted channels.
 
     Returns
     -------
@@ -27,18 +29,24 @@ def update_uncertainty(theta, nints, unc, freenames):
     # Make a copy so we don't edit in place
     unc_fit = copy.deepcopy(unc)
 
-    if "scatter_ppm" in freenames:
-        ind = [i for i in np.arange(len(freenames))
-               if freenames[i][0:11] == "scatter_ppm"]
-        for chan in range(len(ind)):
+    if "scatter_mult" in freenames:
+        for chan in range(nchannel_fitted):
             trim1, trim2 = get_trim(nints, chan)
-            unc_fit[trim1:trim2] = theta[ind[chan]]*1e-6
-    elif "scatter_mult" in freenames:
-        ind = [i for i in range(len(freenames))
-               if freenames[i][0:12] == "scatter_mult"]
-        for chan in range(len(ind)):
+            if chan > 0 and f'scatter_mult_ch{chan}' in freenames:
+                loc = np.where(f'scatter_mult_ch{chan}' == np.array(freenames))
+            else:
+                loc = np.where('scatter_mult' == np.array(freenames))
+            scatter_mult = theta[loc]
+            unc_fit[trim1:trim2] *= scatter_mult
+    elif "scatter_ppm" in freenames:
+        for chan in range(nchannel_fitted):
             trim1, trim2 = get_trim(nints, chan)
-            unc_fit[trim1:trim2] = theta[ind[chan]]*unc[trim1:trim2]
+            if chan > 0 and f'scatter_ppm_ch{chan}' in freenames:
+                loc = np.where(f'scatter_ppm_ch{chan}' == np.array(freenames))
+            else:
+                loc = np.where('scatter_ppm' == np.array(freenames))
+            scatter_ppm = theta[loc]
+            unc_fit[trim1:trim2] = scatter_ppm*1e-6
 
     return unc_fit
 
@@ -75,7 +83,7 @@ def ln_like(theta, lc, model, freenames):
     """
     model.update(theta)
     model_lc = model.eval()
-    lc.unc_fit = update_uncertainty(theta, lc.nints, lc.unc, freenames)
+    lc.unc_fit = update_uncertainty(theta, lc.nints, lc.unc, freenames, lc.nchannel_fitted)
 
     if model.GP:
         ln_like_val = 0

--- a/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .Model import Model
-from ...lib.split_channels import split
+from ...lib.split_channels import split, get_trim
 
 
 class CentroidModel(Model):
@@ -52,15 +52,15 @@ class CentroidModel(Model):
         if self.centroid is not None:
             # Convert to local centroid
             if self.multwhite:
-                self.centroid_local = np.ma.zeros(0)
+                self.centroid_local = np.ma.zeros(self.centroid.shape)
                 for chan in self.fitted_channels:
                     # Split the arrays that have lengths
                     # of the original time axis
-                    centroid = split([self.centroid, ], self.nints, chan)[0]
-                    self.centroid_local = np.ma.append(
-                        self.centroid_local, centroid-np.ma.mean(centroid))
+                    trim1, trim2 = get_trim(self.nints, chan)
+                    centroid = self.centroid[trim1:trim2]
+                    self.centroid_local[trim1:trim2] = centroid - centroid.mean()
             else:
-                self.centroid_local = self.centroid - np.ma.mean(self.centroid)
+                self.centroid_local = self.centroid - self.centroid.mean()
 
     def eval(self, channel=None, **kwargs):
         """Evaluate the function with the given values.

--- a/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
@@ -37,7 +37,7 @@ class CentroidModel(Model):
         self.axis = kwargs.get('axis')
         self.centroid = kwargs.get('centroid')
 
-        self.coeff_keys = [f'{self.axis}_{c}' if c > 0 else self.axis
+        self.coeff_keys = [f'{self.axis}_ch{c}' if c > 0 else self.axis
                            for c in range(self.nchannel_fitted)]
 
     @property

--- a/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
@@ -58,7 +58,7 @@ class CentroidModel(Model):
                     # of the original time axis
                     trim1, trim2 = get_trim(self.nints, chan)
                     centroid = self.centroid[trim1:trim2]
-                    self.centroid_local[trim1:trim2] = centroid - centroid.mean()
+                    self.centroid_local[trim1:trim2] = centroid-centroid.mean()
             else:
                 self.centroid_local = self.centroid - self.centroid.mean()
 

--- a/src/eureka/S5_lightcurve_fitting/models/DampedOscillator.py
+++ b/src/eureka/S5_lightcurve_fitting/models/DampedOscillator.py
@@ -77,7 +77,7 @@ class DampedOscillatorModel(Model):
             self.time = kwargs.get('time')
 
         # Set all parameters
-        lcfinal = np.array([])
+        lcfinal = np.ma.masked_array([])
         for c in range(nchan):
             if self.nchannel_fitted > 1:
                 chan = channels[c]
@@ -100,6 +100,6 @@ class DampedOscillatorModel(Model):
             osc = 1 + amp * np.sin(2 * np.pi * (time - params.osc_t1) / per)
             osc[time < params.osc_t0] = 1
 
-            lcfinal = np.append(lcfinal, osc)
+            lcfinal = np.ma.append(lcfinal, osc)
 
         return lcfinal

--- a/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
@@ -81,7 +81,7 @@ class ExpRampModel(Model):
                         self.coeffs[c, i] = self.parameters.dict[f'r{i}'][0]
                     else:
                         self.coeffs[c, i] = \
-                            self.parameters.dict[f'r{i}_{chan}'][0]
+                            self.parameters.dict[f'r{i}_ch{chan}'][0]
                 except KeyError:
                     pass
 

--- a/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
@@ -45,8 +45,8 @@ class ExpRampModel(Model):
     @time.setter
     def time(self, time_array):
         """A setter for the time."""
-        self._time = np.ma.masked_invalid(time_array)
-        if self.time is not None:
+        if time_array is not None:
+            self._time = np.ma.masked_invalid(time_array)
             # Convert to local time
             if self.multwhite:
                 self.time_local = np.ma.zeros(self.time.shape)

--- a/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .Model import Model
 from ...lib.readEPF import Parameters
-from ...lib.split_channels import split
+from ...lib.split_channels import split, get_trim
 
 
 class ExpRampModel(Model):
@@ -45,17 +45,17 @@ class ExpRampModel(Model):
     @time.setter
     def time(self, time_array):
         """A setter for the time."""
-        self._time = time_array
+        self._time = np.ma.masked_invalid(time_array)
         if self.time is not None:
             # Convert to local time
             if self.multwhite:
-                self.time_local = []
+                self.time_local = np.ma.zeros(self.time.shape)
                 for chan in self.fitted_channels:
                     # Split the arrays that have lengths
                     # of the original time axis
-                    time = split([self.time, ], self.nints, chan)[0]
-                    self.time_local.extend(time - time[0])
-                self.time_local = np.array(self.time_local)
+                    trim1, trim2 = get_trim(self.nints, chan)
+                    time = self.time[trim1:trim2]
+                    self.time_local[trim1:trim2] = time - time[0]
             else:
                 self.time_local = self.time - self.time[0]
 

--- a/src/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -90,7 +90,7 @@ class GPModel(Model):
             if chan == 0:
                 chankey = ''
             else:
-                chankey = f'_{chan}'
+                chankey = f'_ch{chan}'
 
             for i, par in enumerate(['A', 'm']):
                 for k in range(self.nkernels):
@@ -110,7 +110,7 @@ class GPModel(Model):
         super().update(newparams, **kwargs)
 
         self.unc_fit = update_uncertainty(newparams, self.nints, self.unc,
-                                          self.freenames)
+                                          self.freenames, self.nchannel_fitted)
 
     def eval(self, fit, channel=None, gp=None, **kwargs):
         """Compute GP with the given parameters

--- a/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
@@ -82,7 +82,7 @@ class HSTRampModel(Model):
                         self.coeffs[c, i] = self.parameters.dict[f'h{i}'][0]
                     else:
                         self.coeffs[c, i] = \
-                            self.parameters.dict[f'h{i}_{chan}'][0]
+                            self.parameters.dict[f'h{i}_ch{chan}'][0]
                 except KeyError:
                     pass
 

--- a/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
@@ -46,17 +46,17 @@ class HSTRampModel(Model):
     @time.setter
     def time(self, time_array):
         """A setter for the time."""
-        self._time = time_array
+        self._time = np.ma.masked_invalid(time_array)
         if self.time is not None:
             # Convert to local time
             if self.multwhite:
-                self.time_local = []
+                self.time_local = np.ma.zeros(self.time.shape)
                 for chan in self.fitted_channels:
                     # Split the arrays that have lengths
                     # of the original time axis
-                    time = split([self.time, ], self.nints, chan)[0]
-                    self.time_local.extend(time - time[0])
-                self.time_local = np.array(self.time_local)
+                    trim1, trim2 = get_trim(self.nints, chan)
+                    time = self.time[trim1:trim2]
+                    self.time_local[trim1:trim2] = time - time[0]
             else:
                 self.time_local = self.time - self.time[0]
 

--- a/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .Model import Model
 from ...lib.readEPF import Parameters
-from ...lib.split_channels import split
+from ...lib.split_channels import split, get_trim
 
 
 class HSTRampModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/LorentzianModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/LorentzianModel.py
@@ -79,7 +79,7 @@ class LorentzianModel(Model):
             self.time = kwargs.get('time')
 
         # Set all parameters
-        lcfinal = np.array([])
+        lcfinal = np.ma.masked_array([])
         for c in range(nchan):
             if self.nchannel_fitted > 1:
                 chan = channels[c]
@@ -98,11 +98,11 @@ class LorentzianModel(Model):
 
             if (params.lor_hwhm is None) and (params.lor_amp is None):
                 # Determine left and right halves of asymmetric Lorentzian
-                lhs = np.where(time <= t0)
-                rhs = np.where(time > t0)
+                lhs = np.ma.where(time <= t0)
+                rhs = np.ma.where(time > t0)
                 # Compute asymmetric Lorentzian with baseline offset
-                ut = np.zeros_like(time)
-                lorentzian = np.zeros_like(time)
+                ut = np.ma.zeros(time.shape)
+                lorentzian = np.ma.zeros(time.shape)
                 ut[lhs] = (t0-time[lhs])/params.lor_hwhm_lhs
                 ut[rhs] = (time[rhs]-t0)/params.lor_hwhm_rhs
                 lorentzian[lhs] = 1 + params.lor_amp_lhs/(1 + ut[lhs]**p)
@@ -112,10 +112,10 @@ class LorentzianModel(Model):
                     (params.lor_amp_lhs is None) and \
                     (params.lor_amp_rhs is None):
                 # Determine left and right halves of asymmetric Lorentzian
-                lhs = np.where(time <= t0)
-                rhs = np.where(time > t0)
+                lhs = np.ma.where(time <= t0)
+                rhs = np.ma.where(time > t0)
                 # Compute asymmetric Lorentzian with constant baseline
-                ut = np.zeros_like(time)
+                ut = np.ma.zeros(time.shape)
                 ut[lhs] = (time[lhs]-t0)/params.lor_hwhm_lhs
                 ut[rhs] = (time[rhs]-t0)/params.lor_hwhm_rhs
                 lorentzian = 1 + params.lor_amp_lhs/(1 + ut**p)
@@ -135,6 +135,6 @@ class LorentzianModel(Model):
                                 "3. lor_amp_lhs, lor_amp_rhs, lor_hwhm_lhs, "
                                 "lor_hwhm_rhs.")
 
-            lcfinal = np.append(lcfinal, lorentzian)
+            lcfinal = np.ma.append(lcfinal, lorentzian)
 
         return lcfinal

--- a/src/eureka/S5_lightcurve_fitting/models/PolynomialModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/PolynomialModel.py
@@ -82,7 +82,7 @@ class PolynomialModel(Model):
                             self.parameters.dict[f'c{i}'][0]
                     else:
                         self.coeffs[c, 9-i] = \
-                            self.parameters.dict[f'c{i}_{chan}'][0]
+                            self.parameters.dict[f'c{i}_ch{chan}'][0]
                 except KeyError:
                     pass
 

--- a/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
@@ -170,22 +170,37 @@ class SinusoidPhaseCurveModel(Model):
                     w = bm_params.w
                     phi = anom + w*np.pi/180. + np.pi/2.
 
+                if self.force_positivity:
+                    # Check a finely sampled phase range
+                    phi2 = np.linspace(0, 2*np.pi, 1000)
+
                 # calculate the phase variations
                 if bm_params.AmpCos2 == 0. and bm_params.AmpSin2 == 0.:
                     # Skip multiplying by a bunch of zeros to speed up fitting
                     phaseVars = (1. + bm_params.AmpCos1*(np.ma.cos(phi)-1.) +
                                  bm_params.AmpSin1*np.ma.sin(phi))
+                    if self.force_positivity:
+                        phaseVars2 = (1
+                                      + bm_params.AmpCos1*(np.ma.cos(phi2)-1.)
+                                      + bm_params.AmpSin1*np.ma.sin(phi2))
                 else:
                     phaseVars = (1. + bm_params.AmpCos1*(np.ma.cos(phi)-1.) +
                                  bm_params.AmpSin1*np.ma.sin(phi) +
                                  bm_params.AmpCos2*(np.ma.cos(2.*phi)-1.) +
                                  bm_params.AmpSin2*np.ma.sin(2.*phi))
+                    if self.force_positivity:
+                        phaseVars2 = (1
+                                      + bm_params.AmpCos1*(np.ma.cos(phi2)-1)
+                                      + bm_params.AmpSin1*np.ma.sin(phi2)
+                                      + bm_params.AmpCos2*(np.ma.cos(2*phi2)-1)
+                                      + bm_params.AmpSin2*np.ma.sin(2*phi2))
 
                 # If requested, force positive phase variations
-                if self.force_positivity and np.ma.any(phaseVars < 0):
+                if self.force_positivity and np.ma.any(phaseVars2 <= 0):
                     # Returning nans or infs breaks the fits, so this was
                     # the best I could think of
-                    phaseVars = 1e12*np.ma.ones(time.shape)
+                    light_curve = 1e6*np.ma.ones(time.shape)
+                    continue
 
                 if self.eclipse_model is None:
                     eclipse = 1

--- a/src/eureka/S5_lightcurve_fitting/models/StepModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/StepModel.py
@@ -106,7 +106,7 @@ class StepModel(Model):
             self.time = kwargs.get('time')
 
         # Create the ramp from the coeffs
-        lcfinal = np.ones((nchan, len(self.time)))
+        lcfinal = np.ma.ones((nchan, len(self.time)))
         for c in range(nchan):
             if self.nchannel_fitted > 1:
                 chan = channels[c]

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -961,6 +961,7 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
                                        nints=lc_model.nints)
     else:
         model = m.CompositeModel(modellist, parameters=params, time=time,
+                                 freenames=freenames,
                                  nchannel=chanrng,
                                  nchannel_fitted=nchannel_fitted,
                                  fitted_channels=fitted_channels,

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -1093,7 +1093,7 @@ def make_longparamlist(meta, params, chanrng):
                 name += f'_ch{c}'
             longparamlist[c].append(name)
             if (name not in params.dict.keys() and
-                    getattr(params, param).ptype == 'free'):
+                    getattr(params, param).ptype != 'shared'):
                 # Set this parameter based on channel 0's parameter
                 params.__setattr__(name, params.dict[param])
 

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -1094,8 +1094,9 @@ def make_longparamlist(meta, params, chanrng):
                 name += f'_ch{c}'
             longparamlist[c].append(name)
             if (name not in params.dict.keys() and
-                    getattr(params, param).ptype != 'shared'):
-                # Set this parameter based on channel 0's parameter
+                    getattr(params, param).ptype not in ['shared',
+                                                         'independent']):
+                # Set this parameter based on channel 0
                 params.__setattr__(name, params.dict[param])
 
     freenames = [key for key in params.dict.keys()
@@ -1105,11 +1106,11 @@ def make_longparamlist(meta, params, chanrng):
     freenames_sorted = []
     for name in paramtitles:
         for c in range(nspecchan):
-            channelkey = ''
-            if c>0:
-                channelkey += f'_ch{c}'
-            if name+channelkey in freenames:
-                freenames_sorted.append(name+channelkey)
+            key = ''
+            if c > 0:
+                key += f'_ch{c}'
+            if name+key in freenames:
+                freenames_sorted.append(name+key)
 
     return longparamlist, paramtitles, freenames_sorted
 

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -498,7 +498,14 @@ def parse_unshared_saves(meta, log, fit_methods):
     for channel in range(meta.nspecchan):
         ch_number = str(channel).zfill(len(str(meta.nspecchan)))
         channel_key = f'ch{ch_number}'
-        meta = parse_s5_saves(meta, log, fit_methods, channel_key)
+        try:
+            meta = parse_s5_saves(meta, log, fit_methods, channel_key)
+        except FileNotFoundError:
+            # This channel was skipped or was all masked.
+            # Insert NaNs in its place.
+            spectrum_median.extend([np.nan,])
+            spectrum_err.extend([[np.nan, np.nan]])
+            continue
         if meta.spectrum_median is None:
             # Parameter wasn't found, so don't keep looking for it
             meta.spectrum_median = np.array([None for _ in

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -267,7 +267,7 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                     elif meta.y_param_basic == 'fn':
                         # Nightside emission
                         suffix = planetSuffix+channelSuffix
-                        meta.y_label = ('$F_{\\rm p'+suffix +',night'
+                        meta.y_label = ('$F_{\\rm p'+suffix + ',night'
                                         '}/F_{\\rm *}$')
                     elif meta.y_param_basic == 't0':
                         # Time of transit

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -247,69 +247,72 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                 elif meta.y_param_basic in ['1/r1', '1/r4']:
                     meta = compute_timescale(meta)
 
+                planetSuffix = getPlanetSuffix(meta)
+                channelSuffix = getChannelSuffix(meta)
+
                 if meta.y_label is None:
                     # Provide some default formatting
                     if meta.y_param_basic in ['rp^2', 'rprs^2']:
                         # Transit depth
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = '$(R_{\\rm p'+suffix+'}/R_{\\rm *})^2$'
                     elif meta.y_param_basic in ['rp', 'rprs']:
                         # Radius ratio
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = '$R_{\\rm p'+suffix+'}/R_{\\rm *}$'
                     elif meta.y_param_basic in ['fp', 'fpfs']:
                         # Eclipse depth
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
-                        meta.y_label = '$F_{\\rm p,day'+suffix+'}/F_{\\rm *}$'
+                        suffix = planetSuffix+channelSuffix
+                        meta.y_label = '$F_{\\rm p'+suffix+',day}/F_{\\rm *}$'
                     elif meta.y_param_basic == 'fn':
                         # Nightside emission
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
-                        meta.y_label = ('$F_{\\rm p,night'+suffix +
+                        suffix = planetSuffix+channelSuffix
+                        meta.y_label = ('$F_{\\rm p'+suffix +',night'
                                         '}/F_{\\rm *}$')
                     elif meta.y_param_basic == 't0':
                         # Time of transit
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = '$t_{\\rm 0'+suffix+'}$'
                     elif meta.y_param_basic == 'AmpSin1':
                         # Sine amplitude
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = 'Amplitude of $\\sin(\\phi)$'+suffix
                     elif meta.y_param_basic == 'AmpSin2':
                         # Sine2 amplitude
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = 'Amplitude of $\\sin(2\\phi)$'+suffix
                     elif meta.y_param_basic == 'AmpCos1':
                         # Cosine amplitude
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = 'Amplitude of $\\cos(\\phi)$'+suffix
                     elif meta.y_param_basic == 'AmpCos2':
                         # Cosine2 amplitude
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = 'Amplitude of $\\cos(2\\phi)$'+suffix
                     elif meta.y_param_basic == 'pc_offset':
                         # Phase Curve Offset, first order
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = 'Phase Curve Offset'+suffix
                         if meta.y_label_unit is None:
                             meta.y_label_unit = '($^{\\circ}$E)'
                     elif meta.y_param_basic == 'pc_amp':
                         # Phase Curve Amplitude, first order
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = 'Phase Curve Amplitude'+suffix
                     elif meta.y_param_basic == 'pc_offset2':
                         # Phase Curve Offset, second order
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = 'Second Order Phase Curve Offset'+suffix
                         if meta.y_label_unit is None:
                             meta.y_label_unit = '($^{\\circ}$E)'
                     elif meta.y_param_basic == 'pc_amp2':
                         # Phase Curve Amplitude, second order
-                        suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
+                        suffix = planetSuffix+channelSuffix
                         meta.y_label = ('Second Order Phase Curve Amplitude' +
                                         suffix)
                     elif meta.y_param_basic in [f'u{i}' for i in range(1, 5)]:
                         # Limb darkening parameter
-                        suffix = getChannelSuffix(meta)
+                        suffix = channelSuffix
                         meta.y_label = '$u_{\\rm '+meta.y_param_basic[-1]+'}$'
                         # Figure out which limb darkening law was used
                         epf_name = glob(meta.inputdir+'*.epf')[0]
@@ -324,17 +327,17 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                         meta.y_label += ' for '+limb_law+suffix
                     elif meta.y_param_basic in [f'c{i}' for i in range(0, 10)]:
                         # Polynomial in time coefficient
-                        suffix = getChannelSuffix(meta)
+                        suffix = channelSuffix
                         meta.y_label = ('$c_{\\rm '+meta.y_param_basic[1:] +
                                         '}$'+suffix)
                     elif meta.y_param_basic in [f'r{i}' for i in range(6)]:
                         # Exponential ramp parameters
-                        suffix = getChannelSuffix(meta)
+                        suffix = channelSuffix
                         meta.y_label = ('$r_{\\rm '+meta.y_param_basic[1:] +
                                         '}$'+suffix)
                     elif meta.y_param_basic in ['1/r1', '1/r4']:
                         # Exponential ramp timescales
-                        suffix = getChannelSuffix(meta)
+                        suffix = channelSuffix
                         meta.y_label = ('$1/r_{\\rm '+meta.y_param_basic[-1] +
                                         '}$'+suffix)
                     else:

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -189,12 +189,16 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                  meta.y_label, meta.y_label_unit) = vals
                 log.writelog(f'Plotting {meta.y_param}...')
 
-                meta.y_param_basic = meta.y_param.split('_pl')[0].split('_ch')[0].split('^')[0]
+                meta.y_param_basic = meta.y_param.split('_pl')[0]
+                meta.y_param_basic = meta.y_param_basic.split('_ch')[0]
+                meta.y_param_basic = meta.y_param_basic.split('^')[0]
                 if meta.y_param[-2:] == '^2':
                     meta.y_param_basic += '^2'
 
                 # Figure out which channel we're working with
-                channelNumber = meta.y_param.split('_ch')[-1].split('_pl')[0].split('^')[0]
+                channelNumber = meta.y_param.split('_ch')[-1]
+                channelNumber = channelNumber.split('_pl')[0]
+                channelNumber = channelNumber.split('^')[0]
                 if channelNumber.isnumeric():
                     channelNumber = int(channelNumber)
                 else:
@@ -202,7 +206,9 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                 meta.channelNumber = channelNumber
 
                 # Figure out which planet we're working with
-                planetNumber = meta.y_param.split('_pl')[-1].split('_ch')[0].split('^')[0]
+                planetNumber = meta.y_param.split('_pl')[-1]
+                planetNumber = planetNumber.split('_ch')[0]
+                planetNumber = planetNumber.split('^')[0]
                 if planetNumber.isnumeric():
                     planetNumber = int(planetNumber)
                 else:
@@ -258,7 +264,8 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                     elif meta.y_param_basic == 'fn':
                         # Nightside emission
                         suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
-                        meta.y_label = '$F_{\\rm p,night'+suffix+'}/F_{\\rm *}$'
+                        meta.y_label = ('$F_{\\rm p,night'+suffix +
+                                        '}/F_{\\rm *}$')
                     elif meta.y_param_basic == 't0':
                         # Time of transit
                         suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
@@ -298,7 +305,8 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                     elif meta.y_param_basic == 'pc_amp2':
                         # Phase Curve Amplitude, second order
                         suffix = getPlanetSuffix(meta)+getChannelSuffix(meta)
-                        meta.y_label = 'Second Order Phase Curve Amplitude'+suffix
+                        meta.y_label = ('Second Order Phase Curve Amplitude' +
+                                        suffix)
                     elif meta.y_param_basic in [f'u{i}' for i in range(1, 5)]:
                         # Limb darkening parameter
                         suffix = getChannelSuffix(meta)
@@ -317,15 +325,18 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                     elif meta.y_param_basic in [f'c{i}' for i in range(0, 10)]:
                         # Polynomial in time coefficient
                         suffix = getChannelSuffix(meta)
-                        meta.y_label = '$c_{\\rm '+meta.y_param_basic[1:]+'}$'+suffix
+                        meta.y_label = ('$c_{\\rm '+meta.y_param_basic[1:] +
+                                        '}$'+suffix)
                     elif meta.y_param_basic in [f'r{i}' for i in range(6)]:
                         # Exponential ramp parameters
                         suffix = getChannelSuffix(meta)
-                        meta.y_label = '$r_{\\rm '+meta.y_param_basic[1:]+'}$'+suffix
+                        meta.y_label = ('$r_{\\rm '+meta.y_param_basic[1:] +
+                                        '}$'+suffix)
                     elif meta.y_param_basic in ['1/r1', '1/r4']:
                         # Exponential ramp timescales
                         suffix = getChannelSuffix(meta)
-                        meta.y_label = '$1/r_{\\rm '+meta.y_param_basic[-1]+'}$'+suffix
+                        meta.y_label = ('$1/r_{\\rm '+meta.y_param_basic[-1] +
+                                        '}$'+suffix)
                     else:
                         meta.y_label = meta.y_param
 
@@ -1124,8 +1135,10 @@ def compute_fn_starry(meta, log, fit_methods, nsamp=1e3):
         for ell in range(1, meta.ydeg+1):
             for m in range(-ell, ell+1):
                 if hasattr(temp, f'Y{ell}{m}{suffix}'):
-                    planet_map[ell, m, :] = getattr(temp, f'Y{ell}{m}{suffix}')[i]
-                    planet_map2[ell, m, :] = getattr(temp, f'Y{ell}{m}{suffix}')[i]
+                    planet_map[ell, m, :] = getattr(temp,
+                                                    f'Y{ell}{m}{suffix}')[i]
+                    planet_map2[ell, m, :] = getattr(temp,
+                                                     f'Y{ell}{m}{suffix}')[i]
         planet_map.amp = fp[i][inds]/planet_map2.flux(theta=0)[0]
 
         fluxes = planet_map.flux(theta=180)[0].eval()

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -187,14 +187,33 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
             for vals in zipped_vals:
                 (meta.y_param, meta.y_scalar,
                  meta.y_label, meta.y_label_unit) = vals
-
                 log.writelog(f'Plotting {meta.y_param}...')
+
+                # Figure out which channel we're working with
+                channelNumber = meta.y_param.split('_ch')[-1].split('_pl')[0].split('^')[0]
+                if channelNumber.isnumeric():
+                    channelNumber = int(channelNumber)
+                else:
+                    channelNumber = 0
+                meta.channelNumber = channelNumber
+
+                # Figure out which planet we're working with
+                planetNumber = meta.y_param.split('_pl')[-1].split('_ch')[0].split('^')[0]
+                if planetNumber.isnumeric():
+                    planetNumber = int(planetNumber)
+                else:
+                    planetNumber = 0
+                meta.planetNumber = planetNumber
+
+                meta.y_param_basic = meta.y_param.split('_pl')[0].split('_ch')[0].split('^')[0]
+                if meta.y_param[-2:] == '^2':
+                    meta.y_param_basic += '^2'
 
                 meta.spectrum_median = None
                 meta.spectrum_err = None
 
                 # Read in S5 fitted values
-                if meta.y_param == 'fn':
+                if meta.y_param_basic == 'fn':
                     # Compute nightside flux
                     meta = compute_fn(meta, log, fit_methods)
                 elif 'pc_offset' in meta.y_param:
@@ -216,28 +235,28 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                     continue
 
                 # Manipulate fitted values if needed
-                if meta.y_param == 'rp^2' or meta.y_param == 'rprs^2':
+                if meta.y_param_basic in ['rp^2', 'rprs^2']:
                     meta = compute_transit_depth(meta)
-                elif meta.y_param in ['1/r1', '1/r4']:
+                elif meta.y_param_basic in ['1/r1', '1/r4']:
                     meta = compute_timescale(meta)
 
                 if meta.y_label is None:
                     # Provide some default formatting
-                    if meta.y_param == 'rp^2' or meta.y_param == 'rprs^2':
+                    if meta.y_param_basic in ['rp^2', 'rprs^2']:
                         # Transit depth
                         meta.y_label = r'$(R_{\rm p}/R_{\rm *})^2$'
-                    elif meta.y_param == 'rp' or meta.y_param == 'rprs':
+                    elif meta.y_param_basic in ['rp', 'rprs']:
                         # Radius ratio
                         meta.y_label = r'$R_{\rm p}/R_{\rm *}$'
-                    elif meta.y_param == 'fp' or meta.y_param == 'fpfs':
+                    elif meta.y_param_basic in ['fp', 'fpfs']:
                         # Eclipse depth
                         meta.y_label = r'$F_{\rm p,day}/F_{\rm *}$'
-                    elif meta.y_param == 'fn':
+                    elif meta.y_param_basic == 'fn':
                         # Nightside emission
                         meta.y_label = r'$F_{\rm p,night}/F_{\rm *}$'
-                    elif meta.y_param in [f'u{i}' for i in range(1, 5)]:
+                    elif meta.y_param_basic in [f'u{i}' for i in range(1, 5)]:
                         # Limb darkening parameter
-                        meta.y_label = r'$u_{\rm '+meta.y_param[-1]+'}$'
+                        meta.y_label = r'$u_{\rm '+meta.y_param_basic[-1]+'}$'
                         # Figure out which limb darkening law was used
                         epf_name = glob(meta.inputdir+'*.epf')[0]
                         with open(epf_name, 'r') as file:
@@ -249,46 +268,46 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                         if limb_law == 'kipping2013':
                             limb_law = 'Kipping (2013)'
                         meta.y_label += ' for '+limb_law
-                    elif meta.y_param == 't0':
+                    elif meta.y_param_basic == 't0':
                         # Time of transit
                         meta.y_label = r'$t_{\rm 0}$'
-                    elif meta.y_param == 'AmpSin1':
+                    elif meta.y_param_basic == 'AmpSin1':
                         # Sine amplitude
                         meta.y_label = r'Amplitude of $\sin(\phi)$'
-                    elif meta.y_param == 'AmpSin2':
+                    elif meta.y_param_basic == 'AmpSin2':
                         # Sine2 amplitude
                         meta.y_label = r'Amplitude of $\sin(2\phi)$'
-                    elif meta.y_param == 'AmpCos1':
+                    elif meta.y_param_basic == 'AmpCos1':
                         # Cosine amplitude
                         meta.y_label = r'Amplitude of $\cos(\phi)$'
-                    elif meta.y_param == 'AmpCos2':
+                    elif meta.y_param_basic == 'AmpCos2':
                         # Cosine2 amplitude
                         meta.y_label = r'Amplitude of $\cos(2\phi)$'
-                    elif meta.y_param == 'pc_offset':
+                    elif meta.y_param_basic == 'pc_offset':
                         # Phase Curve Offset, first order
                         meta.y_label = 'Phase Curve Offset'
                         if meta.y_label_unit is None:
                             meta.y_label_unit = r'($^{\circ}$E)'
-                    elif meta.y_param == 'pc_amp':
+                    elif meta.y_param_basic == 'pc_amp':
                         # Phase Curve Amplitude, first order
                         meta.y_label = 'Phase Curve Amplitude'
-                    elif meta.y_param == 'pc_offset2':
+                    elif meta.y_param_basic == 'pc_offset2':
                         # Phase Curve Offset, second order
                         meta.y_label = ('Second Order Phase Curve Offset')
                         if meta.y_label_unit is None:
                             meta.y_label_unit = r'($^{\circ}$E)'
-                    elif meta.y_param == 'pc_amp2':
+                    elif meta.y_param_basic == 'pc_amp2':
                         # Phase Curve Amplitude, second order
                         meta.y_label = ('Second Order Phase Curve Amplitude')
-                    elif meta.y_param in [f'c{i}' for i in range(0, 10)]:
+                    elif meta.y_param_basic in [f'c{i}' for i in range(0, 10)]:
                         # Polynomial in time coefficient
-                        meta.y_label = r'$c_{\rm '+meta.y_param[1:]+'}$'
-                    elif meta.y_param in [f'r{i}' for i in range(6)]:
+                        meta.y_label = r'$c_{\rm '+meta.y_param_basic[1:]+'}$'
+                    elif meta.y_param_basic in [f'r{i}' for i in range(6)]:
                         # Exponential ramp parameters
-                        meta.y_label = r'$r_{\rm '+meta.y_param[1:]+'}$'
-                    elif meta.y_param in ['1/r1', '1/r4']:
+                        meta.y_label = r'$r_{\rm '+meta.y_param_basic[1:]+'}$'
+                    elif meta.y_param_basic in ['1/r1', '1/r4']:
                         # Exponential ramp timescales
-                        meta.y_label = r'$1/r_{\rm '+meta.y_param[-1]+'}$'
+                        meta.y_label = r'$1/r_{\rm '+meta.y_param_basic[-1]+'}$'
                     else:
                         meta.y_label = meta.y_param
 
@@ -335,7 +354,7 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                                             'planet_Rad', 'planet_Mass',
                                             'star_Rad', 'planet_R0']])
                 make_fig6301 = (meta.isplots_S6 >= 3 and has_requirements and
-                                meta.y_param in ['rp', 'rp^2'])
+                                meta.y_param[:2] == 'rp')
                 if make_fig6301:
                     # Make spectrum plot with scale height on the 2nd y-axis
                     scale_height = compute_scale_height(meta, log)
@@ -387,11 +406,9 @@ def parse_s5_saves(meta, log, fit_methods, channel_key='shared'):
     errs
         The uncertainties from a sampling algorithm like dynesty or emcee.
     """
-    if meta.y_param == 'rp^2':
-        y_param = 'rp'
-    elif meta.y_param == 'rprs^2':
-        y_param = 'rprs'
-    elif meta.y_param in ['1/r1', '1/r4']:
+    if meta.y_param_basic in ['rp^2', 'rprs^2']:
+        y_param = meta.y_param[:-2]
+    elif meta.y_param_basic in ['1/r1', '1/r4']:
         y_param = meta.y_param[2:]
     else:
         y_param = meta.y_param
@@ -587,7 +604,7 @@ def convert_s5_LC(meta, log):
         niter = 1
     else:
         niter = meta.nspecchan
-    wavelengths = meta.wavelengths
+    wavelengths = np.unique(meta.wavelengths)
     lc_array_setup = False
     for ch in range(niter):
         # Get the channel key
@@ -724,17 +741,22 @@ def compute_offset(meta, log, fit_methods, nsamp=1e4):
     y_param = meta.y_param
 
     # Figure out the desired order
-    suffix = meta.y_param[-1]
-
-    if not suffix.isnumeric():
+    orderSuffix = meta.y_param[-1]
+    if not orderSuffix.isnumeric():
         # First order doesn't have a numeric suffix
-        suffix = '1'
+        orderSuffix = '1'
+
+    suffix = ''
+    if meta.planetNumber > 0:
+        suffix += f'_pl{meta.planetNumber}'
+    if meta.channelNumber > 0:
+        suffix += f'_ch{meta.channelNumber}'
 
     # Load sine amplitude
-    meta.y_param = 'AmpSin'+suffix
+    meta.y_param = 'AmpSin'+orderSuffix+suffix
     ampsin = load_s5_saves(meta, log, fit_methods)
     if np.all(ampsin == 0):
-        meta.y_param = f'Y{suffix}1'
+        meta.y_param = f'Y{orderSuffix}1{suffix}'
         ampsin = -load_s5_saves(meta, log, fit_methods)
         if np.all(ampsin == 0):
             # The parameter could not be found - skip it
@@ -744,10 +766,10 @@ def compute_offset(meta, log, fit_methods, nsamp=1e4):
             return meta
 
     # Load cosine amplitude
-    meta.y_param = 'AmpCos'+suffix
+    meta.y_param = 'AmpCos'+orderSuffix+suffix
     ampcos = load_s5_saves(meta, log, fit_methods)
     if np.all(ampcos == 0):
-        meta.y_param = f'Y{suffix}0'
+        meta.y_param = f'Y{orderSuffix}0{suffix}'
         ampcos = load_s5_saves(meta, log, fit_methods)
         if np.all(ampcos == 0):
             # The parameter could not be found - skip it
@@ -764,7 +786,7 @@ def compute_offset(meta, log, fit_methods, nsamp=1e4):
 
     for i in range(meta.nspecchan):
         offsets = -np.arctan2(ampsin[i], ampcos[i])*180/np.pi
-        if suffix == '2':
+        if orderSuffix == '2':
             offsets /= 2
         offset = np.percentile(np.array(offsets), [16, 50, 84])[[1, 2, 0]]
         offset[1] -= offset[0]
@@ -791,14 +813,19 @@ def compute_amp(meta, log, fit_methods):
     y_param = meta.y_param
 
     # Figure out the desired order
-    suffix = meta.y_param[-1]
-
-    if not suffix.isnumeric():
+    orderSuffix = meta.y_param[-1]
+    if not orderSuffix.isnumeric():
         # First order doesn't have a numeric suffix
-        suffix = '1'
+        orderSuffix = '1'
+
+    suffix = ''
+    if meta.planetNumber > 0:
+        suffix += f'_pl{meta.planetNumber}'
+    if meta.channelNumber > 0:
+        suffix += f'_ch{meta.channelNumber}'
 
     # Load eclipse depth
-    meta.y_param = 'fp'
+    meta.y_param = 'fp'+suffix
     fp = load_s5_saves(meta, log, fit_methods)
     if np.all(fp == 0):
         # The parameter could not be found - skip it
@@ -808,10 +835,10 @@ def compute_amp(meta, log, fit_methods):
         return meta
 
     # Load sine amplitude
-    meta.y_param = 'AmpSin'+suffix
+    meta.y_param = 'AmpSin'+orderSuffix+suffix
     ampsin = load_s5_saves(meta, log, fit_methods)
     if np.all(ampsin == 0):
-        meta.y_param = f'Y{suffix}1'
+        meta.y_param = f'Y{orderSuffix}1{suffix}'
         ampsin = -load_s5_saves(meta, log, fit_methods)
         if np.all(ampsin == 0):
             # The parameter could not be found - skip it
@@ -821,10 +848,10 @@ def compute_amp(meta, log, fit_methods):
             return meta
 
     # Load cosine amplitude
-    meta.y_param = 'AmpCos'+suffix
+    meta.y_param = 'AmpCos'+orderSuffix+suffix
     ampcos = load_s5_saves(meta, log, fit_methods)
     if np.all(ampcos == 0):
-        meta.y_param = f'Y{suffix}0'
+        meta.y_param = f'Y{orderSuffix}0{suffix}'
         ampcos = load_s5_saves(meta, log, fit_methods)
         if np.all(ampcos == 0):
             # The parameter could not be found - skip it
@@ -863,8 +890,14 @@ def compute_amp_starry(meta, log, fit_methods, nsamp=1e3):
     # Save meta.y_param
     y_param = meta.y_param
 
+    suffix = ''
+    if meta.planetNumber > 0:
+        suffix += f'_pl{meta.planetNumber}'
+    if meta.channelNumber > 0:
+        suffix += f'_ch{meta.channelNumber}'
+
     # Load eclipse depth
-    meta.y_param = 'fp'
+    meta.y_param = 'fp'+suffix
     fp = load_s5_saves(meta, log, fit_methods)
     if fp.shape[-1] == 0:
         # The parameter could not be found - skip it
@@ -888,10 +921,10 @@ def compute_amp_starry(meta, log, fit_methods, nsamp=1e3):
     temp = temp_class()
     ell = ydeg
     for m in range(-ell, ell+1):
-        meta.y_param = f'Y{ell}{m}'
+        meta.y_param = f'Y{ell}{m}{suffix}'
         val = load_s5_saves(meta, log, fit_methods)
         if val.shape[-1] != 0:
-            setattr(temp, f'Y{ell}{m}', val[:, inds])
+            setattr(temp, f'Y{ell}{m}{suffix}', val[:, inds])
 
     # Reset meta.y_param
     meta.y_param = y_param
@@ -911,9 +944,9 @@ def compute_amp_starry(meta, log, fit_methods, nsamp=1e3):
         inds = np.random.randint(0, len(fp[i]), nsamp)
         ell = ydeg
         for m in range(-ell, ell+1):
-            if hasattr(temp, f'Y{ell}{m}'):
-                planet_map[ell, m, :] = getattr(temp, f'Y{ell}{m}')[i]
-                planet_map2[ell, m, :] = getattr(temp, f'Y{ell}{m}')[i]
+            if hasattr(temp, f'Y{ell}{m}{suffix}'):
+                planet_map[ell, m, :] = getattr(temp, f'Y{ell}{m}{suffix}')[i]
+                planet_map2[ell, m, :] = getattr(temp, f'Y{ell}{m}{suffix}')[i]
         planet_map.amp = fp[i][inds]/planet_map2.flux(theta=0)[0]
 
         theta = np.linspace(0, 359, 360)
@@ -941,16 +974,26 @@ def compute_fn(meta, log, fit_methods):
     if (('nuts' in fit_methods or 'exoplanet' in fit_methods) and
             'sinusoid_pc' not in meta.run_myfuncs):
         return compute_fn_starry(meta, log, fit_methods)
+    elif ('quasilambert_pc' in meta.run_myfuncs):
+        meta.spectrum_median = np.zeros(meta.nspecchan)
+        meta.spectrum_err = np.ones((2, meta.nspecchan))*np.nan
+        return meta
 
     # Save meta.y_param
     y_param = meta.y_param
 
+    suffix = ''
+    if meta.planetNumber > 0:
+        suffix += f'_pl{meta.planetNumber}'
+    if meta.channelNumber > 0:
+        suffix += f'_ch{meta.channelNumber}'
+
     # Load eclipse depth
-    meta.y_param = 'fp'
+    meta.y_param = 'fp'+suffix
     fp = load_s5_saves(meta, log, fit_methods)
     if np.all(fp == 0):
         # The parameter could not be found - try fpfs
-        meta.y_param = 'fpfs'
+        meta.y_param = 'fpfs'+suffix
         fp = load_s5_saves(meta, log, fit_methods)
         if np.all(fp == 0):
             log.writelog('  Planet flux (fp or fpfs) was not in the list of '
@@ -959,7 +1002,7 @@ def compute_fn(meta, log, fit_methods):
             return meta
 
     # Load cosine amplitude
-    meta.y_param = 'AmpCos1'
+    meta.y_param = 'AmpCos1'+suffix
     ampcos = load_s5_saves(meta, log, fit_methods)
     if np.all(ampcos == 0):
         # FINDME: The following only works if the model does not include any
@@ -968,7 +1011,7 @@ def compute_fn(meta, log, fit_methods):
         # use the compute_fp function.
         # FINDME: This is also not the nightside flux for starry models - just
         # the anti-stellar point flux. Really do need to use compute_fp instead
-        meta.y_param = 'Y10'
+        meta.y_param = 'Y10'+suffix
         ampcos = load_s5_saves(meta, log, fit_methods)
         if np.all(ampcos == 0):
             # The parameter could not be found - skip it
@@ -1007,12 +1050,18 @@ def compute_fn_starry(meta, log, fit_methods, nsamp=1e3):
     # Save meta.y_param
     y_param = meta.y_param
 
+    suffix = ''
+    if meta.planetNumber > 0:
+        suffix += f'_pl{meta.planetNumber}'
+    if meta.channelNumber > 0:
+        suffix += f'_ch{meta.channelNumber}'
+
     # Load eclipse depth
-    meta.y_param = 'fp'
+    meta.y_param = 'fp'+suffix
     fp = load_s5_saves(meta, log, fit_methods)
     if fp.shape[-1] == 0:
         # The parameter could not be found - try fpfs
-        meta.y_param = 'fpfs'
+        meta.y_param = 'fpfs'+suffix
         fp = load_s5_saves(meta, log, fit_methods)
         if fp.shape[-1] == 0:
             log.writelog('  Planet flux (fp or fpfs) was not in the list of '
@@ -1033,10 +1082,10 @@ def compute_fn_starry(meta, log, fit_methods, nsamp=1e3):
     temp = temp_class()
     for ell in range(1, meta.ydeg+1):
         for m in range(-ell, ell+1):
-            meta.y_param = f'Y{ell}{m}'
+            meta.y_param = f'Y{ell}{m}{suffix}'
             val = load_s5_saves(meta, log, fit_methods)
             if val.shape[-1] != 0:
-                setattr(temp, f'Y{ell}{m}', val[:, inds])
+                setattr(temp, f'Y{ell}{m}{suffix}', val[:, inds])
 
     # Reset meta.y_param
     meta.y_param = y_param
@@ -1056,9 +1105,9 @@ def compute_fn_starry(meta, log, fit_methods, nsamp=1e3):
         inds = np.random.randint(0, len(fp[i]), nsamp)
         for ell in range(1, meta.ydeg+1):
             for m in range(-ell, ell+1):
-                if hasattr(temp, f'Y{ell}{m}'):
-                    planet_map[ell, m, :] = getattr(temp, f'Y{ell}{m}')[i]
-                    planet_map2[ell, m, :] = getattr(temp, f'Y{ell}{m}')[i]
+                if hasattr(temp, f'Y{ell}{m}{suffix}'):
+                    planet_map[ell, m, :] = getattr(temp, f'Y{ell}{m}{suffix}')[i]
+                    planet_map2[ell, m, :] = getattr(temp, f'Y{ell}{m}{suffix}')[i]
         planet_map.amp = fp[i][inds]/planet_map2.flux(theta=0)[0]
 
         fluxes = planet_map.flux(theta=180)[0].eval()
@@ -1095,7 +1144,7 @@ def compute_scale_height(meta, log):
     """
     if meta.planet_Rad is None:
         meta.planet_Rad = meta.spectrum_median
-        if meta.y_param == 'rp^2' or meta.y_param == 'rprs^2':
+        if meta.y_param_basic in ['rp^2', 'rprs^2']:
             meta.planet_Rad = np.sqrt(meta.planet_Rad)
         meta.planet_Rad = np.nanmean(meta.planet_Rad)
         meta.planet_Rad *= (meta.star_Rad*constants.R_sun /
@@ -1199,12 +1248,12 @@ def load_model(meta, log, x_unit):
     model_x_unit = model_x_unit.to(x_unit, equivalencies=units.spectral())
     model_x *= model_x_unit
     # Figure out if model needs to be converted to Rp/Rs
-    sqrt_model = ((meta.model_y_param == 'rp^2'
-                   or meta.model_y_param == 'rprs^2')
+    sqrt_model = ((meta.model_y_param[:2] == 'rp'
+                   and meta.model_y_param[-2:] == '^2')
                   and meta.model_y_param != meta.y_param)
     # Figure out if model needs to be converted to (Rp/Rs)^2
-    sq_model = ((meta.model_y_param == 'rp'
-                 or meta.model_y_param == 'rprs')
+    sq_model = ((meta.model_y_param[:2] == 'rp'
+                 and meta.model_y_param[-2:] != '^2')
                 and meta.model_y_param != meta.y_param)
     if sqrt_model:
         model_y = np.sqrt(model_y)
@@ -1362,12 +1411,14 @@ def transit_latex_table(meta, log):
     rows = int(np.ceil(nvals/meta.ncols))
 
     # Figure out the labels for the columns
-    if meta.y_param == 'rp^2' or meta.y_param == 'rprs^2':
+    if meta.y_param_basic in ['rp^2', 'rprs^2']:
         colhead = "\\colhead{Transit Depth}"
-    elif meta.y_param == 'rp' or meta.y_param == 'rprs':
+    elif meta.y_param_basic in ['rp', 'rprs']:
         colhead = "\\colhead{$R_{\\rm p}/R_{\\rm *}$}"
-    elif meta.y_param == 'fp' or meta.y_param == 'fpfs':
+    elif meta.y_param_basic in ['fp', 'fpfs']:
         colhead = "\\colhead{Eclipse Depth}"
+    elif meta.y_param_basic in ['fn']:
+        colhead = "\\colhead{Nightside Flux}"
     else:
         colhead = f"\\colhead{{{meta.y_label}}}"
 
@@ -1378,10 +1429,10 @@ def transit_latex_table(meta, log):
         out += "CC|"
     out = out[:-1]+"}\n"
     # Give the table a caption based on the tabulated data
-    if meta.y_param in ['rp', 'rp^2', 'rprs', 'rprs^2']:
+    if meta.y_param_basic in ['rp', 'rp^2', 'rprs', 'rprs^2']:
         out += "\\tablecaption{\\texttt{Eureka!}'s Transit Spectroscopy "
         out += "Results \\label{tab:eureka_transit_spectra}}\n"
-    elif meta.y_param in ['fp', 'fpfs']:
+    elif meta.y_param_basic in ['fp', 'fpfs']:
         out += "\\tablecaption{\\texttt{Eureka!}'s Eclipse Spectroscopy "
         out += "Results \\label{tab:eureka_eclipse_spectra}}\n"
     # Label each column

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -423,7 +423,7 @@ def parse_s5_saves(meta, log, fit_methods, channel_key='shared'):
 
         fname = f'S5_{fitter}_samples_{channel_key}'
 
-        temp_keys = [y_param+f'_{c}' if c > 0 else y_param
+        temp_keys = [y_param+f'_ch{c}' if c > 0 else y_param
                      for c in range(meta.nspecchan)]
         keys = [key for key in temp_keys if key in full_keys]
         if len(keys) == 0:
@@ -448,7 +448,7 @@ def parse_s5_saves(meta, log, fit_methods, channel_key='shared'):
         fitted_values = pd.read_csv(meta.inputdir+fname, escapechar='#',
                                     skipinitialspace=True)
         full_keys = list(fitted_values["Parameter"])
-        temp_keys = [y_param+f'_{c}' if c > 0 else y_param
+        temp_keys = [y_param+f'_ch{c}' if c > 0 else y_param
                      for c in range(meta.nspecchan)]
         keys = [key for key in temp_keys if key in full_keys]
         if len(keys) == 0:

--- a/tests/MIRI_ecfs/POET/s5_POET.epf
+++ b/tests/MIRI_ecfs/POET/s5_POET.epf
@@ -54,4 +54,4 @@ scatter_mult	1				'free'			1.1				0.1			N
 # ---------------------------------------
 # Light travel time correction parameters
 # ---------------------------------------
-Rs			0.697				'independent'
+Rs			0.697				'fixed'

--- a/tests/MIRI_ecfs/s5_fit_par.epf
+++ b/tests/MIRI_ecfs/s5_fit_par.epf
@@ -56,5 +56,4 @@ scatter_mult	1				'free'			0.5				2			U
 # ---------------------------------------
 # Light travel time correction parameters
 # ---------------------------------------
-Rs			0.697				'independent'
-Ms			0.66				'independent'
+Rs			0.697				'fixed'

--- a/tests/MIRI_ecfs/s5_fit_par_starry.epf
+++ b/tests/MIRI_ecfs/s5_fit_par_starry.epf
@@ -54,5 +54,4 @@ scatter_mult	1				'free'			0.5				2			U
 # ---------------------------------------
 # Light travel time correction parameters
 # ---------------------------------------
-Rs			0.697				'independent'
-Ms			0.66				'independent'
+Rs			0.697				'fixed'

--- a/tests/NIRCam_ecfs/POET/S5_POET.epf
+++ b/tests/NIRCam_ecfs/POET/S5_POET.epf
@@ -21,7 +21,6 @@ inc    		82.109	 		'free'			82.109			0.088			N
 ars    		4.97			'free'			4.97			0.14			N
 ecc   		0.0	 			'fixed' 		0 				1				U
 w   		90.				'fixed' 		0 				180				U
-
 # -------------------------
 # ** Limb darkening parameters **
 # Choose limb_dark from ['uniform', 'linear', 'quadratic', 'kipping2013', 'squareroot', 'logarithmic', 'exponential','3-parameter', '4-parameter']

--- a/tests/test_lightcurve_fitting.py
+++ b/tests/test_lightcurve_fitting.py
@@ -80,7 +80,8 @@ class TestModels(unittest.TestCase):
         meta.num_planets = 1
         meta.ld_from_S4 = False
         meta.ld_file = None
-        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
+        longparamlist, paramtitles, freenames = \
+            s5_fit.make_longparamlist(meta, params, 1)
         self.t_model = models.BatmanTransitModel(parameters=params,
                                                  name='transit', fmt='r--',
                                                  freenames=freenames,
@@ -115,7 +116,8 @@ class TestModels(unittest.TestCase):
         meta.sharedp = False
         meta.multwhite = False
         meta.num_planets = 1
-        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
+        longparamlist, paramtitles, freenames = \
+            s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.e_model = models.BatmanEclipseModel(parameters=params,
                                                  name='transit', fmt='r--',
@@ -164,7 +166,8 @@ class TestModels(unittest.TestCase):
         meta.num_planets = 1
         meta.ld_from_S4 = False
         meta.ld_file = None
-        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
+        longparamlist, paramtitles, freenames = \
+            s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_model = models.BatmanTransitModel(parameters=params,
                                                  name='transit', fmt='r--',
@@ -229,7 +232,8 @@ class TestModels(unittest.TestCase):
         meta.num_planets = 1
         meta.ld_from_S4 = False
         meta.ld_file = None
-        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
+        longparamlist, paramtitles, freenames = \
+            s5_fit.make_longparamlist(meta, params, 1)
         self.t_poet_tr = models.PoetTransitModel(parameters=params,
                                                  name='poet_tr', fmt='r--',
                                                  freenames=freenames,
@@ -264,7 +268,8 @@ class TestModels(unittest.TestCase):
         meta.sharedp = False
         meta.multwhite = False
         meta.num_planets = 1
-        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
+        longparamlist, paramtitles, freenames = \
+            s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_poet_ecl = models.PoetEclipseModel(parameters=params,
                                                   name='eclipse', fmt='r--',
@@ -311,7 +316,8 @@ class TestModels(unittest.TestCase):
         meta.num_planets = 1
         meta.ld_from_S4 = False
         meta.ld_file = None
-        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
+        longparamlist, paramtitles, freenames = \
+            s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_model = models.PoetTransitModel(parameters=params,
                                                name='transit', fmt='r--',
@@ -363,7 +369,8 @@ class TestModels(unittest.TestCase):
         meta = MetaClass()
         meta.sharedp = False
         meta.multwhite = False
-        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
+        longparamlist, paramtitles, freenames = \
+            s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_lorentzian = models.LorentzianModel(parameters=params,
                                                    name='transit', fmt='r--',

--- a/tests/test_lightcurve_fitting.py
+++ b/tests/test_lightcurve_fitting.py
@@ -80,12 +80,7 @@ class TestModels(unittest.TestCase):
         meta.num_planets = 1
         meta.ld_from_S4 = False
         meta.ld_file = None
-        longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        freenames = []
-        for key in params.dict:
-            if params.dict[key][1] in ['free', 'shared', 'white_free',
-                                       'white_fixed']:
-                freenames.append(key)
+        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
         self.t_model = models.BatmanTransitModel(parameters=params,
                                                  name='transit', fmt='r--',
                                                  freenames=freenames,
@@ -120,12 +115,7 @@ class TestModels(unittest.TestCase):
         meta.sharedp = False
         meta.multwhite = False
         meta.num_planets = 1
-        longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        freenames = []
-        for key in params.dict:
-            if params.dict[key][1] in ['free', 'shared', 'white_free',
-                                       'white_fixed']:
-                freenames.append(key)
+        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.e_model = models.BatmanEclipseModel(parameters=params,
                                                  name='transit', fmt='r--',
@@ -174,12 +164,7 @@ class TestModels(unittest.TestCase):
         meta.num_planets = 1
         meta.ld_from_S4 = False
         meta.ld_file = None
-        longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        freenames = []
-        for key in params.dict:
-            if params.dict[key][1] in ['free', 'shared', 'white_free',
-                                       'white_fixed']:
-                freenames.append(key)
+        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_model = models.BatmanTransitModel(parameters=params,
                                                  name='transit', fmt='r--',
@@ -244,12 +229,7 @@ class TestModels(unittest.TestCase):
         meta.num_planets = 1
         meta.ld_from_S4 = False
         meta.ld_file = None
-        longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        freenames = []
-        for key in params.dict:
-            if params.dict[key][1] in ['free', 'shared', 'white_free',
-                                       'white_fixed']:
-                freenames.append(key)
+        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
         self.t_poet_tr = models.PoetTransitModel(parameters=params,
                                                  name='poet_tr', fmt='r--',
                                                  freenames=freenames,
@@ -284,12 +264,7 @@ class TestModels(unittest.TestCase):
         meta.sharedp = False
         meta.multwhite = False
         meta.num_planets = 1
-        longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        freenames = []
-        for key in params.dict:
-            if params.dict[key][1] in ['free', 'shared', 'white_free',
-                                       'white_fixed']:
-                freenames.append(key)
+        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_poet_ecl = models.PoetEclipseModel(parameters=params,
                                                   name='eclipse', fmt='r--',
@@ -336,12 +311,7 @@ class TestModels(unittest.TestCase):
         meta.num_planets = 1
         meta.ld_from_S4 = False
         meta.ld_file = None
-        longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        freenames = []
-        for key in params.dict:
-            if params.dict[key][1] in ['free', 'shared', 'white_free',
-                                       'white_fixed']:
-                freenames.append(key)
+        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_model = models.PoetTransitModel(parameters=params,
                                                name='transit', fmt='r--',
@@ -393,12 +363,7 @@ class TestModels(unittest.TestCase):
         meta = MetaClass()
         meta.sharedp = False
         meta.multwhite = False
-        longparamlist, paramtitles = s5_fit.make_longparamlist(meta, params, 1)
-        freenames = []
-        for key in params.dict:
-            if params.dict[key][1] in ['free', 'shared', 'white_free',
-                                       'white_fixed']:
-                freenames.append(key)
+        longparamlist, paramtitles, freenames = s5_fit.make_longparamlist(meta, params, 1)
         log = logedit.Logedit(f'.{os.sep}data{os.sep}test.log')
         self.t_lorentzian = models.LorentzianModel(parameters=params,
                                                    name='transit', fmt='r--',


### PR DESCRIPTION
This PR reformats the fitted variable names in Stage 5 to use _ch# for different channels and _pl# for different planets. This will make the code far more robust since we can far more easily identify the channel and planet number, and this should also help with Stage 6 bugs. It will also make the variable names a bit more human readable, and this PR should also fix multiple bugs related to trying to manually set different priors or fixed values for different channels.

These changes resolve #643

While I was at it, I also added support for ecosw and esinw in astrophysical models which avoids the well known ecc>0 bias of fitting for ecc and w directly.

I still need to fully integrate and test the _pl tags, especially for starry, and I still need to do a bunch of testing. For now I'm just opening a draft PR to help me keep track of my progress, so don't worry about reviewing it until I mark it as ready for review.

Note, this change is going to break backwards compatibility for S6 running on old S5 outputs, but that isn't a huge deal since S6 isn't critical and we're working towards v1.0