### PR TITLE
Bug patches and docs improvements for v1.0

### DIFF
--- a/demos/HST/S5_wfc3_template.ecf
+++ b/demos/HST/S5_wfc3_template.ecf
@@ -44,6 +44,7 @@ run_sample      'auto'
 run_tol         0.1
 
 # PyMC3 NUTS fitter
+exoplanet_first False   # Initialize with an initial exoplanet optimizer call (generally not recommended, but can sometimes be helpful if your initial manual guess is quite poor)
 tune            3000
 draws           1500
 chains          3

--- a/demos/HST/s5_fit_par_wfc3_template.epf
+++ b/demos/HST/s5_fit_par_wfc3_template.epf
@@ -53,8 +53,8 @@ u2           0.1           'free'         0            1            U
 # --------------------
 # ** Systematic variables **
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
-# HST exponential ramp + polynomial model variables (h0--h2 for exponential, h3--h4 for polynomial in time)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
+# HST exponential ramp + polynomial model variables (h0--h1 for exponential, h2--h3 for polynomial in time, h4 is HST orbital period, h5 is a time-offset)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)
@@ -62,9 +62,9 @@ u2           0.1           'free'         0            1            U
 c0           1             'free'         0.95         1.05         U
 h0           0             'free'         -0.1         0.1          U
 h1           10            'free'         0            100          U
-h3           0.0           'fixed'        -1           1            U
-h5           6.6422e-02    'fixed'        6.6422e-02   0.001        N
-h6           0.03          'fixed'        0.03         0.0          N
+h2           0.0           'fixed'        -1           1            U
+h4           6.6422e-02    'fixed'        6.6422e-02   0.001        N
+h5           0.03          'fixed'        0.03         0.0          N
 # -----------
 # ** White noise **
 # Use scatter_mult to fit a multiplier to the expected noise level from Stage 3 (recommended)

--- a/demos/JWST/S5_fit_par_template.epf
+++ b/demos/JWST/S5_fit_par_template.epf
@@ -78,7 +78,7 @@ u2          0.2             'free'          0           1           U
 # --------------------
 # ** Systematic variables **
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)

--- a/demos/JWST/S5_template.ecf
+++ b/demos/JWST/S5_template.ecf
@@ -45,6 +45,7 @@ run_sample      'auto'
 run_tol         0.1
 
 # PyMC3 NUTS fitter
+exoplanet_first False   # Initialize with an initial exoplanet optimizer call (generally not recommended, but can sometimes be helpful if your initial manual guess is quite poor)
 tune            3000
 draws           1500
 chains          3

--- a/docs/media/S5_fit_par_template.epf
+++ b/docs/media/S5_fit_par_template.epf
@@ -78,7 +78,7 @@ u2          0.2             'free'          0           1           U
 # --------------------
 # ** Systematic variables **
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)

--- a/docs/media/S5_template.ecf
+++ b/docs/media/S5_template.ecf
@@ -45,6 +45,7 @@ run_sample      'auto'
 run_tol         0.1
 
 # PyMC3 NUTS fitter
+exoplanet_first False   # Initialize with an initial exoplanet optimizer call (generally not recommended, but can sometimes be helpful if your initial manual guess is quite poor)
 tune            3000
 draws           1500
 chains          3

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1139,16 +1139,17 @@ This file describes the transit/eclipse and systematics parameters and their pri
          The exponential ramp model is defined as follows: ``r0*np.exp(-r1*time_local + r2) + r3*np.exp(-r4*time_local + r5) + 1``,
          where ``r0--r2`` describe the first ramp, and ``r3--r5`` the second. ``time_local`` is the time relative to the first frame of the dataset.
          If you only want to fit a single ramp, you can omit ``r3--r5`` or set them as fixed to ``0``.
-         Users should not fit all three parameters from each model at the same time as there are significant degeneracies between the ``r0`` and ``r2`` parameters (and ``r3`` and ``r5`` parameters).
-         One option is to set ``r0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``r0--r1`` and set ``r2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
+         .. note::
+            Users should not fit all three parameters from each model at the same time as there are significant degeneracies between the ``r0`` and ``r2`` parameters (and ``r3`` and ``r5`` parameters).
+            One option is to set ``r0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``r0--r1`` and set ``r2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
       - ``h0--h5`` - Coefficients for the HST exponential + polynomial ramp model.
 
          The HST ramp model is defined as follows: ``1 + h0*np.exp(-h1*time_batch + h2) + h3*time_batch + h4*time_batch**2``,
          where ``h0--h2`` describe the exponential ramp per HST orbit, ``h3--h4`` describe the polynomial (up to order two) per HST orbit,  ``h5`` is the orbital period of HST (in the same time units as the data, usually days), and ``h6`` is the time offset when computing ``time_batch``.  A good starting point for ``h5`` is 0.066422 days and ``h6`` is 0.03 days.  ``time_batch = (time_local-h6) % h5``.
          If you want to fit a linear trend in time, you can omit ``h4`` or fix it to ``0``.
-         Users should not fit all three parameters from the exponential model at the same time as there are significant degeneracies between the ``h0`` and ``h2`` parameters.
-         One option is to set ``h0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``h0--h1`` and set ``h2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
-
+         .. note::
+            Users should not fit all three parameters from the exponential model at the same time as there are significant degeneracies between the ``h0`` and ``h2`` parameters.
+            One option is to set ``h0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``h0--h1`` and set ``h2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
       - ``step0`` and ``steptime0`` - The step size and time for the first step function (useful for removing mirror segment tilt events).
 
          For additional steps, simply increment the integer at the end (e.g. ``step1`` and ``steptime1``).  The change in flux is relative to the flux from the previous step.

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1000,6 +1000,10 @@ NUTS Fitting Parameters
 '''''''''''''''''''''''
 The following set the parameters for running PyMC3's NUTS sampler. These options are described in more detail in: https://docs.pymc.io/en/v3/api/inference.html#pymc3.sampling.sample
 
+exoplanet_first
+'''''''''''''''
+Boolean to determine whether to run exoplanet optimizer before NUTS. This is generally not recommended, but it can sometimes be helpful if your initial manual guess is quite poor.
+
 tune
 ^^^^
 Number of iterations to tune. Samplers adjust the step sizes, scalings or similar during tuning. Tuning samples will be drawn in addition to the number specified in the draws argument.

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1139,7 +1139,7 @@ This file describes the transit/eclipse and systematics parameters and their pri
          The exponential ramp model is defined as follows: ``r0*np.exp(-r1*time_local + r2) + r3*np.exp(-r4*time_local + r5) + 1``,
          where ``r0--r2`` describe the first ramp, and ``r3--r5`` the second. ``time_local`` is the time relative to the first frame of the dataset.
          If you only want to fit a single ramp, you can omit ``r3--r5`` or set them as fixed to ``0``.
-         .. note::
+         .. warning::
             Users **should not** fit all three parameters from each model at the same time as there are significant degeneracies between the ``r0`` and ``r2`` parameters (and ``r3`` and ``r5`` parameters).
             One option is to set ``r0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``r0--r1`` and set ``r2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
       - ``h0--h5`` - Coefficients for the HST exponential + polynomial ramp model.
@@ -1147,7 +1147,7 @@ This file describes the transit/eclipse and systematics parameters and their pri
          The HST ramp model is defined as follows: ``1 + h0*np.exp(-h1*time_batch + h2) + h3*time_batch + h4*time_batch**2``,
          where ``h0--h2`` describe the exponential ramp per HST orbit, ``h3--h4`` describe the polynomial (up to order two) per HST orbit,  ``h5`` is the orbital period of HST (in the same time units as the data, usually days), and ``h6`` is the time offset when computing ``time_batch``.  A good starting point for ``h5`` is 0.066422 days and ``h6`` is 0.03 days.  ``time_batch = (time_local-h6) % h5``.
          If you want to fit a linear trend in time, you can omit ``h4`` or fix it to ``0``.
-         .. note::
+         .. warning::
             Users **should not** fit all three parameters from the exponential model at the same time as there are significant degeneracies between the ``h0`` and ``h2`` parameters.
             One option is to set ``h0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``h0--h1`` and set ``h2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
       - ``step0`` and ``steptime0`` - The step size and time for the first step function (useful for removing mirror segment tilt events).

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1138,25 +1138,17 @@ This file describes the transit/eclipse and systematics parameters and their pri
          The polynomial coefficients are numbered as increasing powers (i.e. ``c0`` a constant, ``c1`` linear, etc.).
          The x-values of the polynomial are the time with respect to the mean of the time of the lightcurve time array.
          Polynomial fits should include at least ``c0`` for usable results.
-      - ``r0--r2`` and ``r3--r5`` - Coefficients for the first and second exponential ramp models.
+      - ``r0--r1`` and ``r2--r3`` - Coefficients for the first and second exponential ramp models.
 
-         The exponential ramp model is defined as follows: ``r0*np.exp(-r1*time_local + r2) + r3*np.exp(-r4*time_local + r5) + 1``,
-         where ``r0--r2`` describe the first ramp, and ``r3--r5`` the second. ``time_local`` is the time relative to the first frame of the dataset.
-         If you only want to fit a single ramp, you can omit ``r3--r5`` or set them as fixed to ``0``.
+         The exponential ramp model is defined as follows: ``r0*np.exp(-r1*time_local) + r2*np.exp(-r3*time_local) + 1``,
+         where ``r0--r1`` describe the first ramp, and ``r2--r3`` the second. ``time_local`` is the time relative to the first frame of the dataset.
+         If you only want to fit a single ramp, you can omit ``r2--r3`` or set them as fixed to ``0``.
 
