### PR TITLE
Adds number of pixel bins as option in S4

### DIFF
--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -47,8 +47,6 @@ def GLBS(input_model, log, meta):
         meta.int_end = meta.n_int
     else:
         meta.int_end = meta.int_start+meta.nplots
-    if meta.inst == 'miri':
-        meta.isrotate = 0
 
     for ngrp in range(all_data.shape[1]):
         log.writelog(f'  Starting group {ngrp}.')
@@ -69,9 +67,13 @@ def GLBS(input_model, log, meta):
         data['mask'] = (['time', 'y', 'x'], grp_mask)
         data.attrs['intstart'] = meta.intstart
         meta.bg_dir = 'CxC'
+        if meta.inst == 'miri':
+            meta.isrotate = 0
 
-        # Only show plots for the last group
-        if ngrp == all_data.shape[1]-1:
+        # Only show plots for the last good group
+        if meta.inst == 'miri' and ngrp == all_data.shape[1]-2:
+            isplots_S1 = meta.isplots_S1
+        elif meta.inst != 'miri' and ngrp == all_data.shape[1]-1:
             isplots_S1 = meta.isplots_S1
         else:
             isplots_S1 = 0
@@ -81,7 +83,13 @@ def GLBS(input_model, log, meta):
         # (only useful for NIRCam data)
         if meta.bg_row_by_row:
             meta.bg_dir = 'RxR'
-            if ngrp == all_data.shape[1]-1:
+            if meta.inst == 'miri':
+                meta.isrotate = 2
+                if ngrp == all_data.shape[1]-2:
+                    isplots_S1 = meta.isplots_S1
+                else:
+                    isplots_S1 = 0
+            elif ngrp == all_data.shape[1]-1:
                 isplots_S1 = meta.isplots_S1
             else:
                 isplots_S1 = 0

--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -67,33 +67,36 @@ def GLBS(input_model, log, meta):
         data['mask'] = (['time', 'y', 'x'], grp_mask)
         data.attrs['intstart'] = meta.intstart
         meta.bg_dir = 'CxC'
-        if meta.inst == 'miri':
-            meta.isrotate = 0
 
-        # Only show plots for the last good group
-        if meta.inst == 'miri' and ngrp == all_data.shape[1]-2:
+        if meta.isplots_S1 == 4:
+            # Plot all groups
+            isplots_S1 = meta.isplots_S1
+        # Otherwise, only show plots for the last good group
+        elif meta.inst == 'miri' and ngrp == all_data.shape[1]-2:
             isplots_S1 = meta.isplots_S1
         elif meta.inst != 'miri' and ngrp == all_data.shape[1]-1:
             isplots_S1 = meta.isplots_S1
         else:
             isplots_S1 = 0
-        data = bkg.BGsubtraction(data, meta, log, meta.m, isplots_S1)
+        data = bkg.BGsubtraction(data, meta, log, meta.m, isplots_S1,
+                                 group=ngrp)
 
         # Perform BG subtraction along dispersion direction
         # (only useful for NIRCam data)
         if meta.bg_row_by_row:
             meta.bg_dir = 'RxR'
-            if meta.inst == 'miri':
-                meta.isrotate = 2
-                if ngrp == all_data.shape[1]-2:
-                    isplots_S1 = meta.isplots_S1
-                else:
-                    isplots_S1 = 0
-            elif ngrp == all_data.shape[1]-1:
+            if meta.isplots_S1 == 4:
+                # Plot all groups
+                isplots_S1 = meta.isplots_S1
+            # Otherwise, only show plots for the last good group
+            elif meta.inst == 'miri' and ngrp == all_data.shape[1]-2:
+                isplots_S1 = meta.isplots_S1
+            elif meta.inst != 'miri' and ngrp == all_data.shape[1]-1:
                 isplots_S1 = meta.isplots_S1
             else:
                 isplots_S1 = 0
-            data = bkg.BGsubtraction(data, meta, log, meta.m, isplots_S1)
+            data = bkg.BGsubtraction(data, meta, log, meta.m, isplots_S1,
+                                     group=ngrp)
 
         # Overwrite values in all_data
         all_data[:, ngrp, :, :] = data['flux'].values

--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -67,6 +67,8 @@ def GLBS(input_model, log, meta):
         data['mask'] = (['time', 'y', 'x'], grp_mask)
         data.attrs['intstart'] = meta.intstart
         meta.bg_dir = 'CxC'
