### PR TITLE
Minor documentation edits to reflect pre-1.0 testing

### DIFF
--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1141,7 +1141,7 @@ This file describes the transit/eclipse and systematics parameters and their pri
          If you only want to fit a single ramp, you can omit ``r3--r5`` or set them as fixed to ``0``.
          Users should not fit all three parameters from each model at the same time as there are significant degeneracies between the ``r0`` and ``r2`` parameters (and ``r3`` and ``r5`` parameters).
          One option is to set ``r0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``r0--r1`` and set ``r2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
-      - ``h0--h5`` - Coefficients for the HST exponential + polynomial ramp model.
+      - ``h0--h6`` - Coefficients for the HST exponential + polynomial ramp model.
 
          The HST ramp model is defined as follows: ``1 + h0*np.exp(-h1*time_batch + h2) + h3*time_batch + h4*time_batch**2``,
          where ``h0--h2`` describe the exponential ramp per HST orbit, ``h3--h4`` describe the polynomial (up to order two) per HST orbit,  ``h5`` is the orbital period of HST (in the same time units as the data, usually days), and ``h6`` is the time offset when computing ``time_batch``.  A good starting point for ``h5`` is 0.066422 days and ``h6`` is 0.03 days.  ``time_batch = (time_local-h6) % h5``.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -119,6 +119,15 @@ Some more permanent solutions would be to:
   An example of this is to change ``export PATH="~/anaconda3/bin:$PATH"`` in your **~/.bashrc** file to ``export PATH="~/anaconda3/bin:~/Library/TeX/texbin:$PATH"``.
   For anyone using Ubuntu or an older version of Mac this might be found in /usr/bin instead. Make sure you run source ~/.bash_profile or source ~/.bashrc to apply the changes.
 
+
+"ERROR: Inconsistent numbers of reads" when running HST analyses
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+HST observations are usually consistent between scans (i.e. all the spatial scans are the same number of reads), but some observations may modify 
+the number of reads in a scan for timing purposes. Ensure that your datasets have scans of consistent length, or exclude the shorter 
+scans at the end of orbits if needed (e.g. by removing those FITS files from your input data directory).
+
+
+
 My question isn't listed here!
 ''''''''''''''''''''''''''''''
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -73,11 +73,12 @@ There are also several optional dependency collections that can be installed wit
 
 In the installation instructions above, the ``jwst`` optional dependency is used as we strongly recommend users run Stages 1 and 2 locally, but we wanted to give users the ability to opt-out of installing the dependencies installed with ``jwst`` if they didn't work on their system.
 
-To install with one or more optional dependency collections, the above examples can be generalized upon. For example, to install with just the ``hst`` dependencies, one can replace ``[jwst]`` with ``[hst]``. Or if you want to install with multiple options, you can do things like ``[jwst,hst]``.
+To install with one or more optional dependency collections, the above examples can be generalized upon. For example, to install with just the ``hst`` dependencies, one can replace ``[jwst]`` with ``[hst]``. Or if you want to install with multiple options, you can do things like ``[jwst,hst]``. 
 
 .. warning::
-	To install the ``pymc3`` optional dependencies, you also need to install ``mkl-service`` which can only be installed from conda using ``conda install mkl-service``.
-
+	To install the ``pymc3`` optional dependencies, you also need to install ``mkl-service`` which can only be installed from conda using ``conda install mkl-service``. 
+	
+	In addition, attempting to specify ``[jwst,pymc3]`` when installing ``Eureka!`` will fail with a dependency conflict, as the newest version of the ``jwst`` pipeline is incompatible with ``pymc3``. Optional NUTS users should only specify ``[pymc3]`` in their installs, which will default to a slightly older version of the ``jwst`` pipeline. Other optional dependencies are currently compatible.
 
 Installing with a ``conda`` environment.yml file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -253,9 +253,8 @@ Note that HST operations start at Stage 3, unlike JWST operations. HST systemati
 can also be slightly more complicated to fit, so it may be worthwhile to read some
 papers discussing these, such as `Knutson et al. (2014) <knutson2014_>`_ or
 `Brande et al. (2022) <brande2022_>`_. Exponential ramps are available as systematics
