### PR TITLE
Fixes bugs in Stage 1 GLBS due to recent PR

### DIFF
--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -62,11 +62,11 @@ def GLBS(input_model, log, meta):
                                          grp_data.shape)
             grp_mask |= trace_mask
 
-        xrdata = (['time', 'y', 'x'], grp_data)
-        xrmask = (['time', 'y', 'x'], grp_mask)
-        xrdict = dict(flux=xrdata, mask=xrmask)
-        data = xrio.makeDataset(dictionary=xrdict)
-        data['flux'].attrs['flux_units'] = 'n/a'
+        data = xrio.makeDataset()
+        time = np.arange(grp_data.shape[0])
+        data['flux'] = xrio.makeFluxLikeDA(grp_data, time, flux_units='n/a',
+                                           time_units='n/a', name='flux')
+        data['mask'] = (['time', 'y', 'x'], grp_mask)
         data.attrs['intstart'] = meta.intstart
         meta.bg_dir = 'CxC'
 

--- a/src/eureka/S1_detector_processing/s1_meta.py
+++ b/src/eureka/S1_detector_processing/s1_meta.py
@@ -1,3 +1,4 @@
+# pylint: disable=attribute-defined-outside-init
 from ..lib.readECF import MetaClass
 
 
@@ -185,6 +186,8 @@ class S1MetaClass(MetaClass):
             self.p3thresh = getattr(self, 'p3thresh', 3)
             # Row-by-row BG subtraction (only useful for NIRCam)
             self.bg_row_by_row = getattr(self, 'bg_row_by_row', False)
+            self.orders = getattr(self, 'orders', None)
+            self.src_ypos = getattr(self, 'src_ypos', 15)
         # bg_x1 and bg_x2 also need to be defined if meta.masktrace is True
         # Left edge of exclusion region for row-by-row BG subtraction
         self.bg_x1 = getattr(self, 'bg_x1', None)

--- a/src/eureka/S5_lightcurve_fitting/lightcurve.py
+++ b/src/eureka/S5_lightcurve_fitting/lightcurve.py
@@ -216,9 +216,10 @@ class LightCurve(m.Model):
                 binned_unc = unc
             else:
                 nbin_plot = meta.nbin_plot
-                binned_time = util.binData_time(time, time, nbin_plot)
-                binned_flux = util.binData_time(flux, time, nbin_plot)
-                binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
+                binned_time = util.binData_time(time, time, nbin=nbin_plot)
+                binned_flux = util.binData_time(flux, time, nbin=nbin_plot)
+                binned_unc = util.binData_time(unc, time, nbin=nbin_plot,
+                                               err=True)
 
             fig = plt.figure(5103, figsize=(8, 6))
             fig.clf()

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -40,16 +40,6 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
     isTitle : bool; optional
         Should figure have a title. Defaults to True.
 
-    Notes
-    -----
-    History:
-
-    - December 29, 2021 Taylor Bell
-        Moved plotting code to a separate function.
-    - January 7-22, 2022 Megan Mansfield
-        Adding ability to do a single shared fit across all channels
-    - February 28-March 1, 2022 Caroline Piaulet
-        Adding scatter_ppm parameter
     """
     if not isinstance(fitter, str):
         raise ValueError(f'Expected type str for fitter, instead received a '
@@ -108,12 +98,12 @@ def plot_fit(lc, model, meta, fitter, isTitle=True):
             binned_res = residuals
         else:
             nbin_plot = meta.nbin_plot
-            binned_time = util.binData_time(time, time, nbin_plot)
-            binned_flux = util.binData_time(flux, time, nbin_plot)
-            binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
+            binned_time = util.binData_time(time, time, nbin=nbin_plot)
+            binned_flux = util.binData_time(flux, time, nbin=nbin_plot)
+            binned_unc = util.binData_time(unc, time, nbin=nbin_plot, err=True)
             binned_normflux = util.binData_time(flux/model_sys - gp, time,
-                                                nbin_plot)
-            binned_res = util.binData_time(residuals, time, nbin_plot)
+                                                nbin=nbin_plot)
+            binned_res = util.binData_time(residuals, time, nbin=nbin_plot)
 
         fig = plt.figure(5101, figsize=(8, 6))
         plt.clf()
@@ -238,9 +228,9 @@ def plot_phase_variations(lc, model, meta, fitter, isTitle=True):
             binned_unc = unc
         else:
             nbin_plot = meta.nbin_plot
-            binned_time = util.binData_time(time, time, nbin_plot)
-            binned_flux = util.binData_time(flux, time, nbin_plot)
-            binned_unc = util.binData_time(unc, time, nbin_plot, err=True)
+            binned_time = util.binData_time(time, time, nbin=nbin_plot)
+            binned_flux = util.binData_time(flux, time, nbin=nbin_plot)
+            binned_unc = util.binData_time(unc, time, nbin=nbin_plot, err=True)
 
         # Setup the figure
         fig = plt.figure(5104, figsize=(8, 6))

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -602,7 +602,7 @@ def normalize_spectrum(meta, optspec, opterr=None, optmask=None, scandir=None):
                         normspec[iscans[r::meta.nreads]], axis=0)
     else:
         if opterr is not None:
-            normerr = normerr/np.ma.mean(normspec, axis=0)
+            normerr = np.ma.abs(normerr/np.ma.mean(normspec, axis=0))
         normspec = normspec/np.ma.mean(normspec, axis=0)
 
     if opterr is not None:

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -596,8 +596,8 @@ def normalize_spectrum(meta, optspec, opterr=None, optmask=None, scandir=None):
             if len(iscans) > 0:
                 for r in range(meta.nreads):
                     if opterr is not None:
-                        normerr[iscans[r::meta.nreads]] /= np.ma.mean(
-                            normspec[iscans[r::meta.nreads]], axis=0)
+                        normerr[iscans[r::meta.nreads]] /= np.ma.abs(np.ma.mean(
+                            normspec[iscans[r::meta.nreads]], axis=0))
                     normspec[iscans[r::meta.nreads]] /= np.ma.mean(
                         normspec[iscans[r::meta.nreads]], axis=0)
     else:


### PR DESCRIPTION
The recent PR that enabled the NIRISS pipeline made some important changes that didn't make it into Stage 1.  When running group-level BG subtraction, `meta.orders` and `meta.src_ypos` need to be specified.  

There was also an issue with how an Xarray was being created, such that it didn't have the necessary coordinates.

A big thanks to @astroRez for finding the issue and helping to come up with a solution.