+        if meta.inst == 'miri':
+            meta.isrotate = 0
 
         if meta.isplots_S1 == 4:
             # Plot all groups
@@ -85,6 +87,8 @@ def GLBS(input_model, log, meta):
         # (only useful for NIRCam data)
         if meta.bg_row_by_row:
             meta.bg_dir = 'RxR'
+            if meta.inst == 'miri':
+                meta.isrotate = 2
             if meta.isplots_S1 == 4:
                 # Plot all groups
                 isplots_S1 = meta.isplots_S1

--- a/src/eureka/S1_detector_processing/s1_meta.py
+++ b/src/eureka/S1_detector_processing/s1_meta.py
@@ -7,13 +7,6 @@ class S1MetaClass(MetaClass):
 
     This class loads a Stage 1 Eureka! Control File (ecf) and lets you
     query the parameters and values.
-
-    Notes
-    -----
-    History:
-
-    - 2024-03 Taylor J Bell
-        Made specific S1 class based on MetaClass
     '''
 
     def __init__(self, folder=None, file=None, eventlabel=None, **kwargs):
@@ -33,25 +26,11 @@ class S1MetaClass(MetaClass):
         **kwargs : dict
             Any additional parameters to be loaded into the MetaClass after
             the ECF has been read in
-
-        Notes
-        -----
-        History:
-
-        - 2024-03 Taylor J Bell
-            Initial version.
         '''
         super().__init__(folder, file, eventlabel, stage=1, **kwargs)
 
     def set_defaults(self):
         '''Set Stage 1 specific defaults for generic instruments.
-
-        Notes
-        -----
-        History:
-
-        - 2024-03 Taylor J Bell
-            Initial version setting defaults for any instrument.
         '''
         # Data file suffix
         self.suffix = getattr(self, 'suffix', 'uncal')
@@ -235,13 +214,6 @@ class S1MetaClass(MetaClass):
 
     def set_MIRI_defaults(self):
         '''Set Stage 1 specific defaults for MIRI.
-
-        Notes
-        -----
-        History:
-
-        - 2024-03 Taylor J Bell
-            Initial version setting defaults for MIRI.
         '''
         # MIRI-specific pipeline stages
 

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -129,15 +129,6 @@ class EurekaS1Pipeline(Detector1Pipeline):
     '''A wrapper class for jwst.pipeline.calwebb_detector1.Detector1Pipeline
 
     This wrapper class allows non-standard changes to Stage 1 for Eureka!.
-
-    Notes
-    -----
-    History:
-
-    - October 2021 Aarynn Carter /  Eva-Maria Ahrer
-        Initial version
-    - February 2022 Aarynn Carter /  Eva-Maria Ahrer
-        Updated for JWST version 1.3.3, code restructure
     '''
 
     def run_eurekaS1(self, filename, meta, log):
@@ -151,22 +142,13 @@ class EurekaS1Pipeline(Detector1Pipeline):
             The metadata object.
         log : logedit.Logedit
             The open log in which notes from this step can be added.
