### PR TITLE
S4: Rescaling the mu-grid in the Phoenix grid to more accurately align with the true edge of the star

### DIFF
--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -38,6 +38,7 @@ logg            4.0     # Surface gravity in log g
 minmu			0.2		# minimum mu to use when calculating LD in ExoTiC-LD
 exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids, or custom (to use custom_si_grid below)
+# rescale_phoenix  True. #Option to rescale the mu grid for phoenix models. See Section 2.2: https://academic.oup.com/mnras/article/450/2/1879/985166
 # custom_si_grid  /home/User/path/to/custom/stellar/intensity/profile  #Custom Stellar Intensity profile. For examples see Eureka/demos/JWST/Custom_Stellar_Intensity_Files
 # exotic_ld_file  /home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 # Options for SPAM

--- a/demos/JWST/S4_template.ecf
+++ b/demos/JWST/S4_template.ecf
@@ -38,7 +38,7 @@ logg            4.0     # Surface gravity in log g
 minmu			0.2		# minimum mu to use when calculating LD in ExoTiC-LD
 exotic_ld_direc /home/User/exotic-ld_data/ # Directory for ancillary files for exotic-ld, download from: https://zenodo.org/doi/10.5281/zenodo.6047317
 exotic_ld_grid  stagger # You can choose from kurucz (or 1D), stagger (or 3D), mps1, or mps2 model grids, or custom (to use custom_si_grid below)
-# rescale_phoenix  True. #Option to rescale the mu grid for phoenix models. See Section 2.2: https://academic.oup.com/mnras/article/450/2/1879/985166
+# rescale_phoenix  True # Option to rescale the mu grid for phoenix models. See Section 2.2: https://academic.oup.com/mnras/article/450/2/1879/985166
 # custom_si_grid  /home/User/path/to/custom/stellar/intensity/profile  #Custom Stellar Intensity profile. For examples see Eureka/demos/JWST/Custom_Stellar_Intensity_Files
 # exotic_ld_file  /home/User/exotic-ld_data/Custom_throughput_file.csv # Custom throughput file, for examples see Eureka/demos/JWST/Custom_throughput_files
 # Options for SPAM

--- a/src/eureka/S4_generate_lightcurves/generate_LD.py
+++ b/src/eureka/S4_generate_lightcurves/generate_LD.py
@@ -104,8 +104,8 @@ def exotic_ld(meta, spec, log, white=False):
         sld = StellarLimbDarkening(meta.metallicity, meta.teff, meta.logg,
                                    meta.exotic_ld_grid, meta.exotic_ld_direc)
      
-    # Now if Phoenix, rescale the mu grid                               
-    if meta.exotic_ld_grid == 'phoenix':
+    # Now if Phoenix, rescale the mu grid                         
+    if meta.exotic_ld_grid == 'phoenix' and meta.rescale_phoenix:
         print('Rescaling Phoenix')
         # loop over wavelengths and rescale
         
@@ -129,9 +129,9 @@ def exotic_ld(meta, spec, log, white=False):
                                        custom_mus=mus_new,
                                        custom_stellar_model=sis_new)  
         if meta.isplots_S4 >= 3: 
