### PR TITLE
Fixing bug in light travel time calculation for circular orbit

### DIFF
--- a/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
@@ -537,13 +537,6 @@ def true_anomaly(model, t, lib=np, xtol=1e-10):
     -------
     ndarray
         The true anomaly in radians.
-
-    Notes
-    -----
-    History:
-
-    - March 2023 Taylor Bell
-        Based on Bell_EBM code, but modified to enable theano code.
     """
     return 2.*lib.arctan(lib.sqrt((1.+model.ecc)/(1.-model.ecc)) *
                          lib.tan(eccentric_anomaly(model, t, lib,
@@ -569,13 +562,6 @@ def eccentric_anomaly(model, t, lib=np, xtol=1e-10):
     -------
     ndarray
         The eccentric anomaly in radians.
-
-    Notes
-    -----
-    History:
-
-    - March 2023 Taylor Bell
-        Based on Bell_EBM code, but modified to enable theano code.
     """
     ta_peri = np.pi/2.-model.w*np.pi/180.
     ea_peri = 2.*lib.arctan(lib.sqrt((1.-model.ecc)/(1.+model.ecc)) *
@@ -616,13 +602,6 @@ def FSSI_Eccentric_Inverse(model, M, lib=np, xtol=1e-10):
     -------
     ndarray
         The eccentric anomaly in radians.
-
-    Notes
-    -----
-    History:
-
-    - March 2023 Taylor Bell
-        Based on Bell_EBM code, but modified to enable theano code.
     """
     xtol = np.max([1e-15, xtol])
     nGrid = (xtol/100.)**(-1./4.)
@@ -659,13 +638,6 @@ def FSSI(Y, x, f, fP, lib=np):
     -------
     ndarray
         The numerical approximation of f^-(y).
-
-    Notes
-    -----
-    History:
-
-    - March 2023 Taylor Bell
-        Based on Bell_EBM code, but modified to enable theano code.
     """
     y = f(x)
     d = 1./fP(x)
@@ -724,15 +696,6 @@ def correct_light_travel_time(time, pl_params):
         Updated times that can be put into batman transit and eclipse functions
         that will give the expected results assuming a finite light travel
         speed.
-
-    Notes
-    -----
-    History:
-
-    - 2022-03-31 Taylor J Bell
-        Initial version based on the Bell_EMB KeplerOrbit.py file by
-        Taylor J Bell and the light travel time calculations of SPIDERMAN's
-        web.c file by Tom Louden
     '''
     # Need to convert from a/Rs to a in meters
     a = pl_params.a * (pl_params.Rs*const.R_sun.value)
@@ -748,7 +711,7 @@ def correct_light_travel_time(time, pl_params):
     else:
         # No need to solve Kepler's equation for circular orbits, so save
         # some computation time
-        transit_x = a*np.sin(pl_params.inc)
+        transit_x = a*np.sin(pl_params.inc*np.pi/180)
         old_x = transit_x*np.cos(2*np.pi*(time-pl_params.t0)/pl_params.per)
 
     # Get the radial distance variations of the planet


### PR DESCRIPTION
Resolves #735

There was previously an error in the units used within a sin function call, where degrees were accidentally passed in instead of radians.