-         .. warning::
-            Users **should not** fit all three parameters from each model at the same time as there are significant degeneracies between the ``r0`` and ``r2`` parameters (and ``r3`` and ``r5`` parameters).
-            One option is to set ``r0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``r0--r1`` and set ``r2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
-
-      - ``h0--h6`` - Coefficients for the HST exponential + polynomial ramp model.
+      - ``h0--h5`` - Coefficients for the HST exponential + polynomial ramp model.
 
          The HST ramp model is defined as follows: ``1 + h0*np.exp(-h1*time_batch + h2) + h3*time_batch + h4*time_batch**2``,
-         where ``h0--h2`` describe the exponential ramp per HST orbit, ``h3--h4`` describe the polynomial (up to order two) per HST orbit,  ``h5`` is the orbital period of HST (in the same time units as the data, usually days), and ``h6`` is the time offset when computing ``time_batch``.  A good starting point for ``h5`` is 0.066422 days and ``h6`` is 0.03 days.  ``time_batch = (time_local-h6) % h5``.
-         If you want to fit a linear trend in time, you can omit ``h4`` or fix it to ``0``.
-
-         .. warning::
-            Users **should not** fit all three parameters from the exponential model at the same time as there are significant degeneracies between the ``h0`` and ``h2`` parameters.
-            One option is to set ``h0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``h0--h1`` and set ``h2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
+         where ``h0--h1`` describe the exponential ramp per HST orbit, ``h2--h3`` describe the polynomial (up to order two) per HST orbit, ``h4`` is the orbital period of HST (in the same time units as the data, usually days), and ``h5`` is the time offset when computing ``time_batch``.  A good starting point for ``h4`` is 0.066422 days and ``h5`` is 0.03 days.  ``time_batch = (time_local-h5) % h4``.
+         If you want to fit a linear trend in time, you can omit ``h3`` or fix it to ``0``.
 
       - ``step0`` and ``steptime0`` - The step size and time for the first step function (useful for removing mirror segment tilt events).
 

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1139,17 +1139,21 @@ This file describes the transit/eclipse and systematics parameters and their pri
          The exponential ramp model is defined as follows: ``r0*np.exp(-r1*time_local + r2) + r3*np.exp(-r4*time_local + r5) + 1``,
          where ``r0--r2`` describe the first ramp, and ``r3--r5`` the second. ``time_local`` is the time relative to the first frame of the dataset.
          If you only want to fit a single ramp, you can omit ``r3--r5`` or set them as fixed to ``0``.
+
          .. warning::
             Users **should not** fit all three parameters from each model at the same time as there are significant degeneracies between the ``r0`` and ``r2`` parameters (and ``r3`` and ``r5`` parameters).
             One option is to set ``r0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``r0--r1`` and set ``r2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
+
       - ``h0--h5`` - Coefficients for the HST exponential + polynomial ramp model.
 
          The HST ramp model is defined as follows: ``1 + h0*np.exp(-h1*time_batch + h2) + h3*time_batch + h4*time_batch**2``,
          where ``h0--h2`` describe the exponential ramp per HST orbit, ``h3--h4`` describe the polynomial (up to order two) per HST orbit,  ``h5`` is the orbital period of HST (in the same time units as the data, usually days), and ``h6`` is the time offset when computing ``time_batch``.  A good starting point for ``h5`` is 0.066422 days and ``h6`` is 0.03 days.  ``time_batch = (time_local-h6) % h5``.
          If you want to fit a linear trend in time, you can omit ``h4`` or fix it to ``0``.
+
          .. warning::
             Users **should not** fit all three parameters from the exponential model at the same time as there are significant degeneracies between the ``h0`` and ``h2`` parameters.
             One option is to set ``h0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``h0--h1`` and set ``h2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
+
       - ``step0`` and ``steptime0`` - The step size and time for the first step function (useful for removing mirror segment tilt events).
 
          For additional steps, simply increment the integer at the end (e.g. ``step1`` and ``steptime1``).  The change in flux is relative to the flux from the previous step.

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -1140,7 +1140,7 @@ This file describes the transit/eclipse and systematics parameters and their pri
          where ``r0--r2`` describe the first ramp, and ``r3--r5`` the second. ``time_local`` is the time relative to the first frame of the dataset.
          If you only want to fit a single ramp, you can omit ``r3--r5`` or set them as fixed to ``0``.
          .. note::
-            Users should not fit all three parameters from each model at the same time as there are significant degeneracies between the ``r0`` and ``r2`` parameters (and ``r3`` and ``r5`` parameters).
+            Users **should not** fit all three parameters from each model at the same time as there are significant degeneracies between the ``r0`` and ``r2`` parameters (and ``r3`` and ``r5`` parameters).
             One option is to set ``r0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``r0--r1`` and set ``r2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
       - ``h0--h5`` - Coefficients for the HST exponential + polynomial ramp model.
 
@@ -1148,7 +1148,7 @@ This file describes the transit/eclipse and systematics parameters and their pri
          where ``h0--h2`` describe the exponential ramp per HST orbit, ``h3--h4`` describe the polynomial (up to order two) per HST orbit,  ``h5`` is the orbital period of HST (in the same time units as the data, usually days), and ``h6`` is the time offset when computing ``time_batch``.  A good starting point for ``h5`` is 0.066422 days and ``h6`` is 0.03 days.  ``time_batch = (time_local-h6) % h5``.
          If you want to fit a linear trend in time, you can omit ``h4`` or fix it to ``0``.
          .. note::
-            Users should not fit all three parameters from the exponential model at the same time as there are significant degeneracies between the ``h0`` and ``h2`` parameters.
+            Users **should not** fit all three parameters from the exponential model at the same time as there are significant degeneracies between the ``h0`` and ``h2`` parameters.
             One option is to set ``h0`` to the sign of the ramp (-1 for decaying, 1 for rising) while fitting for the remaining coefficients.  Another option is to fit for ``h0--h1`` and set ``h2`` to zero.  This option works well when fitting spectroscopic light curves that could be rising or decaying.
       - ``step0`` and ``steptime0`` - The step size and time for the first step function (useful for removing mirror segment tilt events).
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,8 +6,8 @@ Installation methods
 --------------------
 
 In order to have consistent, repeatable results across the ``Eureka!`` user community, we recommend that all general users install
-the most recent stable release of ``Eureka!``, v0.10. The following installation instructions are written with this in mind,
-and the most recent stable release is also available as a zipped archive `here <https://github.com/kevin218/Eureka/releases/tag/v0.10>`_.
+the most recent stable release of ``Eureka!``, v1.0. The following installation instructions are written with this in mind,
+and the most recent stable release is also available as a zipped archive `here <https://github.com/kevin218/Eureka/releases/tag/v1.0>`_.
 Also note that if you are using a macOS device with an Apple Silicon processor (e.g., M1), you may need to use the ``conda`` environment.yml file
 installation instructions below as the ``pip`` dependencies have been reported to fail to build on Apple Silicon processors.
 
@@ -31,7 +31,7 @@ Once in your new conda environment, you can install ``Eureka!`` directly from so
 
 .. code-block:: bash
 
-	git clone -b v0.10 https://github.com/kevin218/Eureka.git
+	git clone -b v1.0 https://github.com/kevin218/Eureka.git
 	cd Eureka
 	pip install -e '.[jwst]'
 
@@ -39,7 +39,7 @@ To update your ``Eureka!`` installation to the most recent version, you can do t
 
 .. code-block:: bash
 
-	git pull
+	git checkout v1.0
 	pip install --upgrade '.[jwst]'
 
 Option 2) With ``pip`` only
@@ -49,7 +49,7 @@ Once in your new conda environment, you can install the ``Eureka!`` package with
 
 .. code-block:: bash
 
-	pip install -e 'eureka[jwst]@git+https://github.com/kevin218/Eureka.git@v0.10'
+	pip install -e 'eureka[jwst]@git+https://github.com/kevin218/Eureka.git@v1.0'
 
 Other specific branches can be installed using:
 
@@ -90,7 +90,7 @@ To install using conda:
 
 .. code-block:: bash
 
-	git clone -b v0.10 https://github.com/kevin218/Eureka.git
+	git clone -b v1.0 https://github.com/kevin218/Eureka.git
 	cd Eureka
 	conda env create --file environment.yml --force
 	conda activate eureka
@@ -100,7 +100,7 @@ To update your ``Eureka!`` installation to the most recent version, you can do t
 
 .. code-block:: bash
 
-	git pull
+	git checkout v1.0
 	conda env update --file environment.yml --prune
 	pip install --no-deps --upgrade .
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -24,6 +24,10 @@ new environment by doing:
 	conda create -n eureka python==3.10.14
 	conda activate eureka
 
+Alternatively, if you are following the "Installing with a ``conda`` environment.yml file" instructions below,
+you will not need to manually make a new ``conda`` environment as the ``conda env create --file environment.yml --force``
+line will make a new one for you (or replace your old one if you already had one).
+
 Option 1) With ``git`` and ``pip``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Once in your new conda environment, you can install ``Eureka!`` directly from source on