-            sld._integrate_I_mu([meta.wave_min, meta.wave_max], 
+            sld._integrate_I_mu([meta.wave_min*1e4, meta.wave_max*1e4], 
                                 mode, None, None)
-            sld_new._integrate_I_mu([meta.wave_min, meta.wave_max], 
+            sld_new._integrate_I_mu([meta.wave_min*1e4, meta.wave_max*1e4], 
                                     mode, None, None)
             plots_s4.plot_rescaled_phoenix(meta, sld, sld_new)
         

--- a/src/eureka/S4_generate_lightcurves/generate_LD.py
+++ b/src/eureka/S4_generate_lightcurves/generate_LD.py
@@ -1,6 +1,7 @@
 from exotic_ld import StellarLimbDarkening
 import numpy as np
 import pandas as pd
+from scipy.interpolate import interp1d
 
 from . import plots_s4
 
@@ -98,9 +99,38 @@ def exotic_ld(meta, spec, log, white=False):
                                    custom_wavelengths=s_wvs,
                                    custom_mus=s_mus,
                                    custom_stellar_model=custom_si)
+
     else:
         sld = StellarLimbDarkening(meta.metallicity, meta.teff, meta.logg,
                                    meta.exotic_ld_grid, meta.exotic_ld_direc)
+     
+    #Now if Phoenix, rescale the mu grid                               
+    if  meta.exotic_ld_grid == 'phoenix':
+        print('Rescaling Phoenix')
+        #loop over wavelengths and rescale
+        
+        interp_I_mu = np.empty([sld.stellar_intensities.shape[0],50])
+        
+        for wi in range(sld.stellar_intensities.shape[0]):  
+            if sld.stellar_wavelengths[wi] < wavelength_range[0][0] or sld.stellar_wavelengths[wi] > wavelength_range[-1][-1]:
+                continue
+            interp_mus, interp_I_mu[wi,:], _ = _phoenix_rescaled_mu_and_intensity(
+                sld.mus, sld.stellar_intensities[wi,:]
+            ) 
+            
+                
+        sld_new = StellarLimbDarkening(ld_data_path=meta.exotic_ld_direc,
+                                   ld_model="custom",
+                                   custom_wavelengths=sld.stellar_wavelengths,
+                                   custom_mus=np.flip(interp_mus),
+                                   custom_stellar_model=np.flip(interp_I_mu,axis=1))  
+        if meta.isplots_S4 >= 3: 
+            sld._integrate_I_mu([wavelength_range[0][0],wavelength_range[-1][-1]], mode, None, None)
+            sld_new._integrate_I_mu([wavelength_range[0][0],wavelength_range[-1][-1]], mode, None, None)
+            plots_s4.plot_rescaled_phoenix(meta,sld,sld_new)
+        
+        sld = sld_new
+                   
 
     if mode != 'custom':
         # Figure out if we need to extrapolate the throughput, since the
@@ -241,3 +271,63 @@ def spam_ld(meta, white=False):
     # Replace relevant item with actual values
     ld_list[num_ld_coef-1] = ld_coeffs
     return ld_list
+
+def _phoenix_rescaled_mu_and_intensity(mus, I_mu,
+                                       n_interp=50,
+                                       edge_buffer=4):
+    """Rescale the Phoenix spherical-model mu grid before fitting.
+
+    Phoenix intensities include very sharp, low-mu limb points.  This follows
+    the rescaling approach commonly used for these spherical grids:
+
+        mu_scaled = (mu - mu_cri) / (1 - mu_cri)
+
+    where mu_cri is selected just inside the largest intensity-gradient point.
+    The resulting profile is interpolated onto a fixed 0..1 mu grid before the
+    limb-darkening law is fit.
+    """
+    mus = np.asarray(mus, dtype=float)
+    I_mu = np.asarray(I_mu, dtype=float)
+
+    finite = np.isfinite(mus) & np.isfinite(I_mu)
+    mus = mus[finite]
+    I_mu = I_mu[finite]
+    if mus.size < 4:
+        raise ValueError(
+            "Need at least four finite Phoenix mu points to rescale the grid."
+        )
+
+    dy_dx = np.gradient(I_mu, mus)
+    max_derivative_index = int(np.nanargmax(dy_dx))
+    mu_cri_index = max(max_derivative_index - edge_buffer, 0)
+    mu_cri = mus[mu_cri_index]
+    if (not np.isfinite(mu_cri)) or np.isclose(mu_cri, 1.0):
+        raise ValueError(
+            "Could not identify a valid Phoenix critical mu for rescaling."
+        )
+
+    mu_scaled = (mus - mu_cri) / (1.0 - mu_cri)
+    good = (np.isfinite(mu_scaled) & np.isfinite(I_mu) &
+            (mu_scaled > 0.0) & (mu_scaled <= 1.0 + 1e-12))
+    if np.sum(good) < 4:
+        raise ValueError(
+            "Too few Phoenix mu points remain after rescaling; try reducing "
+            "PHOENIX_EDGE_BUFFER."
+        )
+
+    x = mu_scaled[good]
+    y = I_mu[good]
+    order = np.argsort(x)
+    x = x[order]
+    y = y[order]
+    x, unique = np.unique(x, return_index=True)
+    y = y[unique]
+
+    interp_kind = 'cubic' if x.size >= 4 else 'linear'
+    intensity_interp = interp1d(x, y, kind=interp_kind,
+                                fill_value='extrapolate',
+                                bounds_error=False)
+    interp_mus = np.linspace(0.0, 1.0, n_interp)
+    interp_I_mu = intensity_interp(interp_mus)
+
+    return interp_mus, interp_I_mu, mu_cri

--- a/src/eureka/S4_generate_lightcurves/generate_LD.py
+++ b/src/eureka/S4_generate_lightcurves/generate_LD.py
@@ -104,34 +104,39 @@ def exotic_ld(meta, spec, log, white=False):
         sld = StellarLimbDarkening(meta.metallicity, meta.teff, meta.logg,
                                    meta.exotic_ld_grid, meta.exotic_ld_direc)
      
-    #Now if Phoenix, rescale the mu grid                               
-    if  meta.exotic_ld_grid == 'phoenix':
+    # Now if Phoenix, rescale the mu grid                               
+    if meta.exotic_ld_grid == 'phoenix':
         print('Rescaling Phoenix')
-        #loop over wavelengths and rescale
+        # loop over wavelengths and rescale
         
-        interp_I_mu = np.empty([sld.stellar_intensities.shape[0],50])
+        interp_I_mu = np.empty([sld.stellar_intensities.shape[0], 50])
         
         for wi in range(sld.stellar_intensities.shape[0]):  
-            if sld.stellar_wavelengths[wi] < wavelength_range[0][0] or sld.stellar_wavelengths[wi] > wavelength_range[-1][-1]:
+            # Can fail at edges of phoenix grid, only rescaling where needed
+            if (sld.stellar_wavelengths[wi] < wavelength_range[0][0] or 
+                    sld.stellar_wavelengths[wi] > wavelength_range[-1][-1]):
                 continue
-            interp_mus, interp_I_mu[wi,:], _ = _phoenix_rescaled_mu_and_intensity(
-                sld.mus, sld.stellar_intensities[wi,:]
+            interp_mus, interp_I_mu[wi, :], _ = phoenix_rescaled(
+                sld.mus, sld.stellar_intensities[wi, :]
             ) 
-            
-                
+
+        wvs_new = sld.stellar_wavelengths
+        mus_new = np.flip(interp_mus)
+        sis_new = np.flip(interp_I_mu, axis=1)
         sld_new = StellarLimbDarkening(ld_data_path=meta.exotic_ld_direc,
-                                   ld_model="custom",
-                                   custom_wavelengths=sld.stellar_wavelengths,
-                                   custom_mus=np.flip(interp_mus),
-                                   custom_stellar_model=np.flip(interp_I_mu,axis=1))  
+                                       ld_model="custom",
+                                       custom_wavelengths=wvs_new,
+                                       custom_mus=mus_new,
+                                       custom_stellar_model=sis_new)  
         if meta.isplots_S4 >= 3: 
-            sld._integrate_I_mu([wavelength_range[0][0],wavelength_range[-1][-1]], mode, None, None)
-            sld_new._integrate_I_mu([wavelength_range[0][0],wavelength_range[-1][-1]], mode, None, None)
-            plots_s4.plot_rescaled_phoenix(meta,sld,sld_new)
+            sld._integrate_I_mu([meta.wave_min, meta.wave_max], 
+                                mode, None, None)
+            sld_new._integrate_I_mu([meta.wave_min, meta.wave_max], 
+                                    mode, None, None)
+            plots_s4.plot_rescaled_phoenix(meta, sld, sld_new)
         
         sld = sld_new
                    
-
     if mode != 'custom':
         # Figure out if we need to extrapolate the throughput, since the
         # ExoTiC-LD throughput files don't go close enought to the edges of
@@ -272,9 +277,8 @@ def spam_ld(meta, white=False):
     ld_list[num_ld_coef-1] = ld_coeffs
     return ld_list
 
-def _phoenix_rescaled_mu_and_intensity(mus, I_mu,
-                                       n_interp=50,
-                                       edge_buffer=4):
+
+def phoenix_rescaled(mus, I_mu, n_interp=50, edge_buffer=4):
     """Rescale the Phoenix spherical-model mu grid before fitting.
 
     Phoenix intensities include very sharp, low-mu limb points.  This follows

--- a/src/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/src/eureka/S4_generate_lightcurves/plots_s4.py
@@ -494,3 +494,44 @@ def plot_extrapolated_throughput(meta, throughput_wavelengths, throughput,
     plt.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
     if not meta.hide_plots:
         plt.pause(0.2)
+        
+@plots.apply_style
+def plot_rescaled_phoenix(meta,sld, sld_new):
+    '''Make a plot of rescaled phoenix mus/intensities (Fig 4305).
+
+    Parameters
+    ----------
+    meta : eureka.lib.readECF.MetaClass
+        The metadata object.
+    sld : original sld object from ExoTIC phoenix grid
+    sld_new : sld object after re-scaling mu/intensity.
+
+    '''
+    
+    fig = plt.figure(4305)
+    fig.set_size_inches(8, 8, forward=True)
+    fig.clf()
+    plt.title('Phoenix Grid Rescaling, Full Band Integrated')
+    plt.plot(sld.mus, sld.I_mu, color = 'goldenrod', lw = 1.5, 
+            marker = 'o', ms = 6, 
+            label = 'Original Phoenix Intensity Profile')
+    plt.plot(sld_new.mus, sld_new.I_mu, color = 'tomato', lw = 1.0, 
+            marker = 'o', ms = 6, 
+            label = 'Rescaled Phoenix Intensity Profile')
+    
+    plt.xlim(-0.05,1.05)
+    plt.ylim(-0.05,1.05)
+    
+    plt.ylabel('I($\mu$)')
+    plt.xlabel('$\mu$')
+    plt.legend(loc='best')
+
+    fname = ('figs'+os.sep+'fig4305_RescaledPhoenix' +
+             plots.get_filetype())
+    plt.savefig(meta.outputdir+fname, bbox_inches='tight', dpi=300)
+    if not meta.hide_plots:
+        plt.pause(0.2)
+    
+
+
+


### PR DESCRIPTION
The Phoenix stellar grid defines mu=0 to be outside of the photosphere of the star due to the geometry of the model. This causes issues when using the model as-is to calculate limb darkening parameters. See Section 2.2 and Figure 4 here for a detailed discussion: https://academic.oup.com/mnras/article/450/2/1879/985166

This PR adapts code from David Sing to rescale the mu-grid prior to fitting limb darkening parameters to the stellar intensity profile. @astroRez assisted in coding this up. The PR includes a new figure to show the rescaled and original stellar intensity profile as integrated over the entire bandpass considered in S4.

<img width="2434" height="2434" alt="fig4305_RescaledPhoenix" src="https://github.com/user-attachments/assets/2054eb80-33b7-4f8a-9fac-6e43427fe4d1" />
