### PR TITLE
Bugfix in HSTRampModel, corrected nchan assignment

### DIFF
--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/HSTRampModel.py
@@ -72,8 +72,8 @@ class HSTRampModel(PyMC3Model):
             The value of the model at the times self.time.
         """
         if channel is None:
-            nchan = self.nchan
-            channels = np.arange(nchan)
+            nchan = self.nchannel_fitted
+            channels = self.fitted_channels
         else:
             nchan = 1
             channels = [channel, ]


### PR DESCRIPTION
There was a bug in the HSTRamp differentiable model, which wasn't updated to the new parameters for setting the number of channels in `eval()`. This was throwing an error in S5 when using `starry` lightcurves. This was only an issue in this model, and the rest of the differentiable models look fine.