### PR TITLE
Enables NIRISS SUBSTRIP96 mode

### DIFF
--- a/demos/JWST/S3_niriss_soss_template.ecf
+++ b/demos/JWST/S3_niriss_soss_template.ecf
@@ -15,6 +15,7 @@ calibrated_spectra  False   # Set True to generate flux-calibrated spectra/photo
 ywindow         [1,250]     # Vertical axis as seen in DS9
 xwindow         [6,2043]    # Horizontal axis as seen in DS9
 orders          [1,2]       # Spectral order(s)
+trace_offset    None        # Manually adjust trace position for SUBSTRIP96 mode
 src_ypos        [35,90]     # Spectral trace will be shifted to given vertical position.  Must be same size as meta.orders.
 dqmask          True        # Mask pixels with an odd entry in the DQ array
 expand          1           # Super-sampling factor along cross-dispersion direction

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -440,11 +440,11 @@ Only used for NIRISS. List of spectral orders to be reduced.
 
 trace_offset
 ''''''''''''
-Only used for NIRISS. Manually adjust trace position for SUBSTRIP96 mode.  Default is -10 pixels.
+Only used for NIRISS. PASTASOSS v1.2 doesn't correctly compute the trace position for SUBSTRIP96 mode; therefore, we have to apply a manual offset in the cross-dispersion direction.  The default is -12 pixels for SUBSTRIP96 and should be good to within a pixel or two.  If you see in Fig. 3304 that the spectrum is not quite centered, you should adjust the ``trace_offset`` accordingly.
 
 src_ypos
 ''''''''
-Only used for NIRISS. Spectral trace will be shifted to given vertical position.  Must be same size as meta.orders.
+The user should only specify this parameter for NIRISS data. Spectral trace will be shifted to given vertical position.  Must be same size as meta.orders.
 
 src_pos_type
 ''''''''''''

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -434,6 +434,18 @@ subarray_halfwidth
 ''''''''''''''''''
 Only used if any element of xwindow or ywindow is set to None, and only used for MIRI photometry data. This sets the half-width of the xwindow, ywindow subarray in pixels and is centered on the approximate centroid position. For MIRI photometry, the default is 75 pixels, which is a good value for most datasets since the MIRI full frame images are very large and it is generally helpful and faster to zoom-in on the science target.
 
+orders
+''''''
+Only used for NIRISS. List of spectral orders to be reduced.
+
+trace_offset
+''''''''''''
+Only used for NIRISS. Manually adjust trace position for SUBSTRIP96 mode.  Default is -10 pixels.
+
+src_ypos
+''''''''
+Only used for NIRISS. Spectral trace will be shifted to given vertical position.  Must be same size as meta.orders.
+
 src_pos_type
 ''''''''''''
 Determine the source position on the detector. Options: header, gaussian, weighted, max, or hst. The value 'header' uses the value of SRCYPOS in the FITS header.

--- a/src/eureka/S3_data_reduction/niriss.py
+++ b/src/eureka/S3_data_reduction/niriss.py
@@ -82,7 +82,7 @@ def read(filename, data, meta, log):
     # Duplicate science arrays for each order to be analyzed
     if isinstance(meta.orders, int):
         meta.orders = [meta.orders]
-    norders = len(meta.orders)
+    norders = len(meta.all_orders)  # FINDME: temp fix
     sci = np.repeat(sci[:, :, :, np.newaxis], norders, axis=3)
     err = np.repeat(err[:, :, :, np.newaxis], norders, axis=3)
     dq = np.repeat(dq[:, :, :, np.newaxis], norders, axis=3)
