### PR TITLE
Fixing our readthedocs pages

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -128,7 +128,10 @@ e.g. ``/Users/your_name/crds_cache`` for Mac users or ``/home/your_name/crds_cac
 
 		export CRDS_SERVER_URL=https://jwst-crds.stsci.edu
 
-If these environment variables are not set, Stages 1-3 of the pipeline will fail.
+In order for your changes to apply, you must close your current terminal(s) and open a new terminal; alternatively, you can instead do ``source ~/.bashrc``
+(changing .bashrc to whichever filename your system uses) within your currently open terminal(s).
+
+If these environment variables are not set, then Stages 1-3 of the pipeline will fail with an error message that says something like ``No such file or directory: '/grp/crds/cache/config/jwst/server_config'``
 
 Issues with installing the jwst dependency
 ------------------------------------------

--- a/docs/source/notebooks.rst
+++ b/docs/source/notebooks.rst
@@ -3,15 +3,14 @@
 Eureka! Tutorial Notebooks
 ==========================
 
-Tutorial notebooks showcasing ``Eureka!`` functionality can be found in the navigation sidebar. 
+Tutorial notebooks showcasing ``Eureka!`` functionality can be found in the navigation sidebar.
 
 You can also download and run these tutorials locally using Jupyter notebook, but please note that some notebook variables, such as directory and file paths, may need adjusting.
 
-At the moment the number of available notebooks is small, but may be expanded in the future. 
+At the moment the number of available notebooks is small, but may be expanded in the future.
 
 .. toctree::
    :maxdepth: 1
    :caption: Tutorial Notebooks
-   :hidden:
 
    tutorials/formatting_eureka_s4_compatible_data.ipynb

--- a/src/eureka/S1_detector_processing/update_saturation.py
+++ b/src/eureka/S1_detector_processing/update_saturation.py
@@ -71,7 +71,7 @@ def update_sat(input_model, log, meta):
         for i in range(ngrp-1):
             new_sat_mask[i, :, :] += new_sat_mask[i+1, :, :]
 
-    # If flags in the first group, raise a warning that columns will not be used
+    # If flags in first group, raise a warning that columns will not be used
     if np.count_nonzero(new_sat_mask[0]) > 0:
         log.writelog('  WARNING:')
         log.writelog('    Saturation found in the first group.')
@@ -93,7 +93,8 @@ def update_sat(input_model, log, meta):
     # Saturation flagging conditions
     # Where our saturation mask is True and dq is not already flagged
     condition = np.where((new_sat_mask) & (input_model.groupdq == 0))
-    full_saturation = np.where((new_sat_mask[0,:,:]==True) & (input_model.groupdq == 0))
+    full_saturation = np.where(new_sat_mask[0, :, :] &
+                               (input_model.groupdq == 0))
     # Now update the groupdq map
     input_model.groupdq[condition] = sat_flag
     input_model.groupdq[full_saturation] = do_not_use_flag

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -501,9 +501,10 @@ def parse_unshared_saves(meta, log, fit_methods):
         try:
             meta = parse_s5_saves(meta, log, fit_methods, channel_key)
         except FileNotFoundError:
-            # This channel was skipped or was all masked. Insert NaNs in its place.
+            # This channel was skipped or was all masked.
+            # Insert NaNs in its place.
             spectrum_median.extend([np.nan,])
-            spectrum_err.extend([[np.nan,np.nan]])
+            spectrum_err.extend([[np.nan, np.nan]])
             continue
         if meta.spectrum_median is None:
             # Parameter wasn't found, so don't keep looking for it


### PR DESCRIPTION
This tiny little PR fixes our Read the Docs pages. Since requiring Python >= 3.10 our docs page has apparently been failing to build since the .readthedocs.yml file was setup to use Python 3.9. I've tested this change and can confirm it resolves the issue.