@@ -35,12 +39,6 @@ Once in your new conda environment, you can install ``Eureka!`` directly from so
 	cd Eureka
 	pip install -e '.[jwst]'
 
-To update your ``Eureka!`` installation to the most recent version, you can do the following within that Eureka folder:
-
-.. code-block:: bash
-
-	git checkout v1.0
-	pip install --upgrade '.[jwst]'
 
 Option 2) With ``pip`` only
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -73,11 +71,11 @@ There are also several optional dependency collections that can be installed wit
 
 In the installation instructions above, the ``jwst`` optional dependency is used as we strongly recommend users run Stages 1 and 2 locally, but we wanted to give users the ability to opt-out of installing the dependencies installed with ``jwst`` if they didn't work on their system.
 
-To install with one or more optional dependency collections, the above examples can be generalized upon. For example, to install with just the ``hst`` dependencies, one can replace ``[jwst]`` with ``[hst]``. Or if you want to install with multiple options, you can do things like ``[jwst,hst]``. 
+To install with one or more optional dependency collections, the above examples can be generalized upon. For example, to install with just the ``hst`` dependencies, one can replace ``[jwst]`` with ``[hst]``. Or if you want to install with multiple options, you can do things like ``[jwst,hst]``.
 
 .. warning::
-	To install the ``pymc3`` optional dependencies, you also need to install ``mkl-service`` which can only be installed from conda using ``conda install mkl-service``. 
-	
+	To install the ``pymc3`` optional dependencies, you also need to install ``mkl-service`` which can only be installed from conda using ``conda install mkl-service``.
+
 	In addition, attempting to specify ``[jwst,pymc3]`` when installing ``Eureka!`` will fail with a dependency conflict, as the newest version of the ``jwst`` pipeline is incompatible with ``pymc3``. Optional NUTS users should only specify ``[pymc3]`` in their installs, which will default to a slightly older version of the ``jwst`` pipeline. Other optional dependencies are currently compatible.
 
 Installing with a ``conda`` environment.yml file
@@ -96,13 +94,12 @@ To install using conda:
 	conda activate eureka
 	pip install --no-deps .
 
-To update your ``Eureka!`` installation to the most recent version, you can do the following within that Eureka folder:
 
-.. code-block:: bash
-
-	git checkout v1.0
-	conda env update --file environment.yml --prune
-	pip install --no-deps --upgrade .
+Upgrading your Eureka! installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The safest and most reliable way of upgrading your Eurkea! installation from one version to another is to start from scratch by creating a new ``conda`` environment
+and installing the new Eureka! version in that fresh environment. Trying to upgrade your Eureka! installation within an existing environment
+(i.e., without first making a new conda environment) can lead to dependency mismatches, and we cannot provide support to users trying to upgrade Eureka! in this manner.
 
 
 Additional ExoTiC-LD Downloads

--- a/environment.yml
+++ b/environment.yml
@@ -43,6 +43,8 @@ dependencies:
         - jwst==1.15.1
         - mc3 # Needed for uncertainties in the Allan variance plots in S5
         - myst-parser # Needed for documentation
+        - numpy>=1.20.0,<=1.23 # Upper limit needed for Apple silicon and for theano, starry, and pymc3
+        - scipy>=1.8.0 # Lower limit needed for scipy.spatial.QhullError
         - setuptools_scm # Needed for version number
         - sphinx-rtd-theme # Needed for documentation
         - stcal>=1.0.0 # Lower limit needed for our create_integration_model function

--- a/src/eureka/S1_detector_processing/s1_meta.py
+++ b/src/eureka/S1_detector_processing/s1_meta.py
@@ -106,10 +106,10 @@ class S1MetaClass(MetaClass):
             if self.bias_correction == 'smooth':
                 # Force this to be specified if bias_correction is 'smooth'
                 self.bias_smooth_length = getattr(self, 'bias_smooth_length')
-            self.custom_bias = getattr(self, 'custom_bias', False)
-            if self.custom_bias:
-                # Force this to be specified if custom_bias is True
-                self.superbias_file = getattr(self, 'superbias_file')
+        self.custom_bias = getattr(self, 'custom_bias', False)
+        if self.custom_bias:
+            # Force this to be specified if custom_bias is True
+            self.superbias_file = getattr(self, 'superbias_file')
 
         # Manually mask groups
         self.mask_groups = getattr(self, 'mask_groups', False)

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -407,7 +407,7 @@ def do_oneoverf_corr(data, meta, i, star_pos_x, log):
         The updated Dataset object after the 1/f correction has been completed.
     """
     if i == 0:
-        log.writelog('Correcting for 1/f noise...', mute=(not meta.verbose))
+        log.writelog('  Correcting for 1/f noise...', mute=(not meta.verbose))
 
     # Let's first determine which amplifier regions are left in the frame.
     # For NIRCam: 4 amplifiers, 512 pixels in x dimension per amplifier

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -1157,7 +1157,8 @@ def phot_2d_frame_oneoverf(data, meta, m, i, flux_w_oneoverf):
     """
     plt.figure(3307)
     plt.clf()
-    fig, ax = plt.subplots(2, 1, num=3307, figsize=(8.2, 4.2), gridspec_kw={'hspace': 0.0})
+    fig, ax = plt.subplots(2, 1, num=3307, figsize=(8.2, 4.2),
+                           gridspec_kw={'hspace': 0.0})
 
     cmap = plt.cm.viridis.copy()
     ax[0].imshow(flux_w_oneoverf, origin='lower',

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -321,7 +321,7 @@ def source_position(meta, x_dim, pos_max, m, n,
         plt.axvline(y_pos, ls='-', label='Weighted Row')
     plt.axvline(pos_max, ls='--', label='Brightest Row', c='C3')
     plt.ylabel('Row Flux')
-    plt.xlabel('Row Pixel Position')
+    plt.xlabel('Row Relative Pixel Position')
     plt.legend()
 
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -1207,7 +1207,12 @@ def phot_2d_frame_diff(data, meta):
     - 2022-08-02 Sebastian Zieba
         Initial version
     """
-    for i in range(meta.nplots-1):
+    nplots = meta.nplots
+    if nplots == meta.n_int:
+        # Need to reduce by 1 since we're doing differences
+        nplots -= 1
+
+    for i in range(nplots):
         plt.figure(3505)
         plt.clf()
         flux1 = data.flux.values[i]

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -965,7 +965,6 @@ def phot_2d_frame(data, meta, m, i):
     """
     plt.figure(3306, figsize=(8, 8))
     plt.clf()
-    plt.suptitle('2D frame with centroid and apertures')
 
     flux, centroid_x, centroid_y = \
         data.flux[i], data.centroid_x[i], data.centroid_y[i]
@@ -982,7 +981,7 @@ def phot_2d_frame(data, meta, m, i):
                     extent=[xmin, xmax, ymin, ymax])
     plt.scatter(centroid_x, centroid_y, marker='x', s=25, c='r',
                 label='centroid')
-    plt.title('Full 2D frame')
+    plt.title('Full 2D frame\nwith centroid and apertures')
     plt.ylabel('y pixels')
     plt.xlabel('x pixels')
 
@@ -1037,7 +1036,7 @@ def phot_2d_frame(data, meta, m, i):
     plt.ylim(0, flux.shape[0])
     plt.xlabel('x pixels')
     plt.ylabel('y pixels')
-    plt.legend()
+    plt.legend(loc=1)
 
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
     int_number = str(i).zfill(int(np.floor(np.log10(meta.n_int))+1))
@@ -1050,13 +1049,12 @@ def phot_2d_frame(data, meta, m, i):
     if meta.isplots_S3 >= 5:
         plt.figure(3504, figsize=(6, 5))
         plt.clf()
-        plt.suptitle('2D frame with centroid and apertures (zoom-in version)')
+        plt.title('Zoomed-in 2D frame\nwith centroid and apertures')
 
         im = plt.imshow(flux, vmin=vmin, vmax=vmax, origin='lower',
                         aspect='equal', extent=[xmin, xmax, ymin, ymax])
         plt.scatter(centroid_x, centroid_y, marker='x', s=25, c='r',
                     label='centroid')
-        plt.title('Zoom into 2D frame')
         plt.ylabel('y pixels')
         plt.xlabel('x pixels')
 
@@ -1120,7 +1118,7 @@ def phot_2d_frame(data, meta, m, i):
         plt.ylim(ylim_min, ylim_max)
         plt.xlabel('x pixels')
         plt.ylabel('y pixels')
-        plt.legend()
+        plt.legend(loc=1)
 
         fname = (f'figs{os.sep}fig3504_file{file_number}_int{int_number}'
                  f'_2D_Frame_Zoom' + plots.figure_filetype)
@@ -1159,12 +1157,11 @@ def phot_2d_frame_oneoverf(data, meta, m, i, flux_w_oneoverf):
     """
     plt.figure(3307)
     plt.clf()
-    fig, ax = plt.subplots(2, 1, num=3307, figsize=(8.2, 4.2))
+    fig, ax = plt.subplots(2, 1, num=3307, figsize=(8.2, 4.2), gridspec_kw={'hspace': 0.0})
 
     cmap = plt.cm.viridis.copy()
     ax[0].imshow(flux_w_oneoverf, origin='lower',
                  norm=LogNorm(vmin=0.1, vmax=40), cmap=cmap)
-    ax[0].set_title('Before 1/f correction')
     ax[0].set_ylabel('y pixels')
 
     flux = data.flux.values[i]
@@ -1180,7 +1177,8 @@ def phot_2d_frame_oneoverf(data, meta, m, i, flux_w_oneoverf):
 
     file_number = str(m).zfill(int(np.floor(np.log10(meta.num_data_files))+1))
     int_number = str(i).zfill(int(np.floor(np.log10(meta.n_int))+1))
-    fig.suptitle((f'Segment {file_number}, Integration {int_number}'), y=0.99)
+    ax[0].set_title(f'Segment {file_number}, Integration {int_number}\n\n'
+                    'Before 1/f correction')
     fname = (f'figs{os.sep}fig3307_file{file_number}_int{int_number}'
              f'_2D_Frame_OneOverF' + plots.figure_filetype)
     plt.savefig(meta.outputdir + fname, dpi=250)
@@ -1208,19 +1206,19 @@ def phot_2d_frame_diff(data, meta):
     - 2022-08-02 Sebastian Zieba
         Initial version
     """
-    for i in range(meta.nplots):
+    for i in range(meta.nplots-1):
         plt.figure(3505)
         plt.clf()
-        plt.suptitle('2D frame differences')
         flux1 = data.flux.values[i]
         flux2 = data.flux.values[i+1]
-        plt.imshow(flux2-flux1, origin='lower', vmin=-600, vmax=600)
+        im = plt.imshow(flux2-flux1, origin='lower', vmin=-600, vmax=600)
         plt.xlabel('x pixels')
         plt.ylabel('y pixels')
-        plt.colorbar(label='Delta Flux (electrons)')
+        add_colorbar(im, label='Delta Flux (electrons)')
 
         int_number = str(i).zfill(int(np.floor(np.log10(meta.n_int)) + 1))
-        plt.suptitle((f'Integration {int_number}'), y=0.99)
+        plt.title('2D frame differences\n'
+                  f'Integration {int_number}')
         fname = (f'figs{os.sep}fig3505_int{int_number}_2D_Frame_Diff'
                  + plots.figure_filetype)
         plt.savefig(meta.outputdir + fname, dpi=250)
@@ -1350,7 +1348,6 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
                         vmin=0.98, vmax=1.02, cmap=cmap)
 
         # Figure settings
