### PR TITLE
Add s4_meta.mad_box_width and update related calculations

### DIFF
--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -13,7 +13,8 @@ allapers        False       # Run S4 on all of the apertures considered in S3? O
 
 # Manually mask pixel columns by index number
 # mask_columns  []
-mad_sigma       7       # The number of sigmas an unbinned MAD value must be from the rolling median (using box_width) to be considered an outlier.  Outlier columns are masked.
+mad_sigma       7       # The number of sigmas an unbinned MAD value must be from the rolling median (using mad_box_width) to be considered an outlier.  Outlier columns are masked.
+mad_box_width   21      # The rolling median box width to use when computing whether a wavelength element's MAD is an outlier
 
 # Parameters for drift correction of 1D spectra
 recordDrift     False   # Set True to record drift/jitter in 1D spectra (always recorded if correctDrift is True)

--- a/docs/media/S4_template.ecf
+++ b/docs/media/S4_template.ecf
@@ -13,6 +13,8 @@ allapers        False       # Run S4 on all of the apertures considered in S3? O
 
 # Manually mask pixel columns by index number
 # mask_columns  []
+mad_sigma       7       # The number of sigmas an unbinned MAD value must be from the rolling median (using mad_box_width) to be considered an outlier.  Outlier columns are masked.
+mad_box_width   21      # The rolling median box width to use when computing whether a wavelength element's MAD is an outlier
 
 # Parameters for drift correction of 1D spectra
 recordDrift     False   # Set True to record drift/jitter in 1D spectra (always recorded if correctDrift is True)

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -839,7 +839,11 @@ Only used if sigma_clip=True. Either the string 'mask' to mask the outlier value
 
 mad_sigma
 '''''''''
-The number of sigmas an unbinned MAD value must be from the rolling median (using box_width) to be considered an outlier.  Outlier columns are masked.
+The number of sigmas an unbinned MAD value must be from the rolling median (using mad_box_width) to be considered an outlier.  Outlier columns are masked.
+
+mad_box_width
+'''''''''''''
+The width of the box-car filter (used to calculated the rolling median) in units of number of wavelength elements. Used in calculating whether wavelength elements are outliers in the unbinned spectrum.
 
 sum_reads
 '''''''''

--- a/src/eureka/S4_generate_lightcurves/outliers.py
+++ b/src/eureka/S4_generate_lightcurves/outliers.py
@@ -50,9 +50,9 @@ def get_outliers(meta, spec):
     mask = np.isnan(mad)
     x = spec.x[iwmin:iwmax]
     x_mask = x[~mask]
-    smoothed_mad = smooth.medfilt(mad[~mask], window_len=meta.box_width)
+    smoothed_mad = smooth.medfilt(mad[~mask], window_len=meta.mad_box_width)
     residual_mad = mad[~mask] - smoothed_mad
-    smoothed_dev = smooth.medfilt(dev[~mask], window_len=meta.box_width)
+    smoothed_dev = smooth.medfilt(dev[~mask], window_len=meta.mad_box_width)
     residual_dev = dev[~mask] - smoothed_dev
 
     # Identify only high outliers from residuals

--- a/src/eureka/S4_generate_lightcurves/s4_meta.py
+++ b/src/eureka/S4_generate_lightcurves/s4_meta.py
@@ -119,6 +119,7 @@ class S4MetaClass(MetaClass):
         self.fill_value = getattr(self, 'fill_value', 'mask')
         # Used in Fig 4106
         self.mad_sigma = getattr(self, 'mad_sigma', 7)
+        self.mad_box_width = getattr(self, 'mad_box_width', 21)
 
         # HST/WFC3 temporal binning (sum together all reads from one scan)
         self.sum_reads = getattr(self, 'sum_reads', True)


### PR DESCRIPTION
Previously relied on box_width which was in units of number of integrations, while mad_box_width should be in units of wavelength elements. The two shouldn't be forced to be the same