-
-        Notes
-        -----
-        History:
-
-        - October 2021 Aarynn Carter /  Eva-Maria Ahrer
-            Initial version
-        - February 2022 Aarynn Carter /  Eva-Maria Ahrer
-            Updated for JWST version 1.3.3, code restructure
         '''
         # Define superbias offset procedure
         self.superbias = Eureka_SuperBiasStep()
         self.superbias.s1_meta = meta
         self.superbias.s1_log = log
 
-        # Reset suffix and assign whether to save and the output directory
+        # Reset suffix and assign whether to save the output directory
         self.suffix = None
         self.save_results = (not meta.testing_S1)
         self.output_dir = meta.outputdir

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -11,7 +11,7 @@ from . import plots_s3
 __all__ = ['BGsubtraction', 'fitbg', 'fitbg2']
 
 
-def BGsubtraction(data, meta, log, m, isplots=0):
+def BGsubtraction(data, meta, log, m, isplots=0, group=None):
     """Does background subtraction using inst.fit_bg & background.fitbg
 
     Parameters
@@ -28,6 +28,8 @@ def BGsubtraction(data, meta, log, m, isplots=0):
     isplots : bool; optional
        Plots intermediate steps for the background fitting routine.
        Default is False.
+    group : int; optional
+        The group number (only applies to Stage 1).  Default is None.
 
     Returns
     -------
@@ -151,11 +153,11 @@ def BGsubtraction(data, meta, log, m, isplots=0):
     # Make image+background plots
     if isplots >= 3:
         if meta.orders is None:
-            plots_s3.image_and_background(data, meta, log, m)
+            plots_s3.image_and_background(data, meta, log, m, group=group)
         else:
             for order in meta.orders:
                 plots_s3.image_and_background(data.sel(order=order), meta,
-                                              log, m, order=order)
+                                              log, m, order=order, group=group)
 
     return data
 

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -358,12 +358,10 @@ def fit_bg(dataim, datamask, n, meta, isplots=0):
     """
     if meta.bg_dir == 'RxR':
         y1, y2 = meta.bg_x1, meta.bg_x2
-        isrotate = 2
     else:
         y1, y2 = meta.bg_y1, meta.bg_y2
-        isrotate = 0
     bg, mask = background.fitbg(dataim, meta, datamask, y1, y2, deg=meta.bg_deg,
-                                threshold=meta.p3thresh, isrotate=isrotate,
+                                threshold=meta.p3thresh, isrotate=meta.isrotate,
                                 isplots=isplots)
     return bg, mask, n
 

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -356,9 +356,12 @@ def fit_bg(dataim, datamask, n, meta, isplots=0):
     n : int
         The current integration number.
     """
-    bg, mask = background.fitbg(dataim, meta, datamask, meta.bg_y1,
-                                meta.bg_y2, deg=meta.bg_deg,
-                                threshold=meta.p3thresh, isrotate=2,
+    if meta.bg_dir == 'RxR':
+        y1, y2 = meta.bg_x1, meta.bg_x2
+    else:
+        y1, y2 = meta.bg_y1, meta.bg_y2
+    bg, mask = background.fitbg(dataim, meta, datamask, y1, y2, deg=meta.bg_deg,
+                                threshold=meta.p3thresh, isrotate=meta.isrotate,
                                 isplots=isplots)
     return bg, mask, n
 

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -358,10 +358,12 @@ def fit_bg(dataim, datamask, n, meta, isplots=0):
     """
     if meta.bg_dir == 'RxR':
         y1, y2 = meta.bg_x1, meta.bg_x2
+        isrotate = 2
     else:
         y1, y2 = meta.bg_y1, meta.bg_y2
+        isrotate = 0
     bg, mask = background.fitbg(dataim, meta, datamask, y1, y2, deg=meta.bg_deg,
-                                threshold=meta.p3thresh, isrotate=meta.isrotate,
+                                threshold=meta.p3thresh, isrotate=isrotate,
                                 isplots=isplots)
     return bg, mask, n
 

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -1515,9 +1515,9 @@ def get_bounds(x, y=None):
     Parameters
     ----------
     x : 1D array
-        Pixel indeces along x axis.
+        Pixel indices along x axis.
     y : 1D array, optional
-        Pixel indeces along y axis.
+        Pixel indices along y axis.
 
     Returns
     -------

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -160,9 +160,11 @@ def image_and_background(data, meta, log, m, order=None, group=None):
     # If need be, transpose array so that largest dimension is on x axis
     if len(data.x) < len(data.y):
         data = data.transpose('time', 'x', 'y')
-        xmin, xmax, ymin, ymax = get_bounds(data.flux.y.values, data.flux.x.values)
+        xmin, xmax, ymin, ymax = get_bounds(data.flux.y.values,
+                                            data.flux.x.values)
     else:
-        xmin, xmax, ymin, ymax = get_bounds(data.flux.x.values, data.flux.y.values)
+        xmin, xmax, ymin, ymax = get_bounds(data.flux.x.values,
+                                            data.flux.y.values)
 
     intstart = data.attrs['intstart']
     subdata = np.ma.masked_invalid(data.flux.values)

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -158,7 +158,9 @@ def image_and_background(data, meta, log, m, order=None):
     # If need be, transpose array so that largest dimension is on x axis
     if len(data.x) < len(data.y):
         data = data.transpose('time', 'x', 'y')
-    xmin, xmax, ymin, ymax = get_bounds(data.flux.x.values, data.flux.y.values)
+        xmin, xmax, ymin, ymax = get_bounds(data.flux.y.values, data.flux.x.values)
+    else:
+        xmin, xmax, ymin, ymax = get_bounds(data.flux.x.values, data.flux.y.values)
 
     intstart = data.attrs['intstart']
     subdata = np.ma.masked_invalid(data.flux.values)

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -136,7 +136,7 @@ def lc_nodriftcorr(meta, wave_1d, optspec, optmask=None, scandir=None,
         plt.pause(0.2)
 
 
-def image_and_background(data, meta, log, m, order=None):
+def image_and_background(data, meta, log, m, order=None, group=None):
     '''Make image+background plot. (Figs 3301)
 
     Parameters
