### PR TITLE
Added the channel-specific calibrated light curve data to the S5 .txt output file

### DIFF
--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -1363,12 +1363,19 @@ def save_fit(meta, lc, model, fitter, results_table, freenames, samples=[]):
             individual_models.append([comp.name, comp.eval(fit)])
     individual_models = np.array(individual_models, dtype=object)
 
+    model_noGP = model.eval(incl_GP=False)
+    gp = model.GPeval(model_noGP)
+
+    model_sys = model.syseval()
+
+    lcdata_cal = lc.flux/model_sys - gp
+
     model_lc = model.eval()
     residuals = lc.flux-model_lc
     astropytable.savetable_S5(meta.tab_filename_s5, meta, lc.time,
                               wavelengths[lc.fitted_channels],
                               wave_errs[lc.fitted_channels],
-                              lc.flux, lc.unc_fit, individual_models, model_lc,
+                              lc.flux, lcdata_cal, lc.unc_fit, individual_models, model_lc,
                               residuals)
 
     return

--- a/src/eureka/lib/astropytable.py
+++ b/src/eureka/lib/astropytable.py
@@ -33,7 +33,7 @@ def savetable_S1(filename, scale_factor):
     return
 
 
-def savetable_S5(filename, meta, time, wavelength, bin_width, lcdata, lcerr,
+def savetable_S5(filename, meta, time, wavelength, bin_width, lcdata, lcdata_cal, lcerr,
                  individual_models, model, residuals):
     """Save the results from Stage 5 as an ECSV file.
 
@@ -49,6 +49,8 @@ def savetable_S5(filename, meta, time, wavelength, bin_width, lcdata, lcerr,
         The width of each wavelength bin.
     lcdata : ndarray (1D)
         The normalized flux measurements for each data point.
+    lcdata_cal : ndarray (1D)
+        The calibrated flux measurements for each data point.
     lcerr : ndarray (1D)
         The normalized uncertainties for each data point.
     individual_models : ndarray (2D)
@@ -80,31 +82,32 @@ def savetable_S5(filename, meta, time, wavelength, bin_width, lcdata, lcerr,
             bin_width[trim1:trim2] = terse_widths[chan]
 
     orig_shapes = [str(time.shape), str(wavelength.shape),
-                   str(bin_width.shape), str(lcdata.shape), str(lcerr.shape)]
+                   str(bin_width.shape), str(lcdata.shape), str(lcdata_cal.shape), str(lcerr.shape)]
     orig_shapes.extend([str(individual_models[i, 1].shape)
                         for i in range(individual_models.shape[0])])
     orig_shapes.extend([str(model.shape), str(residuals.shape)])
 
     lcdata = lcdata.flatten()
+    lcdata_cal = lcdata_cal.flatten()
     lcerr = lcerr.flatten()
     model_names = individual_models[:, 0]
     model_values = individual_models[:, 1]
     full_model = model.flatten()
     residuals = residuals.flatten()
 
-    arr = [time, wavelength, bin_width, lcdata, lcerr, *model_values,
+    arr = [time, wavelength, bin_width, lcdata, lcdata_cal, lcerr, *model_values,
            full_model, residuals]
 
     try:
         table = QTable(arr, names=('time', 'wavelength', 'bin_width',
-                                   'lcdata', 'lcerr', *model_names, 'model',
+                                   'lcdata', "lcdata_cal", 'lcerr', *model_names, 'model',
                                    'residuals'))
         ascii.write(table, filename, format='ecsv', overwrite=True,
                     fast_writer=True)
     except ValueError as e:
         raise ValueError("There was a shape mismatch between your arrays which"
                          " had shapes:\n"
-                         "time, wavelength, bin_width, lcdata, lcerr, " +
+                         "time, wavelength, bin_width, lcdata, lcdata_cal, lcerr, " +
                          ', '.join(model_names) +
                          ", model, residuals\n" +
                          ", ".join(orig_shapes)) from e


### PR DESCRIPTION
With these changes, the S5 .txt output file now contains, in addition to the previous products, the _calibrated_ flux for spectroscopic light curves for outside Eureka! access. This allows the user to easily plot astrophysical model spectroscopic light curves over the calibrated data in scientific reports.

By the calibrated flux, I am referring to the `lc.flux/model.syseval() - GP` object that is created for example inside the `plot_fit()` function in `S5_lightcurve_fitting/plots_s5.py`. 

Please note that I have tested this new branch with limited trial runs, and make sure to check for broader compatibility.