### PR TITLE
Addresses #730 and small multwhite bug

### DIFF
--- a/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
@@ -56,9 +56,9 @@ class ExpRampModel(Model):
                     # of the original time axis
                     trim1, trim2 = get_trim(self.nints, chan)
                     time = self.time[trim1:trim2]
-                    self.time_local[trim1:trim2] = time-time[0]
+                    self.time_local[trim1:trim2] = time-time.data[0]
             else:
-                self.time_local = self.time - self.time[0]
+                self.time_local = self.time - self.time.data[0]
 
     def _parse_coeffs(self):
         """Convert dict of 'r#' coefficients into a list

--- a/src/eureka/S5_lightcurve_fitting/models/Model.py
+++ b/src/eureka/S5_lightcurve_fitting/models/Model.py
@@ -258,7 +258,7 @@ class Model:
         if self.name != self.default_name:
             label += ': '+self.name
 
-        if not share:
+        if not share and not self.multwhite:
             channel = 0
         else:
             channel = chan


### PR DESCRIPTION
Fixes bug when first time array element is masked in exponential ramp fitting. (#730 )

Also addresses bug when making a final plot if using multwhite fitting with no shared parameters (was incorrectly setting the channel to 0 for all channels for this plot, mismatched time arrays caused problems). Edge case bug for sure, came up when trying to figure out why my exponential ramps weren't working and I had all the normally "shared" parameters fixed. 