@@ -150,7 +150,9 @@ def image_and_background(data, meta, log, m, order=None):
     m : int
         The file number.
     order : int; optional
-        Spectral order. Default is None
+        Spectral order. Default is None.
+    group : int; optional
+        The group number (only applies to Stage 1).  Default is None.
     '''
     log.writelog('  Creating figures for background subtraction...',
                  mute=(not meta.verbose))
@@ -210,9 +212,13 @@ def image_and_background(data, meta, log, m, order=None):
             orderkey = ''
         else:
             orderkey = f'_order{order}'
+        if group is None:
+            groupkey = ''
+        else:
+            groupkey = f'_group{group}'
         fname = (f'figs{os.sep}fig3301_file{file_number}_int{int_number}' +
-                 f'{orderkey}' + '_' + meta.bg_dir + '_ImageAndBackground' +
-                 plots.figure_filetype)
+                 f'{orderkey}' + f'{groupkey}' + '_' + meta.bg_dir +
+                 '_ImageAndBackground' + plots.figure_filetype)
         plt.savefig(meta.outputdir+fname, dpi=300)
         if not meta.hide_plots:
             plt.pause(0.2)

--- a/src/eureka/S3_data_reduction/s3_meta.py
+++ b/src/eureka/S3_data_reduction/s3_meta.py
@@ -249,6 +249,8 @@ class S3MetaClass(MetaClass):
         '''
         self.set_spectral_defaults()
         self.isrotate = 2
+        self.bg_dir = 'CxC'
+        self.bg_row_by_row = False
 
     def set_NIRCam_defaults(self):
         '''Set Stage 3 specific defaults for NIRCam.

--- a/src/eureka/S3_data_reduction/s3_meta.py
+++ b/src/eureka/S3_data_reduction/s3_meta.py
@@ -248,6 +248,7 @@ class S3MetaClass(MetaClass):
         '''Set Stage 3 specific defaults for MIRI.
         '''
         self.set_spectral_defaults()
+        self.isrotate = 2
 
     def set_NIRCam_defaults(self):
         '''Set Stage 3 specific defaults for NIRCam.

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -453,10 +453,10 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                     log.writelog(f"  Bandpass {i} = "
                                  f"{lc.wave_low.values[i]:.3f} - "
                                  f"{lc.wave_hi.values[i]:.3f}")
-                    # Compute valid indeces within wavelength range
+                    # Compute valid indices within wavelength range
                     index = np.where((spec.wave_1d >= lc.wave_low.values[i]) *
                                      (spec.wave_1d < lc.wave_hi.values[i]))[0]