@@ -95,13 +95,13 @@ def read(filename, data, meta, log):
         meta.ywindow[1] *= meta.expand
 
     data['flux'] = xrio.makeFluxLikeDA(sci, time, flux_units, time_units,
-                                       name='flux', order=meta.orders)
+                                       name='flux', order=meta.all_orders)
     data['err'] = xrio.makeFluxLikeDA(err, time, flux_units, time_units,
-                                      name='err', order=meta.orders)
+                                      name='err', order=meta.all_orders)
     data['dq'] = xrio.makeFluxLikeDA(dq, time, "None", time_units,
-                                     name='dq', order=meta.orders)
+                                     name='dq', order=meta.all_orders)
     data['v0'] = xrio.makeFluxLikeDA(v0, time, flux_units, time_units,
-                                     name='v0', order=meta.orders)
+                                     name='v0', order=meta.all_orders)
 
     # Initialize bad pixel mask (False = good, True = bad)
     data['mask'] = (['time', 'y', 'x', 'order'], np.zeros(data.flux.shape,
@@ -133,7 +133,7 @@ def get_wave(data, meta, log):
     log.writelog(f"  The NIRISS pupil position is {pwcpos:3f} degrees",
                  mute=(not meta.verbose))
 
-    norders = len(data.order)
+    norders = len(meta.all_orders)
     data['trace'] = (['x', 'order'],
                      np.zeros((data.x.shape[0], norders)) +
                      np.array(meta.src_ypos)[np.newaxis])
@@ -141,7 +141,7 @@ def get_wave(data, meta, log):
                        np.zeros((data.x.shape[0], norders))*np.nan)
     data['wave_1d'].attrs['wave_units'] = 'microns'
 
-    for order in meta.orders:
+    for order in meta.all_orders:
         # Get trace for the given order and pupil position
         trace = get_soss_traces(pwcpos=pwcpos, order=str(order), interp=True)
         if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96' and \
@@ -155,7 +155,8 @@ def get_wave(data, meta, log):
             trace.y += meta.trace_offset
             subarray = data.attrs['mhdr']['SUBARRAY']
             log.writelog(f"  Shifting trace by {meta.trace_offset} pixels "
-                         f"for {subarray}.", mute=(not meta.verbose))
+                         f"for {subarray} and Order {order}.",
+                         mute=(not meta.verbose))
         # Assign trace and wavelength for given order
         ind1 = np.nonzero(np.in1d(trace.x, data.x.values))[0]
         ind2 = np.nonzero(np.in1d(data.x.values, trace.x))[0]
