### PR TITLE
Save background model at source position and stddev of background counts in S3, create background lightcurves in S4

### DIFF
--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -152,7 +152,19 @@ def BGsubtraction(data, meta, log, m, isplots=0):
     data['flux'] -= data.bg
     if hasattr(data, 'medflux'):
         data['medflux'] -= np.median(data.bg, axis=0)
-
+        
+    # Save BG value at source position and BG stddev (no outlier rejection)
+    data['skylev'] = (['time', 'x'], np.zeros([data.flux.shape[0],data.flux.shape[2]]))
+    data['skylev'].attrs['flux_units'] = data['flux'].attrs['flux_units']
+    data['skylev'] = data.bg[:, meta.src_ypos, :]
+    
+    data['skyerr'] = (['time', 'x'], np.zeros([data.flux.shape[0],data.flux.shape[2]]))
+    data['skyerr'].attrs['flux_units'] = data['flux'].attrs['flux_units']
+    y_inds = np.zeros([data.flux.shape[1]], dtype = bool)
+    y_inds[:meta.bg_y1] = True
+    y_inds[meta.bg_y2:] = True
+    data['skyerr'] = np.std(data.flux[:,y_inds,:], axis = 1)
+    
     # Make image+background plots
     if isplots >= 3:
         plots_s3.image_and_background(data, meta, log, m)

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -154,13 +154,13 @@ def BGsubtraction(data, meta, log, m, isplots=0):
         data['medflux'] -= np.median(data.bg, axis=0)
         
     # Save BG value at source position and BG stddev (no outlier rejection)
-    data['skylev'] = (['time', 'x'], 
-                      np.zeros([data.flux.shape[0], data.flux.shape[2]]))
+    coords = list(data.coords.keys())
+    coords.remove('y')
+    data['skylev'] = (coords, np.zeros_like(data.flux[:, 0]))
     data['skylev'].attrs['flux_units'] = data['flux'].attrs['flux_units']
     data['skylev'] = data.bg[:, meta.src_ypos, :]
     
-    data['skyerr'] = (['time', 'x'], 
-                      np.zeros([data.flux.shape[0], data.flux.shape[2]]))
+    data['skyerr'] = (coords, np.zeros_like(data.flux[:, 0]))
     data['skyerr'].attrs['flux_units'] = data['flux'].attrs['flux_units']
     y_inds = np.zeros([data.flux.shape[1]], dtype=bool)
     y_inds[:meta.bg_y1] = True

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -154,16 +154,18 @@ def BGsubtraction(data, meta, log, m, isplots=0):
         data['medflux'] -= np.median(data.bg, axis=0)
         
     # Save BG value at source position and BG stddev (no outlier rejection)
-    data['skylev'] = (['time', 'x'], np.zeros([data.flux.shape[0],data.flux.shape[2]]))
+    data['skylev'] = (['time', 'x'], 
+                      np.zeros([data.flux.shape[0], data.flux.shape[2]]))
     data['skylev'].attrs['flux_units'] = data['flux'].attrs['flux_units']
     data['skylev'] = data.bg[:, meta.src_ypos, :]
     
-    data['skyerr'] = (['time', 'x'], np.zeros([data.flux.shape[0],data.flux.shape[2]]))
+    data['skyerr'] = (['time', 'x'], 
+                      np.zeros([data.flux.shape[0], data.flux.shape[2]]))
     data['skyerr'].attrs['flux_units'] = data['flux'].attrs['flux_units']
-    y_inds = np.zeros([data.flux.shape[1]], dtype = bool)
+    y_inds = np.zeros([data.flux.shape[1]], dtype=bool)
     y_inds[:meta.bg_y1] = True
     y_inds[meta.bg_y2:] = True
-    data['skyerr'] = np.std(data.flux[:,y_inds,:], axis = 1)
+    data['skyerr'] = np.std(data.flux[:, y_inds, :], axis=1)
     
     # Make image+background plots
     if isplots >= 3:

--- a/src/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/src/eureka/S4_generate_lightcurves/plots_s4.py
@@ -85,6 +85,7 @@ def binned_lightcurve(meta, log, lc, i, white=False):
     if not meta.hide_plots:
         plt.pause(0.2)
         
+
 def binned_background(meta, log, lc, i, white=False):
     '''Plot each spectroscopic light curve. (Figs 4102)
 
@@ -113,7 +114,6 @@ def binned_background(meta, log, lc, i, white=False):
             scandir=getattr(lc, 'scandir', None))
         i = 0
         fname_tag = 'white'
-        print(lc.time.shape, norm_bgdata.shape, norm_bgerr.shape, lc.skylev_white.shape, lc.skyerr_white.shape)
     elif meta.photometry:
         fig.suptitle(f'Photometric Lightcurve at {meta.phot_wave} microns')
         # Normalize the light curve
@@ -154,7 +154,7 @@ def binned_background(meta, log, lc, i, white=False):
                      fmt='o', color=f'C{i}', mec=f'C{i}', alpha=0.2)
         mad = util.get_mad_1d(norm_bgdata)
         meta.mad_s4_binned.append(mad)
-        #log.writelog(f'    MAD = {np.round(mad).astype(int)} ppm')
+        # log.writelog(f'    MAD = {np.round(mad).astype(int)} ppm')
         plt.text(0.05, 0.1, f"MAD = {np.round(mad).astype(int)} ppm",
                  transform=ax.transAxes, color='k')
     plt.ylabel('Normalized Background')

--- a/src/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/src/eureka/S4_generate_lightcurves/plots_s4.py
@@ -84,6 +84,87 @@ def binned_lightcurve(meta, log, lc, i, white=False):
     fig.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
+        
+def binned_background(meta, log, lc, i, white=False):
+    '''Plot each spectroscopic light curve. (Figs 4102)
+
+    Parameters
+    ----------
+    meta : eureka.lib.readECF.MetaClass
+        The metadata object.
+    log : logedit.Logedit
+        The open log in which notes from this step can be added.
+    lc : Xarray Dataset
+        The Dataset object containing light curve and time data.
+    i : int
+        The current bandpass number.
+    white : bool; optional
+        Is this figure for the additional white-light light curve
+    '''
+    fig = plt.figure(4105, figsize=(8, 6))
+    fig.clf()
+    ax = fig.gca()
+    if white:
+        fig.suptitle(f'White-light Bandpass {i}: {meta.wave_min:.3f} - '
+                     f'{meta.wave_max:.3f}')
+        # Normalize the light curve
+        norm_bgdata, norm_bgerr = util.normalize_spectrum(
+            meta, lc.skylev_white, lc.skyerr_white,
+            scandir=getattr(lc, 'scandir', None))
+        i = 0
+        fname_tag = 'white'
+        print(lc.time.shape, norm_bgdata.shape, norm_bgerr.shape, lc.skylev_white.shape, lc.skyerr_white.shape)
+    elif meta.photometry:
+        fig.suptitle(f'Photometric Lightcurve at {meta.phot_wave} microns')
+        # Normalize the light curve
+        norm_bgdata, norm_bgerr = util.normalize_spectrum(
+            meta, lc['skylev'][i], lc['skyerr'][i],
+            scandir=getattr(lc, 'scandir', None))
+        fname_tag = 'phot'
+    else:
+        fig.suptitle(f'Bandpass {i}: {lc.wave_low.values[i]:.3f} - '
+                     f'{lc.wave_hi.values[i]:.3f}')
+        # Normalize the light curve
+        norm_bgdata, norm_bgerr = util.normalize_spectrum(
+            meta, lc['skylev'][i], lc['skyerr'][i],
+            scandir=getattr(lc, 'scandir', None))
+        ch_number = str(i).zfill(int(np.floor(np.log10(meta.nspecchan))+1))
+        fname_tag = f'ch{ch_number}'
+
+    time_modifier = np.floor(np.ma.min(lc.time.values))
+
+    # Plot the normalized light curve
+    if meta.inst == 'wfc3':
+        for p in range(2):
+            iscans = np.where(lc.scandir.values == p)[0]
+
+            if len(iscans) > 0:
+                ax.errorbar(lc.time.values[iscans]-time_modifier,
+                            norm_bgdata[iscans]+0.005*p,
+                            norm_bgerr[iscans], fmt='o', color=f'C{p}',
+                            mec=f'C{p}', alpha=0.2)
+                mad = util.get_mad_1d(norm_bgdata[iscans])
+                meta.mad_s4_binned.append(mad)
+                log.writelog(f'    MAD = {np.round(mad).astype(int)} ppm')
+                plt.text(0.05, 0.075+0.05*p,
+                         f"MAD = {np.round(mad).astype(int)} ppm",
+                         transform=ax.transAxes, color=f'C{p}')
+    else:
+        plt.errorbar(lc.time.values-time_modifier, norm_bgdata, norm_bgerr,
+                     fmt='o', color=f'C{i}', mec=f'C{i}', alpha=0.2)
+        mad = util.get_mad_1d(norm_bgdata)
+        meta.mad_s4_binned.append(mad)
+        #log.writelog(f'    MAD = {np.round(mad).astype(int)} ppm')
+        plt.text(0.05, 0.1, f"MAD = {np.round(mad).astype(int)} ppm",
+                 transform=ax.transAxes, color='k')
+    plt.ylabel('Normalized Background')
+    time_units = lc.data.attrs['time_units']
+    plt.xlabel(f'Time [{time_units} - {time_modifier}]')
+
+    fname = f'figs{os.sep}fig4105_{fname_tag}_1D_BG'+plots.figure_filetype
+    fig.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
+    if not meta.hide_plots:
+        plt.pause(0.2)
 
 
 def driftxpos(meta, lc):

--- a/src/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/src/eureka/S4_generate_lightcurves/plots_s4.py
@@ -87,7 +87,7 @@ def binned_lightcurve(meta, log, lc, i, white=False):
         
 
 def binned_background(meta, log, lc, i, white=False):
-    '''Plot each spectroscopic light curve. (Figs 4102)
+    '''Plot each spectroscopic background light curve. (Figs 4105)
 
     Parameters
     ----------

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -275,14 +275,16 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
             lc = xrio.makeDataset({'data': lcdata, 'err': lcerr,
                                    'mask': lcmask})
             if 'skylev' in list(spec.keys()):
-                #if background level and error was saved in S3, make bg lightcurves
-                lc['skylev'] = (['wavelength','time'], np.zeros([meta.nspecchan,meta.n_int]))
-                lc['skylev'].attrs['wave_units'] = spec.wave_1d.attrs['wave_units']
+                # if bg level/error was saved in S3, make bg lightcurves
+                lc['skylev'] = (['wavelength', 'time'], 
+                                np.zeros([meta.nspecchan, meta.n_int]))
+                lc['skylev'].attrs['wave_units'] = lc.data.wave_units
                 lc['skylev'].attrs['time_units'] = time_units
                 lc['skylev'].attrs['flux_units'] = flux_units
                 
-                lc['skyerr'] = (['wavelength','time'], np.zeros([meta.nspecchan,meta.n_int]))
-                lc['skyerr'].attrs['wave_units'] = spec.wave_1d.attrs['wave_units']
+                lc['skyerr'] = (['wavelength', 'time'], 
+                                np.zeros([meta.nspecchan, meta.n_int]))
+                lc['skyerr'].attrs['wave_units'] = lc.data.wave_units
                 lc['skyerr'].attrs['time_units'] = time_units
                 lc['skyerr'].attrs['flux_units'] = flux_units
             if hasattr(spec, 'scandir'):
@@ -455,7 +457,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                     lc['err'][i] = (np.sqrt(np.ma.sum(opterr_ma**2, axis=1)) /
                                     np.ma.MaskedArray.count(opterr_ma, axis=1))    
                     if 'skylev' in list(spec.keys()):
-                        #if background level and error was saved in S3, make bg lightcurves
+                        # if bg level/error was saved in S3, make bg lcs
                         skylev_ma = np.ma.masked_where(
                             spec.optmask.values[:, index],
                             spec.skylev.values[:, index])
@@ -463,15 +465,16 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                             spec.optmask.values[:, index],
                             spec.skyerr.values[:, index])
                         lc['skylev'][i] = np.ma.mean(skylev_ma, axis=1)
-                        lc['skyerr'][i] = (np.sqrt(np.ma.sum(skyerr_ma**2, axis=1)) /
-                                            np.ma.MaskedArray.count(skyerr_ma, axis=1))
+                        lc['skyerr'][i] = (np.sqrt(np.ma.sum(
+                            skyerr_ma**2, axis=1)) / 
+                            np.ma.MaskedArray.count(skyerr_ma, axis=1))
                         
                 else:
                     lc['data'][i] = spec.aplev.values
                     lc['err'][i] = spec.aperr.values
                     
                     if 'skylev' in list(spec.keys()):
-                        #if background level and error was saved in S3, make bg lightcurves
+                        # if bg level/error was saved in S3, make bg lcs
                         lc['skylev'][i] = spec.skylev.values
                         lc['skyerr'][i] = spec.skyerr.values
                         
@@ -545,7 +548,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                                                                  axis=1))
                                                                  
                 if 'skylev' in list(spec.keys()):
-                    #if background level and error was saved in S3, make bg lightcurves
+                    # if bg level/error was saved in S3, make bg lcs
                     lc['skylev_white'] = (['time'], np.zeros(meta.n_int))
                     lc['skylev_white'].attrs['wavelength'] = central_wavelength
                     lc['skylev_white'].attrs['wave_units'] = lc.data.wave_units
@@ -565,8 +568,9 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                         spec.optmask.values[:, index],
                         spec.skyerr.values[:, index])
                     lc['skylev_white'][:] = np.ma.mean(skylev_ma, axis=1).data
-                    lc['skyerr_white'][:] = (np.sqrt(np.ma.sum(skyerr_ma**2, axis=1)) /
-                                        np.ma.MaskedArray.count(skyerr_ma, axis=1)).data
+                    lc['skyerr_white'][:] = (np.sqrt(np.ma.sum(
+                        skyerr_ma**2, axis=1)) /
+                        np.ma.MaskedArray.count(skyerr_ma, axis=1)).data
 
                 # Do 1D sigma clipping (along time axis) on binned spectra
                 if meta.clip_binned:
@@ -584,7 +588,8 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                 if meta.isplots_S4 >= 3:
                     plots_s4.binned_lightcurve(meta, log, lc, 0, white=True)
                     if 'skylev' in list(spec.keys()):
-                       plots_s4.binned_background(meta, log, lc, 0, white=True) 
+                        plots_s4.binned_background(meta, log, lc, 
+                                                   0, white=True) 
 
             # Generate ExoTiC limb-darkening coefficients
             if (meta.compute_ld == 'exotic-ld') or \

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -492,7 +492,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                                  f' series', mute=(not meta.verbose))
 
                 # Plot each spectroscopic light curve
-                if meta.isplots_S4 >= 3:
+                if meta.isplots_S4 >= 1:
                     plots_s4.binned_lightcurve(meta, log, lc, i)
                     if 'skylev' in list(spec.keys()):
                         plots_s4.binned_background(meta, log, lc, i)
@@ -585,7 +585,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                                  f' series')
 
                 # Plot the white-light light curve
-                if meta.isplots_S4 >= 3:
+                if meta.isplots_S4 >= 1:
                     plots_s4.binned_lightcurve(meta, log, lc, 0, white=True)
                     if 'skylev' in list(spec.keys()):
                         plots_s4.binned_background(meta, log, lc, 


### PR DESCRIPTION
This functionality enables users to examine the background for trends without saving the full 2D background array (large file sizes!). Also makes plots of the background light curves in S4 for quick inspection. 