-        plt.title('Tilt Identification')
         plt.xticks(np.arange(0, flux_tilt.shape[1], 1),
                    (np.arange(asb_xpos_min, asb_xpos_max, 1)),
                    rotation='vertical')
@@ -1370,8 +1367,8 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
         file_number = str(m).zfill(int(np.floor(np.log10(
             meta.num_data_files))+1))
         int_number = str(i).zfill(int(np.floor(np.log10(meta.n_int))+1))
-        plt.suptitle((f'Batch {file_number}, Integration {int_number}'),
-                     y=0.99)
+        plt.title('Tilt Identification\n'
+                  f'Batch {file_number}, Integration {int_number}')
         fname = (f'figs{os.sep}tilt_events{os.sep}'
                  f'fig3507a_file{file_number}_int{int_number}'
                  f'_tilt_events' + plots.figure_filetype)
@@ -1385,11 +1382,12 @@ def tilt_events(meta, data, log, m, position, saved_refrence_tilt_frame):
 
     # Figure fig3507b
     # Create .gif per batch
-    log.writelog('  Creating batch tilt event GIF',
-                 mute=(not meta.verbose))
-    imageio.mimsave(meta.outputdir + f'figs{os.sep}' +
-                    f'fig3507b_tilt_event_batch_{file_number}.gif',
-                    images, fps=20)
+    if meta.nbatch > 1:
+        log.writelog('  Creating batch tilt event GIF',
+                     mute=(not meta.verbose))
+        imageio.mimsave(meta.outputdir + f'figs{os.sep}' +
+                        f'fig3507b_tilt_event_batch_{file_number}.gif',
+                        images, fps=20)
 
     # Figure fig3507c
     # Create .gif of all tilt event segments combined

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/AstroModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/AstroModel.py
@@ -101,6 +101,8 @@ class AstroModel(PyMC3Model):
         else:
             lib = tt
 
+        # Set all parameters
+        lcfinal = lib.zeros(0)
         for c in range(nchan):
             if self.nchannel_fitted > 1:
                 chan = channels[c]
@@ -141,8 +143,5 @@ class AstroModel(PyMC3Model):
 
                 planetFluxes += planetFlux
 
-            if c == 0:
-                lcfinal = starFlux+planetFluxes
-            else:
-                lcfinal = lib.concatenate([lcfinal, starFlux+planetFluxes])
+            lcfinal = lib.concatenate([lcfinal, starFlux+planetFluxes])
         return lcfinal

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/ExpRampModel.py
@@ -77,7 +77,7 @@ class ExpRampModel(PyMC3Model):
             nchan = 1
             channels = [channel, ]
 
-        ramp_coeffs = np.zeros((nchan, 12)).tolist()
+        ramp_coeffs = np.zeros((nchan, 4)).tolist()
 
         if eval:
             lib = np.ma
@@ -93,7 +93,7 @@ class ExpRampModel(PyMC3Model):
             else:
                 chan = 0
 
-            for i in range(12):
+            for i in range(4):
                 if chan == 0:
                     ramp_coeffs[c][i] = getattr(model, f'r{i}', 0)
                 else:
@@ -111,12 +111,8 @@ class ExpRampModel(PyMC3Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11 = ramp_coeffs[c]
-            lcpiece = (r0*lib.exp(-r1*time + r2) +
-                       r3*lib.exp(-r4*time + r5) +
-                       r6*lib.exp(-r7*time + r8) +
-                       r9*lib.exp(-r10*time + r11) +
-                       1)
+            r0, r1, r2, r3 = ramp_coeffs[c]
+            lcpiece = (1 + r0*lib.exp(-r1*time) + r2*lib.exp(-r3*time))
             ramp_flux = lib.concatenate([ramp_flux, lcpiece])
 
         return ramp_flux

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/HSTRampModel.py
@@ -114,10 +114,12 @@ class HSTRampModel(PyMC3Model):
 
             h0, h1, h2, h3, h4, h5 = hst_coeffs[c]
             # Batch time is relative to the start of each HST orbit
-            # h5 is the orbital period of HST (~96 minutes)
-            self.time_batch = self.time_local % h5
-            lcpiece = (1+h0*lib.exp(-h1*self.time_batch + h2)
-                       + h3*self.time_batch + h4*self.time_batch**2)
+            # h4 is the orbital period of HST (~96 minutes)
+            self.time_batch = (time - h5) % h4
+            lcpiece = (1 +
+                       h0*lib.exp(-h1*self.time_batch) +
+                       h2*self.time_batch +
+                       h3*self.time_batch**2)
             hst_flux = lib.concatenate([hst_flux, lcpiece])
 
         return hst_flux

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -51,11 +51,6 @@ class PyMC3Model(Model):
         for key in self.parameters.dict.keys():
             setattr(self.fit, key, getattr(self.parameters, key).value)
 
-        if hasattr(self.fit, 'ecosw') and hasattr(self.fit, 'esinw'):
-            # ecosw and esinw are defined; convert them to ecc and w
-            self.fit.ecc = np.sqrt(self.fit.ecosw**2 + self.fit.esinw**2)
-            self.fit.w = np.arctan2(self.fit.esinw, self.fit.ecosw)*180/np.pi
-
     def __mul__(self, other):
         """Multiply model components to make a combined model.
 
@@ -138,11 +133,6 @@ class PyMC3Model(Model):
             self.parameters.dict[arg][0] = val
             getattr(self.parameters, arg).value = val
             setattr(self.fit, arg, val)
-
-        if hasattr(self.fit, 'ecosw') and hasattr(self.fit, 'esinw'):
-            # ecosw and esinw are defined; convert them to ecc and w
-            self.fit.ecc = np.sqrt(self.fit.ecosw**2 + self.fit.esinw**2)
-            self.fit.w = np.arctan2(self.fit.esinw, self.fit.ecosw)*180/np.pi
 
         for component in self.components:
             component.update(newparams, **kwargs)
@@ -260,15 +250,6 @@ class CompositePyMC3Model(PyMC3Model, CompositeModel):
                                     lower=param.priorpar1,
                                     upper=param.priorpar2,
                                     testval=param.value)))
-
-            if hasattr(self.model, 'ecosw') and hasattr(self.model, 'esinw'):
-                # ecosw and esinw are defined; convert them to ecc and w
-                setattr(self.model, 'ecc', pm.Deterministic(
-                        'ecc', tt.sqrt(tt.sqr(self.model.ecosw)
-                                       + tt.sqr(self.model.esinw))))
-                setattr(self.model, 'w', pm.Deterministic(
-                        'w', tt.arctan2(self.model.esinw,
-                                        self.model.ecosw)*180/np.pi))
 
     def setup(self, time, flux, lc_unc, newparams):
         """Setup a model for evaluation and fitting.
@@ -462,9 +443,41 @@ class CompositePyMC3Model(PyMC3Model, CompositeModel):
         flux : ndarray
             The evaluated systematics model predictions at the times self.time.
         """
-        # Inherit from CompositeModel but add eval argument for PyMC3 models
-        return CompositeModel.syseval(self, channel=channel, incl_GP=incl_GP,
-                                      eval=eval, **kwargs)
+        # Get the time
+        if self.time is None:
+            self.time = kwargs.get('time')
+
+        if channel is None:
+            nchan = self.nchannel_fitted
+        else:
+            nchan = 1
+
+        if self.multwhite and channel is None:
+            # Evaluating all channels of a multwhite fit
+            flux_length = len(self.time)
+        elif self.multwhite:
+            # Evaluating a single channel of a multwhite fit
+            flux_length = self.nints[channel]
+        else:
+            # Evaluating a non-multwhite fit (individual or shared)
+            flux_length = len(self.time)*nchan
+
+        if eval:
+            flux = np.ma.ones(flux_length)
+        else:
+            flux = tt.ones(flux_length)
+
+        # Evaluate flux at each component
+        for component in self.components:
+            if component.modeltype == 'systematic':
+                if component.time is None:
+                    component.time = self.time
+                flux *= component.eval(channel=channel, eval=eval, **kwargs)
+
+        if incl_GP:
+            flux += self.GPeval(flux, channel=channel, eval=eval, **kwargs)
+
+        return flux
 
     def GPeval(self, fit, channel=None, eval=True, **kwargs):
         """Evaluate the GP model components only.
@@ -486,9 +499,36 @@ class CompositePyMC3Model(PyMC3Model, CompositeModel):
         flux : ndarray
             The evaluated GP model predictions at the times self.time.
         """
-        # Inherit from CompositeModel but add eval argument for PyMC3 models
-        return CompositeModel.GPeval(self, fit, channel=channel,
-                                     eval=eval, **kwargs)
+        # Get the time
+        if self.time is None:
+            self.time = kwargs.get('time')
+
+        if channel is None:
+            nchan = self.nchannel_fitted
+        else:
+            nchan = 1
+
+        if self.multwhite and channel is None:
+            # Evaluating all channels of a multwhite fit
+            flux_length = len(self.time)
+        elif self.multwhite:
+            # Evaluating a single channel of a multwhite fit
+            flux_length = self.nints[channel]
+        else:
+            # Evaluating a non-multwhite fit (individual or shared)
+            flux_length = len(self.time)*nchan
+
+        if eval:
+            flux = np.ma.ones(flux_length)
+        else:
+            flux = tt.ones(flux_length)
+
+        # Evaluate flux
+        for component in self.components:
+            if component.modeltype == 'GP':
+                flux = component.eval(fit, channel=channel, eval=eval,
+                                      **kwargs)
+        return flux
 
     def physeval(self, channel=None, interp=False, eval=True, **kwargs):
         """Evaluate the physical model components only.
@@ -516,9 +556,81 @@ class CompositePyMC3Model(PyMC3Model, CompositeModel):
             The value of self.time if interp==False, otherwise the time points
             used in the temporally interpolated model.
         """
-        # Inherit from CompositeModel but add eval argument for PyMC3 models
-        return CompositeModel.physeval(self, channel=channel, interp=interp,
-                                       eval=eval, **kwargs)
+        # Get the time
+        if self.time is None:
+            self.time = kwargs.get('time')
+
+        if channel is None:
+            nchan = self.nchannel_fitted
+            channels = self.fitted_channels
+        else:
+            nchan = 1
+            channels = [channel]
+
+        if interp:
+            if self.multwhite:
+                new_time = []
+                nints_interp = []
+                for chan in channels:
+                    # Split the arrays that have lengths of
+                    # the original time axis
+                    time = split([self.time, ], self.nints, chan)[0]
+
+                    # Remove masked points at the start or end to avoid
+                    # extrapolating out to those points
+                    time = time[~np.ma.getmaskarray(time)]
+
+                    # Get time step on full time array to ensure good steps
+                    dt = np.min(np.diff(time))
+
+                    # Interpolate as needed
+                    steps = int(np.round((time[-1]-time[0])/dt+1))
+                    nints_interp.append(steps)
+                    new_time.extend(np.linspace(time[0], time[-1], steps,
+                                                endpoint=True))
+                new_time = np.array(new_time)
+            else:
+                time = self.time
+
+                # Remove masked points at the start or end to avoid
+                # extrapolating out to those points
+                time = time[~np.ma.getmaskarray(time)]
+
+                # Get time step on full time array to ensure good steps
+                dt = np.min(np.diff(time))
+
+                # Interpolate as needed
+                dt = time[1]-time[0]
+                steps = int(np.round((time[-1]-time[0])/dt+1))
+                nints_interp = np.ones(nchan)*steps
+                new_time = np.linspace(time[0], time[-1], steps, endpoint=True)
+        else:
+            new_time = self.time
+            if self.multwhite and channel is not None:
+                # Split the arrays that have lengths of the original time axis
+                new_time = split([new_time, ], self.nints, channel)[0]
+            nints_interp = self.nints
+
+        if eval:
+            lib = np.ma
+        else:
+            lib = tt
+
+        # Setup the flux array
+        if self.multwhite:
+            flux = lib.ones(len(new_time))
+        else:
+            flux = lib.ones(len(new_time)*nchan)
+
+        # Evaluate flux at each component
+        for component in self.components:
+            if component.modeltype == 'physical':
+                if interp:
+                    flux *= component.interp(new_time, nints_interp,
+                                             channel=channel, eval=eval, **kwargs)
+                else:
+                    flux *= component.eval(channel=channel, eval=eval, **kwargs)
+        return flux, new_time, nints_interp
 
     def compute_fp(self, theta=0):
         """Compute the planetary flux at an arbitrary orbital position.

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -221,8 +221,8 @@ class CompositePyMC3Model(PyMC3Model, CompositeModel):
                                         testval=param.value))
                         elif any(substring in parname
                                  for substring in ['per', 'scatter_mult',
-                                                   'scatter_ppm', 'c0', 'r1',
-                                                   'r4', 'r7', 'r10']):
+                                                   'scatter_ppm', 'c0',
+                                                   'r1', 'r3']):
                             setattr(self.model, parname,
                                     BoundedNormal_0(
                                         parname,

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -627,9 +627,11 @@ class CompositePyMC3Model(PyMC3Model, CompositeModel):
             if component.modeltype == 'physical':
                 if interp:
                     flux *= component.interp(new_time, nints_interp,
-                                             channel=channel, eval=eval, **kwargs)
+                                             channel=channel, eval=eval,
+                                             **kwargs)
                 else:
-                    flux *= component.eval(channel=channel, eval=eval, **kwargs)
+                    flux *= component.eval(channel=channel, eval=eval,
+                                           **kwargs)
         return flux, new_time, nints_interp
 
     def compute_fp(self, theta=0):

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/PyMC3Models.py
@@ -519,9 +519,9 @@ class CompositePyMC3Model(PyMC3Model, CompositeModel):
             flux_length = len(self.time)*nchan
 
         if eval:
-            flux = np.ma.ones(flux_length)
+            flux = np.ma.zeros(flux_length)
         else:
-            flux = tt.ones(flux_length)
+            flux = tt.zeros(flux_length)
 
         # Evaluate flux
         for component in self.components:

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/QuasiLambertianPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/QuasiLambertianPhaseCurve.py
@@ -90,7 +90,7 @@ class QuasiLambertianPhaseCurve(PyMC3Model):
 
                 if (eval and pl_params.quasi_gamma == 0):
                     # Don't waste time running the following code
-                    phaseVars = np.ma.ones_like(time)
+                    phaseVars = np.ma.ones(time.shape)
                     continue
 
                 if pl_params.t_secondary is None:

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/SinusoidPhaseCurve.py
@@ -88,7 +88,7 @@ class SinusoidPhaseCurveModel(PyMC3Model):
                 if (eval and pl_params.AmpCos1 == 0 and pl_params.AmpSin1 == 0
                         and pl_params.AmpCos2 == 0 and pl_params.AmpSin2 == 0):
                     # Don't waste time running the following code
-                    phaseVars = np.ma.ones_like(time)
+                    phaseVars = np.ma.ones(time.shape)
                     continue
 
                 if pl_params.t_secondary is None:

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
@@ -42,7 +42,10 @@ class StarryModel(PyMC3Model):
         missing = np.array([name not in self.paramtitles for name in required])
         if np.any(missing):
             message = (f'Missing required params {required[missing]} in your '
-                       f'EPF.')
+                       'EPF. Make sure it is not set to \'independent\' as '
+                       'this is no longer a supported option; you can set '
+                       'these parameters to fixed if you want to maintain the '
+                       'old \'independent\' behavior.')
             raise AssertionError(message)
 
         if 'u2' in self.paramtitles:
@@ -135,7 +138,7 @@ class StarryModel(PyMC3Model):
             planets = []
             for pid in range(self.num_planets):
                 # Initialize PlanetParams object for this planet
-                pl_params = PlanetParams(self, pid, chan)
+                pl_params = PlanetParams(self, pid, chan, eval=False)
 
                 if not hasattr(pl_params, 'fp'):
                     planet_map = starry.Map(ydeg=self.ydeg, amp=0)
@@ -276,11 +279,8 @@ class StarryModel(PyMC3Model):
                 # Return the system lightcurve
                 lcpiece = lib.zeros(len(time))
                 for piece in result:
-                    lcpiece = lcpiece+piece
-                if c == 0:
-                    returnVal = lcpiece
-                else:
-                    returnVal = lib.concatenate([returnVal, lcpiece])
+                    lcpiece += piece
+                returnVal = lib.concatenate([returnVal, lcpiece])
 
         return returnVal
 

--- a/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
+++ b/src/eureka/S5_lightcurve_fitting/differentiable_models/StarryModel.py
@@ -248,10 +248,7 @@ class StarryModel(PyMC3Model):
             if self.mutualOccultations:
                 result = temp_system.flux(time, total=False)
                 fstar = result.pop(0)
-                if self.num_planets == 0:
-                    fplanets = []
-                else:
-                    fplanets = result
+                fplanets = result
             else:
                 fstar = lib.ones(len(time))
                 fplanets = []

--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -291,8 +291,7 @@ def emceefitter(lc, model, meta, log, **kwargs):
                                                   priortype)
     else:
         if meta.lsq_first:
-            # Only call lsq fitter first if asked or lsq_first option wasn't
-            # passed (allowing backwards compatibility)
+            # Only call lsq fitter first if asked
             log.writelog('\nCalling lsqfitter first...')
             # RUN LEAST SQUARES
             lsq_sol = lsqfitter(lc, model, meta, log,

--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -71,7 +71,7 @@ def lsqfitter(lc, model, meta, log, calling_function='lsq', **kwargs):
     freepars, prior1, prior2, priortype, indep_vars = \
         group_variables(model)
     if meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
+        freepars = load_old_fitparams(lc, meta, log, freenames, calling_function)
 
     start_lnprob = lnprob(freepars, lc, model, prior1, prior2, priortype,
                           freenames)
@@ -281,7 +281,7 @@ def emceefitter(lc, model, meta, log, **kwargs):
     freepars, prior1, prior2, priortype, indep_vars = \
         group_variables(model)
     if meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
+        freepars = load_old_fitparams(lc, meta, log, freenames, 'emcee')
     ndim = len(freenames)
 
     if meta.old_chain is not None:
@@ -813,7 +813,7 @@ def dynestyfitter(lc, model, meta, log, **kwargs):
     freepars, prior1, prior2, priortype, indep_vars = \
         group_variables(model)
     if meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
+        freepars = load_old_fitparams(lc, meta, log, freenames, 'dynesty')
 
     # DYNESTY
     nlive = meta.run_nlive  # number of live points
@@ -1198,19 +1198,21 @@ def group_variables_lmfit(model):
     return param_list, indep_vars
 
 
-def load_old_fitparams(meta, log, channel, freenames):
+def load_old_fitparams(lc, meta, log, freenames, fitter):
     """Load in the best-fit values from a previous fit.
 
     Parameters
     ----------
+    lc : eureka.S5_lightcurve_fitting.lightcurve.LightCurve
+        The lightcurve data object.
     meta : eureka.lib.readECF.MetaClass
         The metadata object.
     log : logedit.Logedit
         The open log in which notes from this step can be added.
-    channel : int
-        Unused. The current channel.
     freenames : list
         The names of the fitted parameters.
+    fitter : str
+        The name of the fitter, to figure out the old fitparams filename name.
 
     Returns
     -------
@@ -1222,8 +1224,18 @@ def load_old_fitparams(meta, log, channel, freenames):
     AssertionError
         The old fit is incompatible with the current fit.
     """
-    fname = os.path.join(meta.topdir, *meta.old_fitparams.split(os.sep))
-    fitted_values = pd.read_csv(fname, escapechar='#', skipinitialspace=True)
+    if lc.white:
+        channel_tag = '_white'
+    elif lc.share:
+        channel_tag = '_shared'
+    else:
+        ch_number = str(lc.channel).zfill(len(str(lc.nchannel)))
+        channel_tag = f'_ch{ch_number}'
+
+    foldername = os.path.join(meta.topdir, *meta.old_fitparams.split(os.sep))
+    fname = f'S5_{fitter}_fitparams{channel_tag}.csv'
+    fitted_values = pd.read_csv(os.path.join(foldername, fname),
+                                escapechar='#', skipinitialspace=True)
     full_keys = np.array(fitted_values['Parameter'])
 
     if np.all(full_keys != freenames):

--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -71,7 +71,8 @@ def lsqfitter(lc, model, meta, log, calling_function='lsq', **kwargs):
     freepars, prior1, prior2, priortype, indep_vars = \
         group_variables(model)
     if meta.old_fitparams is not None:
-        freepars = load_old_fitparams(lc, meta, log, freenames, calling_function)
+        freepars = load_old_fitparams(lc, meta, log, freenames,
+                                      calling_function)
 
     start_lnprob = lnprob(freepars, lc, model, prior1, prior2, priortype,
                           freenames)

--- a/src/eureka/S5_lightcurve_fitting/gradient_fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/gradient_fitters.py
@@ -49,7 +49,7 @@ def exoplanetfitter(lc, model, meta, log, calling_function='exoplanet',
     freenames = lc.freenames
     freepars = group_variables(model)[0]
     if meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
+        freepars = load_old_fitparams(lc, meta, log, freenames, 'exoplanet')
 
     model.setup(lc.time, lc.flux, lc.unc, freepars)
     model.update(freepars)
@@ -111,7 +111,7 @@ def exoplanetfitter(lc, model, meta, log, calling_function='exoplanet',
         plots.plot_GP_components(lc, model, meta, fitter=calling_function)
 
     # Zoom in on phase variations
-    if meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames 
+    if meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames
                                  or 'sinusoid_pc' in meta.run_myfuncs
                                  or 'poet_pc' in meta.run_myfuncs
                                  or 'quasilambert_pc' in meta.run_myfuncs):
@@ -166,7 +166,7 @@ def nutsfitter(lc, model, meta, log, **kwargs):
     freenames = lc.freenames
     freepars = group_variables(model)[0]
     if meta.old_fitparams is not None:
-        freepars = load_old_fitparams(meta, log, lc.channel, freenames)
+        freepars = load_old_fitparams(lc, meta, log, freenames, 'nuts')
     ndim = len(freenames)
 
     model.setup(lc.time, lc.flux, lc.unc, freepars)
@@ -256,7 +256,7 @@ def nutsfitter(lc, model, meta, log, **kwargs):
         plots.plot_GP_components(lc, model, meta, fitter='nuts')
 
     # Zoom in on phase variations
-    if meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames 
+    if meta.isplots_S5 >= 1 and ('Y10' in freenames or 'Y11' in freenames
                                  or 'sinusoid_pc' in meta.run_myfuncs
                                  or 'poet_pc' in meta.run_myfuncs
                                  or 'quasilambert_pc' in meta.run_myfuncs):

--- a/src/eureka/S5_lightcurve_fitting/gradient_fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/gradient_fitters.py
@@ -172,6 +172,16 @@ def nutsfitter(lc, model, meta, log, **kwargs):
     model.setup(lc.time, lc.flux, lc.unc, freepars)
     model.update(freepars)
 
+    if meta.exoplanet_first:
+        # Only call exoplanet fitter first if asked
+        log.writelog('\nCalling exoplanetfitter first...')
+        # RUN exoplanet optimizer
+        exo_sol = exoplanetfitter(lc, model, meta, log,
+                                  calling_function='nuts_exoplanet', **kwargs)
+
+        freepars = exo_sol.fit_params
+        model.update(freepars)
+
     start = {}
     for name, val in zip(freenames, freepars):
         start[name] = val

--- a/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
@@ -219,7 +219,16 @@ class PlanetParams():
             item0 = 'Rs'
             if model.parameters.dict[item0][1] == 'free':
                 item0 += self.channel_id
-            value = getattr(parameterObject, item0)
+            try:
+                value = getattr(parameterObject, item0)
+            except AttributeError as e:
+                if not eval:
+                    message = (f'Missing required parameter Rs in your '
+                       'EPF. Make sure it is not set to \'independent\' as '
+                       'this is no longer a supported option; you can set '
+                       'these parameters to fixed if you want to maintain the '
+                       'old \'independent\' behavior.')
+                raise AssertionError(message)
             if eval:
                 value = value.value
             setattr(self, 'Rs', value)

--- a/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
@@ -221,13 +221,12 @@ class PlanetParams():
                 item0 += self.channel_id
             try:
                 value = getattr(parameterObject, item0)
-            except AttributeError as e:
-                if not eval:
-                    message = (f'Missing required parameter Rs in your '
-                       'EPF. Make sure it is not set to \'independent\' as '
-                       'this is no longer a supported option; you can set '
-                       'these parameters to fixed if you want to maintain the '
-                       'old \'independent\' behavior.')
+            except AttributeError as message:
+                message = ('Missing required parameter Rs in your EPF. Make'
+                           ' sure it is not set to \'independent\' as'
+                           ' this is no longer a supported option; you can set'
+                           ' these parameters to fixed if you want to maintain'
+                           ' the old \'independent\' behavior.')
                 raise AssertionError(message)
             if eval:
                 value = value.value

--- a/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
@@ -151,6 +151,12 @@ class PlanetParams():
                 value = value.value
             setattr(self, 'a', value)
         # Allow for (ecc, w) or (ecosw, esinw)
+        if (self.ecosw is None) and self.ecc == 0:
+            self.ecosw = 0.
+            self.esinw = 0.
+        elif (self.ecc is None) and self.ecosw == 0 and self.sinw == 0:
+            self.ecc = 0.
+            self.w = None
         if (self.ecosw is None) and ('ecc' in model.parameters.dict.keys()):
             item0 = 'ecc' + self.pid_id
             item1 = 'w' + self.pid_id
@@ -457,7 +463,7 @@ def eccentric_anomaly(model, t, lib=np, xtol=1e-10):
     ma_peri = ea_peri - model.ecc*np.sin(ea_peri)
     t_peri = (model.t0 - (ma_peri/(2.*np.pi)*model.per))
 
-    if lib != np:
+    if lib not in [np, np.ma]:
         t_peri = t_peri + model.per*(lib.lt(t_peri, 0))
     elif t_peri < 0:
         t_peri = t_peri + model.per
@@ -561,7 +567,7 @@ def FSSI(Y, x, f, fP, lib=np):
     c2 = ((2.*d0 + d1)*dy - 3.*dx)/dy2
     c3 = ((d0 + d1)*dy - 2.*dx)/(dy2*dy)
 
-    if lib == np:
+    if lib in [np, np.ma]:
         j = np.searchsorted(y1, Y)
         # Protect against indexing beyond the size of the array
         j[j >= y1.size] = y1.size-1

--- a/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
@@ -35,7 +35,7 @@ class ExpRampModel(Model):
             self.parameters = Parameters(**params)
 
         # Update coefficients
-        self.coeffs = np.zeros((self.nchannel_fitted, 6))
+        self.coeffs = np.zeros((self.nchannel_fitted, 4))
         self._parse_coeffs()
 
     @property
@@ -62,7 +62,7 @@ class ExpRampModel(Model):
 
     def _parse_coeffs(self):
         """Convert dict of 'r#' coefficients into a list
-        of coefficients in increasing order, i.e. ['r0','r1','r2'].
+        of coefficients in increasing order, i.e. ['r0','r1'].
 
         Returns
         -------
@@ -76,7 +76,7 @@ class ExpRampModel(Model):
             else:
                 chan = 0
 
-            for i in range(6):
+            for i in range(4):
                 try:
                     if chan == 0:
                         self.coeffs[c, i] = self.parameters.dict[f'r{i}'][0]
@@ -125,8 +125,7 @@ class ExpRampModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            r0, r1, r2, r3, r4, r5 = self.coeffs[chan]
-            lcpiece = (1+r0*np.exp(-r1*time + r2)
-                       + r3*np.exp(-r4*time + r5))
+            r0, r1, r2, r3 = self.coeffs[chan]
+            lcpiece = (1 + r0*np.exp(-r1*time) + r2*np.exp(-r3*time))
             lcfinal = np.append(lcfinal, lcpiece)
         return lcfinal

--- a/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
@@ -36,7 +36,7 @@ class HSTRampModel(Model):
             self.parameters = Parameters(**params)
 
         # Update coefficients
-        self.coeffs = np.zeros((self.nchannel_fitted, 7))
+        self.coeffs = np.zeros((self.nchannel_fitted, 6))
         self._parse_coeffs()
 
     @property
@@ -77,7 +77,7 @@ class HSTRampModel(Model):
             else:
                 chan = 0
 
-            for i in range(7):
+            for i in range(6):
                 try:
                     if chan == 0:
                         self.coeffs[c, i] = self.parameters.dict[f'h{i}'][0]
@@ -124,11 +124,13 @@ class HSTRampModel(Model):
                 # Split the arrays that have lengths of the original time axis
                 time = split([time, ], self.nints, chan)[0]
 
-            h0, h1, h2, h3, h4, h5, h6 = self.coeffs[c]
+            h0, h1, h2, h3, h4, h5 = self.coeffs[c]
             # Batch time is relative to the start of each HST orbit
             # h5 is the orbital period of HST (~96 minutes)
-            self.time_batch = (time-h6) % h5
-            lcpiece = (1+h0*np.exp(-h1*self.time_batch + h2)
-                       + h3*self.time_batch + h4*self.time_batch**2)
+            self.time_batch = (time - h5) % h4
+            lcpiece = (1 +
+                       h0*np.exp(-h1*self.time_batch) +
+                       h2*self.time_batch +
+                       h3*self.time_batch**2)
             lcfinal = np.append(lcfinal, lcpiece)
         return lcfinal

--- a/src/eureka/S5_lightcurve_fitting/models/QuasiLambertianPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/models/QuasiLambertianPhaseCurve.py
@@ -76,7 +76,7 @@ class QuasiLambertianPhaseCurve(Model):
 
                 if pl_params.quasi_gamma == 0:
                     # Don't waste time running the following code
-                    phaseVars = np.ma.ones_like(time)
+                    phaseVars = np.ma.ones(time.shape)
                     continue
 
                 if pl_params.t_secondary is None:

--- a/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
@@ -82,7 +82,7 @@ class SinusoidPhaseCurveModel(Model):
                 if (pl_params.AmpCos1 == 0 and pl_params.AmpSin1 == 0 and
                         pl_params.AmpCos2 == 0 and pl_params.AmpSin2 == 0):
                     # Don't waste time running the following code
-                    phaseVars = np.ma.ones_like(time)
+                    phaseVars = np.ma.ones(time.shape)
                     continue
 
                 if pl_params.t_secondary is None:

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -554,23 +554,6 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
     nchannel_fitted = lc_model.nchannel_fitted
     fitted_channels = lc_model.fitted_channels
 
-    if meta.testing_model:
-        # FINDME: Use this area to add systematics into the data
-        # when testing new systematics models. In this case, I'm
-        # introducing an exponential ramp to test m.ExpRampModel().
-        log.writelog('***Adding exponential ramp systematic to light curve***')
-        fakeramp = m.ExpRampModel(parameters=params, name='ramp', fmt='r--',
-                                  log=log, time=time,
-                                  longparamlist=lc_model.longparamlist,
-                                  nchannel=chanrng,
-                                  nchannel_fitted=nchannel_fitted,
-                                  fitted_channels=fitted_channels,
-                                  paramtitles=paramtitles)
-        fakeramp.coeffs = (np.array([-1, 40, -3, 0, 0, 0]).reshape(1, -1)
-                           * np.ones(nchannel_fitted))
-        flux *= fakeramp.eval(time=time)
-        lc_model.flux = flux
-
     if 'starry' in meta.run_myfuncs:
         use_starry = True
         StarryModel = dm.StarryModel
@@ -603,6 +586,26 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
         GPModel = m.GPModel
         AstroModel = m.AstroModel
         CompositeModel = m.CompositeModel
+
+    if meta.testing_model:
+        # FINDME: Use this area to add systematics into the data
+        # when testing new systematics models. In this case, I'm
+        # introducing an exponential ramp to test m.ExpRampModel().
+        log.writelog('***Adding exponential ramp systematic to light curve***')
+        fakeramp = ExpRampModel(parameters=params, fmt='r--',
+                                log=log, time=time, time_units=time_units,
+                                freenames=freenames,
+                                longparamlist=lc_model.longparamlist,
+                                nchannel=chanrng,
+                                nchannel_fitted=nchannel_fitted,
+                                fitted_channels=fitted_channels,
+                                paramtitles=paramtitles,
+                                multwhite=lc_model.multwhite,
+                                nints=lc_model.nints)
+        fakeramp.coeffs = (np.array([-1, 40, 0, 0]).reshape(1, -1)
+                           * np.ones(nchannel_fitted))
+        flux *= fakeramp.eval(time=time)
+        lc_model.flux = flux
 
     # Make the astrophysical and detector models
     modellist = []

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -604,13 +604,6 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
         AstroModel = m.AstroModel
         CompositeModel = m.CompositeModel
 
-    freenames = []
-    for key in params.dict:
-        if params.dict[key][1] in ['free', 'shared', 'white_free',
-                                   'white_fixed']:
-            freenames.append(key)
-    freenames = np.array(freenames)
-
     # Make the astrophysical and detector models
     modellist = []
     if use_starry:

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -555,7 +555,6 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
     fitted_channels = lc_model.fitted_channels
 
     if 'starry' in meta.run_myfuncs:
-        use_starry = True
         StarryModel = dm.StarryModel
         SinusoidModel = dm.SinusoidPhaseCurveModel
         QuasiLambertianPhaseCurve = dm.QuasiLambertianPhaseCurve
@@ -568,7 +567,6 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
         AstroModel = dm.AstroModel
         CompositeModel = dm.CompositePyMC3Model
     else:
-        use_starry = False
         BatmanTransitModel = m.BatmanTransitModel
         BatmanEclipseModel = m.BatmanEclipseModel
         PoetTransitModel = m.PoetTransitModel
@@ -609,7 +607,7 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
 
     # Make the astrophysical and detector models
     modellist = []
-    if use_starry:
+    if 'starry' in meta.run_myfuncs:
         # Fixed any masked uncertainties
         masked = np.logical_or(np.ma.getmaskarray(flux),
                                np.ma.getmaskarray(flux_err))
@@ -721,21 +719,7 @@ def fit_channel(meta, time, flux, chan, flux_err, eventlabel, params,
                                 nints=lc_model.nints,
                                 num_planets=meta.num_planets)
         modellist.append(t_poet_pc)
-    if 'sinusoid_pc' in meta.run_myfuncs and use_starry:
-        t_phase = SinusoidModel(parameters=params,
-                                fmt='r--', log=log, time=time,
-                                time_units=time_units,
-                                freenames=freenames,
-                                longparamlist=lc_model.longparamlist,
-                                nchannel=chanrng,
-                                nchannel_fitted=nchannel_fitted,
-                                fitted_channels=fitted_channels,
-                                paramtitles=paramtitles,
-                                multwhite=lc_model.multwhite,
-                                nints=lc_model.nints,
-                                num_planets=meta.num_planets)
-        modellist.append(t_phase)
-    elif 'sinusoid_pc' in meta.run_myfuncs:
+    if 'sinusoid_pc' in meta.run_myfuncs:
         t_phase = SinusoidModel(parameters=params,
                                 fmt='r--', log=log, time=time,
                                 time_units=time_units,

--- a/src/eureka/S5_lightcurve_fitting/s5_meta.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_meta.py
@@ -134,6 +134,7 @@ class S5MetaClass(MetaClass):
         self.run_tol = getattr(self, 'run_tol', 0.1)
 
         # PyMC3 NUTS sampler settings
+        self.exoplanet_first = getattr(self, 'exoplanet_first', False)
         self.chains = getattr(self, 'chains', 3)
         self.target_accept = getattr(self, 'target_accept', 0.85)
         if 'nuts' in self.fit_method:

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -219,7 +219,7 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                 # Manipulate fitted values if needed
                 if meta.y_param_basic in ['rp^2', 'rprs^2']:
                     meta = compute_transit_depth(meta)
-                elif meta.y_param_basic in ['1/r1', '1/r4']:
+                elif meta.y_param_basic in ['1/r1', '1/r3']:
                     meta = compute_timescale(meta)
 
                 planetSuffix = getPlanetSuffix(meta)
@@ -310,7 +310,7 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
                         suffix = channelSuffix
                         meta.y_label = ('$r_{\\rm '+meta.y_param_basic[1:] +
                                         '}$'+suffix)
-                    elif meta.y_param_basic in ['1/r1', '1/r4']:
+                    elif meta.y_param_basic in ['1/r1', '1/r3']:
                         # Exponential ramp timescales
                         suffix = channelSuffix
                         meta.y_label = ('$1/r_{\\rm '+meta.y_param_basic[-1] +
@@ -408,7 +408,7 @@ def parse_s5_saves(meta, log, fit_methods, channel_key='shared'):
     """
     if meta.y_param_basic in ['rp^2', 'rprs^2']:
         y_param = meta.y_param[:-2]
-    elif meta.y_param_basic in ['1/r1', '1/r4']:
+    elif meta.y_param_basic in ['1/r1', '1/r3']:
         y_param = meta.y_param[2:]
     else:
         y_param = meta.y_param
@@ -567,7 +567,7 @@ def compute_transit_depth(meta):
 
 
 def compute_timescale(meta):
-    """Convert the fitted r1 or r4 value to a timescale.
+    """Convert the fitted r1 or r3 value to a timescale.
 
     Parameters
     ----------

--- a/src/eureka/lib/plots.py
+++ b/src/eureka/lib/plots.py
@@ -69,7 +69,8 @@ def set_rc(style='preserve', usetex=False, layout='constrained',
                   'mathtext.fontset': 'dejavuserif',
                   'mathtext.it': 'serif:italic',
                   'mathtext.rm': 'serif', 'mathtext.sf': 'serif',
-                  'mathtext.bf': 'serif:bold'}
+                  'mathtext.bf': 'serif:bold',
+                  'savefig.bbox': 'tight'}
         rcParams.update(params)
     elif style == 'default':
         # Use default matplotlib settings

--- a/tests/MIRI_ecfs/POET/s5_POET.epf
+++ b/tests/MIRI_ecfs/POET/s5_POET.epf
@@ -34,7 +34,7 @@ cos1_off		0.0000	        'free'			-20 			20			U
 # --------------------
 # Systematic variables
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, WN, m1, m2) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)
@@ -42,7 +42,6 @@ cos1_off		0.0000	        'free'			-20 			20			U
 c0			1.000           	'free'			1				0.05		N
 r0			-0.124315778343348	'free' 			-0.12			0.05		N
 r1			35.5170488452062	'free' 			35 				20			N