@@ -180,16 +181,20 @@ def mask_other_orders(data, meta):
     data : Xarray Dataset
         The updated Dataset object with regions masked.
     '''
-    for order in meta.orders:
+    for order in meta.all_orders:
         trace = np.round(data.trace.sel(order=order).values).astype(int)
         wave = data.wave_1d.sel(order=order).values
-        other_orders = list.copy(meta.orders)
+        other_orders = list.copy(meta.all_orders)
         other_orders.remove(order)
-        for j in np.where(~np.isnan(wave))[0]:
-            ymin = np.max((0, trace[j] - meta.spec_hw))
-            ymax = np.min((trace[j] + meta.spec_hw + 1, len(data.y) + 1))
-            for other_order in other_orders:
-                data['mask'].sel(order=other_order)[:, ymin:ymax, j] = True
+        for other_order in other_orders:
+            if other_order in meta.orders:
+                # Loop over valid wavelengths in current order
+                for j in np.where(~np.isnan(wave))[0]:
+                    ymin = np.max((0, trace[j] - meta.spec_hw))
+                    ymax = np.min((trace[j] + meta.spec_hw + 1,
+                                   len(data.y) + 1))
+                    # Mask extraction region for 'order' in 'other_order'
+                    data['mask'].sel(order=other_order)[:, ymin:ymax, j] = True
     return data
 
 
@@ -230,6 +235,25 @@ def straighten_trace(data, meta, log, m):
         shifts = np.round(data.trace.sel(order=order).values).astype(int)
         new_center = meta.src_ypos[k]
         new_shifts = new_center - shifts
+
+        # import matplotlib.pyplot as plt
+        # plt.figure(1)   #FINDME
+        # plt.clf()
+        # plt.plot(new_shifts, '-')
+        # print(f"Order {order}, Shifts:")
+        # print(new_shifts)
+
+        # Keep shifts from exceeding the height of the detector
+        # This only happens with SUBSTRIP96 and Order 2,
+        # which is not recommended.
+        ymax = data.flux.shape[1]
+        new_shifts[np.where(new_shifts > ymax)] = ymax
+        new_shifts[np.where(new_shifts < -ymax)] = -ymax
+
+        # print(f"Order {order}, New Shifts:")
+        # print(new_shifts)
+        # plt.plot(new_shifts, '--')
+        # plt.savefig(f"Order{order}.png")
 
         # broadcast the shifts to the number of integrations
         new_shifts = np.reshape(np.repeat(new_shifts,
@@ -434,13 +458,13 @@ def cut_aperture(data, meta, log):
                  mute=(not meta.verbose))
 
     apdata = np.zeros((len(data.time), 2*meta.spec_hw+1,
-                       len(data.x), len(data.order)))
+                       len(data.x), len(meta.orders)))
     aperr = np.zeros_like(apdata)
     apmask = np.zeros_like(apdata, dtype=bool)
     apbg = np.zeros_like(apdata)
     apv0 = np.zeros_like(apdata)
     apmedflux = np.zeros_like(apdata[0])
-    for k in range(len(data.order)):
+    for k in range(len(meta.orders)):
         ap_y1 = int(meta.src_ypos[k] - meta.spec_hw)
         ap_y2 = int(meta.src_ypos[k] + meta.spec_hw + 1)
         apdata[:, :, :, k] = data.flux.values[:, ap_y1:ap_y2, :, k]

--- a/src/eureka/S3_data_reduction/niriss.py
+++ b/src/eureka/S3_data_reduction/niriss.py
@@ -82,7 +82,7 @@ def read(filename, data, meta, log):
     # Duplicate science arrays for each order to be analyzed
     if isinstance(meta.orders, int):
         meta.orders = [meta.orders]
-    norders = len(meta.all_orders)  # FINDME: temp fix
+    norders = len(meta.all_orders)
     sci = np.repeat(sci[:, :, :, np.newaxis], norders, axis=3)
     err = np.repeat(err[:, :, :, np.newaxis], norders, axis=3)
     dq = np.repeat(dq[:, :, :, np.newaxis], norders, axis=3)
@@ -145,7 +145,7 @@ def get_wave(data, meta, log):
         # Get trace for the given order and pupil position
         trace = get_soss_traces(pwcpos=pwcpos, order=str(order), interp=True)
         if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96' and \
-            meta.trace_offset is None:
+                meta.trace_offset is None:
             # PASTASOSS doesn't account for different substrip starting rows;
             # therefore, reset default trace offset to -10 pixels.
             # SUBSTRIP96: SUBSTRT2 = 1803
@@ -197,9 +197,6 @@ def mask_other_orders(data, meta):
                                    other_trace[j] + meta.bg_hw + 1))
                     ymax = np.min((len(data.y) + 1,
                                    trace[j] + meta.spec_hw + 1))
-                    # print(j, trace[j] - meta.spec_hw,
-                    #       other_trace[j] + meta.bg_hw)
-                    # FINDME: verify this works for substrip256
                     # Mask extraction region for 'order' in 'other_order'
                     data['mask'].sel(order=other_order)[:, ymin:ymax, j] = True
     return data

--- a/src/eureka/S3_data_reduction/niriss.py
+++ b/src/eureka/S3_data_reduction/niriss.py
@@ -147,10 +147,8 @@ def get_wave(data, meta, log):
         if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96' and \
                 meta.trace_offset is None:
             # PASTASOSS doesn't account for different substrip starting rows;
-            # therefore, reset default trace offset to -10 pixels.
-            # SUBSTRIP96: SUBSTRT2 = 1803
-            # SUBSTRIP256: SUBSTRT2 = 1793
-            meta.trace_offset = -10
+            # therefore, set trace offset to best guess (-12 pixels).
+            meta.trace_offset = -12
         if meta.trace_offset is not None:
             trace.y += meta.trace_offset
             subarray = data.attrs['mhdr']['SUBARRAY']

--- a/src/eureka/S3_data_reduction/niriss.py
+++ b/src/eureka/S3_data_reduction/niriss.py
@@ -144,6 +144,18 @@ def get_wave(data, meta, log):
     for order in meta.orders:
         # Get trace for the given order and pupil position
         trace = get_soss_traces(pwcpos=pwcpos, order=str(order), interp=True)
+        if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96' and \
+            meta.trace_offset is None:
+            # PASTASOSS doesn't account for different substrip starting rows;
+            # therefore, reset default trace offset to -10 pixels.
+            # SUBSTRIP96: SUBSTRT2 = 1803
+            # SUBSTRIP256: SUBSTRT2 = 1793
+            meta.trace_offset = -10
+        if meta.trace_offset is not None:
+            trace.y += meta.trace_offset
+            subarray = data.attrs['mhdr']['SUBARRAY']
+            log.writelog(f"  Shifting trace by {meta.trace_offset} pixels "
+                         f"for {subarray}.", mute=(not meta.verbose))
         # Assign trace and wavelength for given order
         ind1 = np.nonzero(np.in1d(trace.x, data.x.values))[0]
         ind2 = np.nonzero(np.in1d(data.x.values, trace.x))[0]

--- a/src/eureka/S3_data_reduction/s3_meta.py
+++ b/src/eureka/S3_data_reduction/s3_meta.py
@@ -274,6 +274,7 @@ class S3MetaClass(MetaClass):
         self.curvature = getattr(self, 'curvature', True)
         self.src_ypos = getattr(self, 'src_ypos', [35, 80])
         self.orders = getattr(self, 'orders', [1, 2])
+        self.all_orders = getattr(self, 'all_orders', [1, 2])
         self.record_ypos = getattr(self, 'record_ypos', False)
         self.trace_offset = getattr(self, 'trace_offset', None)
 

--- a/src/eureka/S3_data_reduction/s3_meta.py
+++ b/src/eureka/S3_data_reduction/s3_meta.py
@@ -275,6 +275,7 @@ class S3MetaClass(MetaClass):
         self.src_ypos = getattr(self, 'src_ypos', [35, 80])
         self.orders = getattr(self, 'orders', [1, 2])
         self.record_ypos = getattr(self, 'record_ypos', False)
+        self.trace_offset = getattr(self, 'trace_offset', None)
 
         self.set_spectral_defaults()
 

--- a/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
@@ -114,6 +114,7 @@ class SinusoidPhaseCurveModel(Model):
                         phaseVars2 = (1 +
                                       pl_params.AmpCos1*(np.ma.cos(phi2)-1) +
                                       pl_params.AmpSin1*np.ma.sin(phi2))
+                        min_val = np.ma.min(phaseVars2)
                 else:
                     phaseVars = (1 +
                                  pl_params.AmpCos1*(np.ma.cos(phi)-1) +
@@ -126,12 +127,13 @@ class SinusoidPhaseCurveModel(Model):
                                       pl_params.AmpSin1*np.ma.sin(phi2) +
                                       pl_params.AmpCos2*(np.ma.cos(2*phi2)-1) +
                                       pl_params.AmpSin2*np.ma.sin(2*phi2))
+                        min_val = np.ma.min(phaseVars2)
 
                 # If requested, force positive phase variations
-                if self.force_positivity and np.ma.any(phaseVars2 <= 0):
+                if self.force_positivity and min_val < 0:
                     # Returning nans or infs breaks the fits, so this was
                     # the best I could think of
-                    phaseVars = 1e6*np.ma.ones(time.shape)
+                    phaseVars = 1e6*np.ma.ones(time.shape)*np.abs(min_val)
 
             lcfinal = np.ma.append(lcfinal, phaseVars)
 

--- a/src/eureka/S5_lightcurve_fitting/s5_meta.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_meta.py
@@ -54,12 +54,6 @@ class S5MetaClass(MetaClass):
     def set_defaults(self):
         '''Set Stage 5 specific defaults for generic instruments.
 