-                    log.writelog(f"    Indeces {index[0]} - {index[-1]}, "
+                    log.writelog(f"    indices {index[0]} - {index[-1]}, "
                                  f"{len(index)} in total")
                     # Make masked arrays for easy summing
                     optspec_ma = np.ma.masked_where(
@@ -518,7 +518,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
             if meta.compute_white and not meta.photometry:
                 log.writelog("Generating white-light light curve")
 
-                # Compute valid indeces within wavelength range
+                # Compute valid indices within wavelength range
                 index = np.where((spec.wave_1d >= meta.wave_min) *
                                  (spec.wave_1d < meta.wave_max))[0]
                 central_wavelength = np.mean(spec.wave_1d[index].values)

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -211,6 +211,9 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                 # User wants bins defined by the given number of pixels
                 istart = np.where(wave_1d >= meta.wave_min)[0][0]
                 iend = np.where(wave_1d >= meta.wave_max)[0][0]
+                # Shift bins by some number of pixels (only useful for MIRI)
+                istart += meta.npixelshift
+                iend += meta.npixelshift
                 edges = wave_1d[istart:iend+meta.npixelbins:meta.npixelbins]
                 dwav = np.ediff1d(
                     wave_1d[istart:iend+meta.npixelbins])[::meta.npixelbins]/2

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -200,7 +200,29 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                 meta.nplots = meta.n_int
 
             # Determine wavelength bins
-            if meta.nspecchan is None:
+            if meta.wave_input is not None:
+                # bins defined by file input. 2 columns: low and high edges
+                meta.wave_low, meta.wave_hi = np.genfromtxt(meta.wave_input).T
+                meta.wave = (meta.wave_low + meta.wave_hi)/2
+                meta.nspecchan = len(meta.wave)
+                log.writelog(f'  Using input file to create {meta.nspecchan} '
+                             'channels.')
+            elif meta.nspecchan is None and meta.npixelbins is not None:
+                # User wants bins defined by the given number of pixels
+                istart = np.where(wave_1d >= meta.wave_min)[0][0]
+                iend = np.where(wave_1d >= meta.wave_max)[0][0]
+                edges = wave_1d[istart:iend+meta.npixelbins:meta.npixelbins]
+                dwav = np.ediff1d(
+                    wave_1d[istart:iend+meta.npixelbins])[::meta.npixelbins]/2
+                if len(edges) != len(dwav):
+                    edges = edges[:len(dwav)]
+                meta.wave_low = (edges-dwav)[:-1]
+                meta.wave_hi = (edges-dwav)[1:]
+                meta.wave = (meta.wave_low + meta.wave_hi)/2
+                meta.nspecchan = len(meta.wave)
+                log.writelog(f'  Creating {meta.nspecchan} channels of '
+                             f'width {meta.npixelbins} pixels each.')
+            elif meta.nspecchan is None:
                 # User wants unbinned spectra
                 dwav = np.ediff1d(wave_1d)/2
                 # Approximate the first neg_dwav as the same as the second
@@ -215,11 +237,8 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                 meta.wave_low = meta.wave-neg_dwav
                 meta.wave_hi = meta.wave+pos_dwav
                 meta.nspecchan = len(meta.wave)
-            elif meta.wave_input is not None:
-                # bins defined by file input. 2 columns: low and high edges
-                meta.wave_low, meta.wave_hi = np.genfromtxt(meta.wave_input).T
-                meta.wave = (meta.wave_low + meta.wave_hi)/2
-                meta.nspecchan = len(meta.wave)
+                log.writelog(f'  Creating {meta.nspecchan} channels at '
+                             f'native resolution.')
             elif meta.wave_hi is None or meta.wave_low is None:
                 binsize = (meta.wave_max - meta.wave_min)/meta.nspecchan
                 meta.wave_low = np.round(np.linspace(meta.wave_min,
@@ -229,6 +248,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                                                     meta.wave_max,
                                                     meta.nspecchan), 3)
                 meta.wave = (meta.wave_low + meta.wave_hi)/2
+                log.writelog('  Using defined wave_hi and wave_low arrays.')
             else:
                 # wave_low and wave_hi were passed in - make them arrays
                 meta.wave_low = np.array(meta.wave_low)
@@ -433,6 +453,8 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                     # Compute valid indeces within wavelength range
                     index = np.where((spec.wave_1d >= lc.wave_low.values[i]) *
                                      (spec.wave_1d < lc.wave_hi.values[i]))[0]
+                    log.writelog(f"    Indeces {index[0]} - {index[-1]}, "
+                                 f"{len(index)} in total")
                     # Make masked arrays for easy summing
                     optspec_ma = np.ma.masked_where(
                         spec.optmask.values[:, index],

--- a/src/eureka/S4_generate_lightcurves/s4_meta.py
+++ b/src/eureka/S4_generate_lightcurves/s4_meta.py
@@ -91,6 +91,7 @@ class S4MetaClass(MetaClass):
         # Spectral binning/trimming control
         self.nspecchan = getattr(self, 'nspecchan', None)
         self.npixelbins = getattr(self, 'npixelbins', None)
+        self.npixelshift = getattr(self, 'npixelshift', 0)
         self.compute_white = getattr(self, 'compute_white', True)
         self.wave_input = getattr(self, 'wave_input', None)
         self.wave_min = getattr(self, 'wave_min', None)

--- a/src/eureka/S4_generate_lightcurves/s4_meta.py
+++ b/src/eureka/S4_generate_lightcurves/s4_meta.py
@@ -90,6 +90,7 @@ class S4MetaClass(MetaClass):
 
         # Spectral binning/trimming control
         self.nspecchan = getattr(self, 'nspecchan', None)
+        self.npixelbins = getattr(self, 'npixelbins', None)
         self.compute_white = getattr(self, 'compute_white', True)
         self.wave_input = getattr(self, 'wave_input', None)
         self.wave_min = getattr(self, 'wave_min', None)

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -802,16 +802,16 @@ def compute_strings(meta, log, fit_methods, limb):
     if meta.channelNumber > 0:
         suffix += f'_ch{meta.channelNumber}'
 
-    # Load a0 string coefficients
-    meta.y_param = 'a0'+suffix
-    a0 = load_s5_saves(meta, log, fit_methods)
-    if all(np.all(v == 0) for v in a0):
+    # Load rp string coefficients
+    meta.y_param = 'rp'+suffix
+    rp = load_s5_saves(meta, log, fit_methods)
+    if all(np.all(v == 0) for v in rp):
         # The parameter could not be found - skip it
         log.writelog(f'  Parameter {meta.y_param} was not in the list of '
                      'fitted parameters')
         log.writelog(f'  Skipping {y_param}')
         return meta
-    n_samples = len(a0[0])
+    n_samples = len(rp[0])
 
     # Load string coefficients
     coeffs = ['a1', 'b1', 'a2', 'b2', 'a3', 'b3']
@@ -845,13 +845,13 @@ def compute_strings(meta, log, fit_methods, limb):
 
     ht = HarmonicaTransit()
     for i in tqdm(range(meta.nspecchan)):
-        if np.all(a0[i] == 0):
+        if np.all(rp[i] == 0):
             # Channel wasn't found
             meta.spectrum_median.append(np.nan)
             meta.spectrum_err.append([np.nan, np.nan])
         else:
             # Compute transmission string
-            ab = np.array([a0[i][::ss],
+            ab = np.array([rp[i][::ss],
                            a1[i][::ss], b1[i][::ss],
                            a2[i][::ss], b2[i][::ss],
                            a3[i][::ss], b3[i][::ss]]).T

--- a/src/eureka/lib/manageevent.py
+++ b/src/eureka/lib/manageevent.py
@@ -113,21 +113,6 @@ def loadevent(filename, load=[], loadfilename=None):
         raise AssertionError(f'Unrecognized metadata save file {filename}'
                              'contains neither "_Meta_Save" or "SpecData".')
 
-    # FINDME: Do we really need this following code anymore?
-    if load != []:
-        if loadfilename is None:
-            loadfilename = filename
-
-        with h5.File(loadfilename + '.h5', 'r') as handle:
-            for param in load:
-                exec('event.' + param + ' = handle["' + param + '"][:]')
-                # calibration data:
-                if event.havecalaor:
-                    exec('event.pre' + param + ' = handle["pre' + param +
-                         '"][:]')
-                    exec('event.post' + param + ' = handle["post' + param +
-                         '"][:]')
-
     return event
 
 

--- a/src/eureka/lib/readECF.py
+++ b/src/eureka/lib/readECF.py
@@ -13,21 +13,6 @@ class MetaClass:
 
     This class loads a Eureka! Control File (ecf) and lets you
     query the parameters and values.
-
-    Notes
-    -----
-    History:
-
-    - 2009-01-02 Christopher Campo
-        Initial Version.
-    - 2010-03-08 Patricio Cubillos
-        Modified from ccampo version.
-    - 2010-10-27 Patricio Cubillos
-        Docstring updated
-    - 2011-02-12 Patricio Cubillos
-        Merged with ccampo's tepclass.py
-    - 2022-03-24 Taylor J Bell
-        Significantly modified for Eureka
     '''
 
     def __init__(self, folder='.'+os.sep, file=None, eventlabel=None,
@@ -183,8 +168,10 @@ class MetaClass:
             # If a specific CRDS context is entered in the ECF, apply it.
             # Otherwise, log and fix the default CRDS context to make sure
             # it doesn't change between different segments.
-            self.pmap = getattr(self, 'pmap',
-                                crds.get_context_name('jwst')[5:-5])
+            self.pmap = getattr(self, 'pmap', None)
+            if self.pmap is None:
+                # Only need an internet connection if pmap is None
+                self.pmap = crds.get_context_name('jwst')[5:-5]
             os.environ['CRDS_CONTEXT'] = f'jwst_{self.pmap}.pmap'
 
         if ((item == 'pmap') and hasattr(self, 'pmap') and


### PR DESCRIPTION
I've been running some tests using MIRI that required specifying spectroscopic channels using a fixed number of pixel rows.  The tests were successful, so I'm adding this new functionality to the `main` branch.

I've also enabled RxR plus CxC BG subtraction for MIRI.  Similar to the 390hz feature, this effort didn't improve the resulting spectrum.

Finally, I fixed a small (but important) bug in Stage 6.  After relabeling `a0` to `rp` in the Harmonica Stage 5 code, I forgot to update Stage 6.