-r2			-0.603176745805961	'free' 			-0.5 			0.4			N
 # -----------
 # ** White noise **
 # Use scatter_mult to fit a multiplier to the expected noise level from Stage 3 (recommended)

--- a/tests/MIRI_ecfs/s5_fit_par.epf
+++ b/tests/MIRI_ecfs/s5_fit_par.epf
@@ -34,7 +34,7 @@ AmpSin1		0.0119516726947867	'free'			-1				1			U
 # --------------------
 # Systematic variables
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, WN, m1, m2) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)

--- a/tests/MIRI_ecfs/s5_fit_par_starry.epf
+++ b/tests/MIRI_ecfs/s5_fit_par_starry.epf
@@ -34,7 +34,7 @@ Y11			0.0119516726947867	'free'			-1				1			U
 # --------------------
 # Systematic variables
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)

--- a/tests/NIRCam_ecfs/POET/S5_POET.epf
+++ b/tests/NIRCam_ecfs/POET/S5_POET.epf
@@ -34,7 +34,7 @@ u4			0.1				'free'			-1				1				U
 # --------------------
 # ** Systematic variables **
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)

--- a/tests/NIRCam_ecfs/S5_fit_par.epf
+++ b/tests/NIRCam_ecfs/S5_fit_par.epf
@@ -32,7 +32,7 @@ u2			0.1				'free'			0				1				U
 # --------------------
 # ** Systematic variables **
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)