-        Notes
-        -----
-        History:
-
-        - 2024-06 Taylor J Bell
-            Initial version setting defaults for any instrument.
         '''
         # Make sure the S3 expand parameter is defined
         # (to allow resuming from old analyses)
@@ -187,6 +181,7 @@ class S5MetaClass(MetaClass):
         self.useHODLR = getattr(self, 'useHODLR', False)
 
         # Diagnostics
+        self.interp = getattr(self, 'interp', False)
         self.isplots_S5 = getattr(self, 'isplots_S5', 3)
         self.nbin_plot = getattr(self, 'nbin_plot', None)
         self.testing_S5 = getattr(self, 'testing_S5', False)

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -802,16 +802,16 @@ def compute_strings(meta, log, fit_methods, limb):
     if meta.channelNumber > 0:
         suffix += f'_ch{meta.channelNumber}'
 
-    # Load a0 string coefficients
-    meta.y_param = 'a0'+suffix
-    a0 = load_s5_saves(meta, log, fit_methods)
-    if all(np.all(v == 0) for v in a0):
+    # Load rp string coefficients
+    meta.y_param = 'rp'+suffix
+    rp = load_s5_saves(meta, log, fit_methods)
+    if all(np.all(v == 0) for v in rp):
         # The parameter could not be found - skip it
         log.writelog(f'  Parameter {meta.y_param} was not in the list of '
                      'fitted parameters')
         log.writelog(f'  Skipping {y_param}')
         return meta
-    n_samples = len(a0[0])
+    n_samples = len(rp[0])
 
     # Load string coefficients
     coeffs = ['a1', 'b1', 'a2', 'b2', 'a3', 'b3']
@@ -845,13 +845,13 @@ def compute_strings(meta, log, fit_methods, limb):
 
     ht = HarmonicaTransit()
     for i in tqdm(range(meta.nspecchan)):
-        if np.all(a0[i] == 0):
+        if np.all(rp[i] == 0):
             # Channel wasn't found
             meta.spectrum_median.append(np.nan)
             meta.spectrum_err.append([np.nan, np.nan])
         else:
             # Compute transmission string
-            ab = np.array([a0[i][::ss],
+            ab = np.array([rp[i][::ss],
                            a1[i][::ss], b1[i][::ss],
                            a2[i][::ss], b2[i][::ss],
                            a3[i][::ss], b3[i][::ss]]).T

--- a/src/eureka/lib/readECF.py
+++ b/src/eureka/lib/readECF.py
@@ -183,8 +183,10 @@ class MetaClass:
             # If a specific CRDS context is entered in the ECF, apply it.
             # Otherwise, log and fix the default CRDS context to make sure
             # it doesn't change between different segments.
-            self.pmap = getattr(self, 'pmap',
-                                crds.get_context_name('jwst')[5:-5])
+            self.pmap = getattr(self, 'pmap', None)
+            if self.pmap is None:
+                # Only need an internet connection if pmap is None
+                self.pmap = crds.get_context_name('jwst')[5:-5]
             os.environ['CRDS_CONTEXT'] = f'jwst_{self.pmap}.pmap'
 
         if ((item == 'pmap') and hasattr(self, 'pmap') and

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -639,7 +639,7 @@ def get_mad(meta, log, wave_1d, optspec, optmask=None,
         The current log.
     wave_1d : ndarray
         Wavelength array (nx) with trimmed edges depending on xwindow and
-        ywindow which have been set in the S3 ecf
+        ywindow which have been set in the S3 ecf.
     optspec : ndarray
         Optimally extracted spectra, 2D array (time, nx)
     optmask : ndarray (1D); optional
@@ -649,7 +649,7 @@ def get_mad(meta, log, wave_1d, optspec, optmask=None,
     wave_min : float; optional
         Minimum wavelength for binned lightcurves, as given in the S4 .ecf
         file. Defaults to None which does not impose a lower limit.
-    wave_maxf : float; optional
+    wave_max : float; optional
         Maximum wavelength for binned lightcurves, as given in the S4 .ecf
         file. Defaults to None which does not impose an upper limit.
     scandir : ndarray; optional
@@ -662,6 +662,12 @@ def get_mad(meta, log, wave_1d, optspec, optmask=None,
     mad : float
         Single MAD value in ppm
     """
+    # Make sure wavelengths are in ascending order
+    if wave_1d[0] > wave_1d[-1]:
+        wave_1d = wave_1d[::-1]
+        optspec = optspec[::-1]
+        optmask = optmask[::-1]
+
     optspec = np.ma.masked_invalid(optspec)
     optspec = np.ma.masked_where(optmask, optspec)
 


### PR DESCRIPTION
PASTASOSS only computes the trace for SUBSTRIP256, so we currently need to supply an offset.  The expected value is -10 pixels, but this can vary by a pixel or two.

I've made sure that Order 2 gets masked, even when only requesting the Order 1 spectrum.  Additionally, I've limited the Order 2 mask so that it doesn't interfere with the spectral extraction of Order 1.

Finally, I (hopefully) fixed the NIRISS MAD calculation.