-models in ``Eureka!`` Stage 5, but the spatial scan model described in
-`Brande et al. (2022) <brande2022_>`_ is forthcoming, so currently only a single
-scan direction will be fit.
+models in ``Eureka!`` Stage 5, and Eureka automatically corrects for the 
+spatial scan flux offset.
 
 
 .. _demo_link: https://github.com/kevin218/Eureka/tree/main/demos

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -242,10 +242,12 @@ download, e.g. ``[60, 61, 62, 63, 64]`` if you want the entire transit
 observation.
 
 .. warning::
-	HST planning is usually consistent between orbits, but may sometimes modify 
-	the number of exposures in a scan for observation timing purposes. Ensure 
-	that your datasets have consistent numbers of exposures, or exclude 
-	trailing exposures at the end of orbits if needed.
+	HST observations are usually consistent between scans (i.e. all the spatial 
+	scans are the same number of reads), but some observations may modify 
+	the number of reads in a scan for timing purposes. Ensure that your 
+	datasets have scans of consistent length, or exclude the shorter 
+	scans at the end of orbits if needed (e.g. by removing those FITS 
+	files from your input data directory).
 
 You'll also need to change the ``final_dir`` variable to a more appropriate
 location for your data, similar to how we made a new directory for the JWST

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -241,6 +241,12 @@ where ``[60]`` can be replaced with a list of the visit numbers you want to
 download, e.g. ``[60, 61, 62, 63, 64]`` if you want the entire transit
 observation.
 
+.. warning::
+	HST planning is usually consistent between orbits, but may sometimes modify 
+	the number of exposures in a scan for observation timing purposes. Ensure 
+	that your datasets have consistent numbers of exposures, or exclude 
+	trailing exposures at the end of orbits if needed.
+
 You'll also need to change the ``final_dir`` variable to a more appropriate
 location for your data, similar to how we made a new directory for the JWST
 data above.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -241,14 +241,6 @@ where ``[60]`` can be replaced with a list of the visit numbers you want to
 download, e.g. ``[60, 61, 62, 63, 64]`` if you want the entire transit
 observation.
 
-.. warning::
-	HST observations are usually consistent between scans (i.e. all the spatial 
-	scans are the same number of reads), but some observations may modify 
-	the number of reads in a scan for timing purposes. Ensure that your 
-	datasets have scans of consistent length, or exclude the shorter 
-	scans at the end of orbits if needed (e.g. by removing those FITS 
-	files from your input data directory).
-
 You'll also need to change the ``final_dir`` variable to a more appropriate
 location for your data, similar to how we made a new directory for the JWST
 data above.

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -670,6 +670,9 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
                 success = xrio.writeXR(meta.filename_S3_SpecData, spec,
                                        verbose=True)
 
+                if not success:
+                    raise OSError('Failed to write S3_SpecData.')
+
             # Compute MAD value
             if not meta.photometry:
                 meta.mad_s3 = util.get_mad(meta, log, spec.wave_1d.values,

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -165,6 +165,12 @@ def conclusion_step(data, meta, log):
     log : logedit.Logedit
         The updated log.
     """
+
+    if len(np.shape(np.array(meta.centroids, dtype=object))) < 2:
+        raise AssertionError("ERROR: Input spectra have inconsistent numbers "
+                             "of reads. Ensure each spatially scanned "
+                             "spectrum is the same size.")
+
     meta.centroids = np.array(meta.centroids)
     meta.guess = np.array(meta.guess)
     meta.subdata_ref = np.array(meta.subdata_ref)


### PR DESCRIPTION
Minor edits, warning users of a dependency conflict that will cause installation to fail when specifying both `jwst` and `pymc3`, as well as one warning users about potential issues with HST spatial scan observations of inconsistent numbers of exposures.