--- a/tests/NIRSpec_ecfs/S5_fit_par.epf
+++ b/tests/NIRSpec_ecfs/S5_fit_par.epf
@@ -32,7 +32,7 @@ u2			0.1				'fixed'
 # --------------------
 # ** Systematic variables **
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)

--- a/tests/Photometry_NIRCam_ecfs/S5_fit_par.epf
+++ b/tests/Photometry_NIRCam_ecfs/S5_fit_par.epf
@@ -32,7 +32,7 @@ u2			0.1				'free'			0				1				U
 # --------------------
 # ** Systematic variables **
 # Polynomial model variables (c0--c9 for 0th--3rd order polynomials in time); Fitting at least c0 is very strongly recommended!
-# Exponential ramp model variables (r0--r2 for one exponential ramp, r3--r5 for a second exponential ramp)
+# Exponential ramp model variables (r0--r1 for one exponential ramp, r2--r3 for a second exponential ramp)
 # GP model parameters (A, m for the first kernel; A1, m1 for the second kernel; etc.) in log scale
 # Step-function model variables (step# and steptime# for step-function model #; e.g. step0 and steptime0)
 # Drift model variables (xpos, ypos, xwidth, ywidth)

--- a/tests/test_lightcurve_fitting.py
+++ b/tests/test_lightcurve_fitting.py
@@ -391,10 +391,9 @@ class TestModels(unittest.TestCase):
     def test_exponentialmodel(self):
         """Tests for the ExponentialModel class"""
         # Create the model
-        freenames = ['r0', 'r1', 'r2']
+        freenames = ['r0', 'r1']
         self.exp_model = models.ExpRampModel(coeff_dict={'r0': [1., 'free'],
-                                                         'r1': [0.05, 'free'],
-                                                         'r2': [0.01, 'free']},
+                                                         'r1': [0.05, 'free']},
                                              freenames=freenames,
                                              nchan=1)
 
@@ -404,13 +403,11 @@ class TestModels(unittest.TestCase):
         self.assertEqual(vals.size, self.time.size)
 
         # Create the model
-        freenames = ['r0', 'r1', 'r2', 'r3', 'r4', 'r5']
+        freenames = ['r0', 'r1', 'r2', 'r3']
         self.exp_model = models.ExpRampModel(coeff_dict={'r0': [1., 'free'],
                                                          'r1': [0.05, 'free'],
-                                                         'r2': [0.01, 'free'],
-                                                         'r3': [1., 'free'],
-                                                         'r4': [0.05, 'free'],
-                                                         'r5': [0.01, 'free']},
+                                                         'r2': [1., 'free'],
+                                                         'r3': [0.05, 'free']},
                                              freenames=freenames,
                                              nchan=1)
 


### PR DESCRIPTION
This PR is an accumulation of bug patches and other small improvements that I made while thoroughly testing the code in prep for v1.0.

This PR:
- [x] Clarifies that Fig3103 x-axis is relative pixel position, not detector pixel position
- [x] Fixes the `load_old_fitparams` function to work for spectroscopic fits
- [x] Fixes a major bug with the PyMC3 code where the `GPeval` function would return a constant 1.0 if no GP was fitted, which would result in a lightcurve with a mean of 2.0.
- [x] Makes some other minor fixes to the PyMC3 code that I made while trying to determing the cause of the previous issue
- [x] Fixes a bug with masked data in the differentiable GPModel
- [x] Adds a better warning if Rs set to independent (which was previously the template default, but is no longer permitted)
- [x] Adds emphasis that users should not fit all ramp parameters at the same time. This resolves #375
- [x] Adds `exoplanet_first` option to `nuts` fitter, similar to the `lsq_first` option for the `emcee` fitter
    - [x] Explains this new feature in the docs
- [x] Fixes plot title issue with Figs 3504, 3505, and 3507 (resolves #683)
- [x] Resolves #389 with a small tweak to environment.yml