### PR TITLE
S1 background patches

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,8 +6,8 @@ Installation methods
 --------------------
 
 In order to have consistent, repeatable results across the ``Eureka!`` user community, we recommend that all general users install
-the most recent stable release of ``Eureka!``, v1.2. The following installation instructions are written with this in mind,
-and the most recent stable release is also available as a zipped archive `here <https://github.com/kevin218/Eureka/releases/tag/v1.2>`_.
+the most recent stable release of ``Eureka!``, v1.2.1. The following installation instructions are written with this in mind,
+and the most recent stable release is also available as a zipped archive `here <https://github.com/kevin218/Eureka/releases/tag/v1.2.1>`_.
 Also note that if you are using a macOS device with an Apple Silicon processor (e.g., M1), you may need to use the ``conda`` environment.yml file
 installation instructions below as the ``pip`` dependencies have been reported to fail to build on Apple Silicon processors.
 
@@ -35,7 +35,7 @@ Once in your new conda environment, you can install ``Eureka!`` directly from so
 
 .. code-block:: bash
 
-	git clone -b v1.2 https://github.com/kevin218/Eureka.git
+	git clone -b v1.2.1 https://github.com/kevin218/Eureka.git
 	cd Eureka
 	pip install -e '.[jwst]'
 
@@ -47,7 +47,7 @@ Once in your new conda environment, you can install the ``Eureka!`` package with
 
 .. code-block:: bash
 
-	pip install -e 'eureka[jwst]@git+https://github.com/kevin218/Eureka.git@v1.2'
+	pip install -e 'eureka[jwst]@git+https://github.com/kevin218/Eureka.git@v1.2.1'
 
 Other specific branches can be installed using:
 
@@ -88,7 +88,7 @@ To install using conda:
 
 .. code-block:: bash
 
-	git clone -b v1.2 https://github.com/kevin218/Eureka.git
+	git clone -b v1.2.1 https://github.com/kevin218/Eureka.git
 	cd Eureka
 	conda env create --file environment.yml --force
 	conda activate eureka

--- a/src/eureka/S1_detector_processing/s1_meta.py
+++ b/src/eureka/S1_detector_processing/s1_meta.py
@@ -291,3 +291,10 @@ class S1MetaClass(MetaClass):
         if self.remove_390hz:
             raise AssertionError('remove_390hz cannot be set to True for NIR '
                                  'instruments!')
+
+    def set_NIRISS_defaults(self):
+        '''Set Stage 1 specific defaults for NIRISS.
+        '''
+        self.orders = getattr(self, 'orders', [1, 2])
+
+        self.set_NIR_defaults()

--- a/src/eureka/S1_detector_processing/s1_meta.py
+++ b/src/eureka/S1_detector_processing/s1_meta.py
@@ -192,7 +192,6 @@ class S1MetaClass(MetaClass):
             # Row-by-row BG subtraction (only useful for NIRCam)
             self.bg_row_by_row = getattr(self, 'bg_row_by_row', False)
             self.orders = getattr(self, 'orders', None)
-            self.src_ypos = getattr(self, 'src_ypos', None)
         # bg_x1 and bg_x2 also need to be defined if meta.masktrace is True
         # Left edge of exclusion region for row-by-row BG subtraction
         self.bg_x1 = getattr(self, 'bg_x1', None)

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -59,7 +59,9 @@ def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):
     # First apply any instrument-specific defaults
     if meta.inst == 'miri':
         meta.set_MIRI_defaults()
-    elif meta.inst in ['nircam', 'nirspec', 'niriss']:
+    elif meta.inst == 'niriss':
+        meta.set_NIRISS_defaults()
+    elif meta.inst in ['nircam', 'nirspec']:
         meta.set_NIR_defaults()
     # Then apply instrument-agnostic defaults
     meta.set_defaults()

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -128,7 +128,8 @@ def BGsubtraction(data, meta, log, m, isplots=0):
     if hasattr(data, 'medflux'):
         data['medflux'] -= np.median(data.bg, axis=0)
 
-    if (meta.bg_dir == 'CxC') and (meta.inst != 'wfc3'):
+    if ('uncal' not in meta.suffix and meta.bg_dir == 'CxC' and
+            meta.inst != 'wfc3'):
         # Save BG value at source position and BG stddev (no outlier rejection)
         coords = list(data.coords.keys())
         coords.remove('y')

--- a/src/eureka/S3_data_reduction/s3_meta.py
+++ b/src/eureka/S3_data_reduction/s3_meta.py
@@ -1,5 +1,5 @@
 import numpy as np
-from stdatamodels.jwst.datamodels import CubeModel
+from jwst.datamodels import JwstDataModel
 
 from ..lib.readECF import MetaClass
 
@@ -69,13 +69,13 @@ class S3MetaClass(MetaClass):
         if self.xwindow[0] is None:
             self.xwindow[0] = 0
         if self.xwindow[1] is None:
-            with CubeModel(self.segment_list[0]) as model:
-                self.xwindow[1] = model.data.shape[2]
+            with JwstDataModel(self.segment_list[0]) as model:
+                self.xwindow[1] = model.data.shape[2]-1
         if self.ywindow[0] is None:
             self.ywindow[0] = 0
         if self.ywindow[1] is None:
-            with CubeModel(self.segment_list[0]) as model:
-                self.ywindow[1] = model.data.shape[1]
+            with JwstDataModel(self.segment_list[0]) as model:
+                self.ywindow[1] = model.data.shape[1]-1
 
         self.src_pos_type = getattr(self, 'src_pos_type', 'gaussian')
         self.record_ypos = getattr(self, 'record_ypos', True)
@@ -334,7 +334,7 @@ class S3MetaClass(MetaClass):
                                  f'got {self.subarray_halfwidth}')
 
             # Get the centroid position and the subarray size
-            with CubeModel(self.segment_list[0]) as model:
+            with JwstDataModel(self.segment_list[0]) as model:
                 guess = [model.meta.wcsinfo.crpix1,
                          model.meta.wcsinfo.crpix2]
                 ysize, xsize = model.data.shape[1:]


### PR DESCRIPTION
Fixing S1 GLBS-related bugs

This PR resolves #763 and resolves #764

This PR also resolves an issue I was having with the recent tweaks to s3_meta.py with an out-of-limits issue from xwindow[1] and ywindow[1] being too large by 1, as well as some strange issue with `CubeModel` expecting inputs of a different size which was resolved by switching to the more generic `JwstDataModel`.

@kevin218, do you think it'd be worth issuing a v1.2.1 release with this PR or at least doing so quite soon? If so, I can update the docs pages to refer to v1.2.1 instead of v1.2