### PR TITLE
Add code to overplot empirical trace for NIRSpec/NIRCam/MIRI

### DIFF
--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -15,6 +15,7 @@ warnings.filterwarnings("ignore", message='Ignoring specified arguments in '
                                           'this call because figure with num')
 
 from .source_pos import gauss
+from .straighten import find_column_median_shifts
 from ..lib import util, plots
 
 
@@ -706,9 +707,9 @@ def median_frame(data, meta, m, medflux, order=None):
                vmin=vmin, vmax=vmax, interpolation='nearest',
                extent=[xmin, xmax, ymin, ymax], cmap=cmap)
 
-    # Overplot nominal spectral trace for NIRISS SOSS
-    # (TODO: Probably also useful for NIRSpec, etc.)
-    if meta.inst == "niriss":
+    # Plot spectral traces over median frame
+    if meta.inst == "niriss": # nominal trace for NIRISS/SOSS
+        # SUBSTRIP96 only deals with a single order
         if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96':
             order = 1
             trace = data["trace"].sel(order=order)
@@ -717,7 +718,7 @@ def median_frame(data, meta, m, medflux, order=None):
                      c="white", lw=2)
             plt.plot(data.flux.x.values, trace,
                      "--k", lw=1, label=f"Trace Order {order}")
-        else:
+        else: # SUBSTRIP256 handles both orders
             for order in meta.all_orders:
                 trace = data["trace"].sel(order=order)
                 plt.plot(data.flux.x.values, trace,
@@ -725,7 +726,15 @@ def median_frame(data, meta, m, medflux, order=None):
                 plt.plot(data.flux.x.values, trace,
                          "--k", lw=1, label=f"Trace Order {order}")
         plt.legend()
+    else: # NIRSpec, NIRCam, MIRI
+        # identify empirical smoothed center-of-mass trace
+        smooth_coms, new_center = find_column_median_shifts(data.medflux, meta, m, plot_3308=True)
 
+        # overplot empirical trace
+        plt.plot(data.x.values, smooth_coms+meta.ywindow[0], c="white", lw=2)
+        plt.plot(data.x.values, smooth_coms+meta.ywindow[0], "--k", lw=1, label="Spectral Trace")
+        plt.legend()
+        
     plt.ylabel('Detector Pixel Position')
     plt.xlabel('Detector Pixel Position')
 

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -708,7 +708,7 @@ def median_frame(data, meta, m, medflux, order=None):
                extent=[xmin, xmax, ymin, ymax], cmap=cmap)
 
     # Plot spectral traces over median frame
-    if meta.inst == "niriss": # nominal trace for NIRISS/SOSS
+    if meta.inst == "niriss":  # nominal trace for NIRISS/SOSS
         # SUBSTRIP96 only deals with a single order
         if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96':
             order = 1
@@ -718,7 +718,7 @@ def median_frame(data, meta, m, medflux, order=None):
                      c="white", lw=2)
             plt.plot(data.flux.x.values, trace,
                      "--k", lw=1, label=f"Trace Order {order}")
-        else: # SUBSTRIP256 handles both orders
+        else:  # SUBSTRIP256 handles both orders
             for order in meta.all_orders:
                 trace = data["trace"].sel(order=order)
                 plt.plot(data.flux.x.values, trace,
@@ -726,13 +726,15 @@ def median_frame(data, meta, m, medflux, order=None):
                 plt.plot(data.flux.x.values, trace,
                          "--k", lw=1, label=f"Trace Order {order}")
         plt.legend()
-    else: # NIRSpec, NIRCam, MIRI
+    else:  # NIRSpec, NIRCam, MIRI
         # identify empirical smoothed center-of-mass trace
-        smooth_coms, new_center = find_column_median_shifts(data.medflux, meta, m, plot_3308=True)
+        smooth_coms, new_center = find_column_median_shifts(data.medflux, meta, 
+                                                            m, plot_3308=True)
 
         # overplot empirical trace
         plt.plot(data.x.values, smooth_coms+meta.ywindow[0], c="white", lw=2)
-        plt.plot(data.x.values, smooth_coms+meta.ywindow[0], "--k", lw=1, label="Spectral Trace")
+        plt.plot(data.x.values, smooth_coms+meta.ywindow[0], "--k", lw=1, 
+                 label="Spectral Trace")
         plt.legend()
         
     plt.ylabel('Detector Pixel Position')

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -709,22 +709,12 @@ def median_frame(data, meta, m, medflux, order=None):
 
     # Plot spectral traces over median frame
     if meta.inst == "niriss":  # nominal trace for NIRISS/SOSS
-        # SUBSTRIP96 only deals with a single order
-        if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96':
-            order = 1
+        for order in meta.orders:
             trace = data["trace"].sel(order=order)
-
             plt.plot(data.flux.x.values, trace,
                      c="white", lw=2)
             plt.plot(data.flux.x.values, trace,
                      "--k", lw=1, label=f"Trace Order {order}")
-        else:  # SUBSTRIP256 handles both orders
-            for order in meta.all_orders:
-                trace = data["trace"].sel(order=order)
-                plt.plot(data.flux.x.values, trace,
-                         c="white", lw=2)
-                plt.plot(data.flux.x.values, trace,
-                         "--k", lw=1, label=f"Trace Order {order}")
         plt.legend()
     else:  # NIRSpec, NIRCam, MIRI
         # identify empirical smoothed center-of-mass trace

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -5,7 +5,7 @@ from .source_pos import gauss
 from scipy.optimize import curve_fit
 
 
-def find_column_median_shifts(data, meta, m):
+def find_column_median_shifts(data, meta, m, plot_3308=False):
     '''Takes the median frame (in time) and finds the
     center of mass (COM) in pixels for each column. It then returns the needed
     shift to apply to each column to bring the COM to the center
@@ -18,11 +18,17 @@ def find_column_median_shifts(data, meta, m):
         The metadata object.
     m : int
         The file number.
+    plot_3308 : boolean
+        Flag to determine if this method is being called to 
+        get the smoothed spectral trace to plot over Fig. 3308
 
     Returns
     -------
     shifts : ndarray (2D)
         The shifts to apply to each column to straighten the trace.
+    smooth_coms : ndarray (1D)
+        If plot_3308 is True, the y positions of the smoothed center
+        of mass trace.
     new_center : int
         The central row of the detector where the trace is moved to.
     '''
@@ -67,7 +73,8 @@ def find_column_median_shifts(data, meta, m):
     # Convert to integer pixels
     int_coms = np.round(smooth_coms).astype(int)
 
-    if meta.isplots_S3 >= 1:
+    # only plot curvature plot during desired reduction step
+    if meta.isplots_S3 >= 1 and not plot_3308:
         plots_s3.curvature(meta, column_coms, smooth_coms, int_coms, m)
 
     # define the new center (where we will align the trace) in the
@@ -82,8 +89,12 @@ def find_column_median_shifts(data, meta, m):
     shifts[column_coms < 0] = 0
     shifts[column_coms > nb_rows] = 0
 
-    return shifts, new_center
-
+    if not plot_3308:
+        # return shifts to straighten trace
+        return shifts, new_center
+    else:
+        # return empirical smoothed center of mass trace
+        return smooth_coms, new_center
 
 def roll_columns(data, shifts):
     '''For each column of each integration, rolls the columns by the

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -25,7 +25,8 @@ def find_column_median_shifts(data, meta, m, plot_3308=False):
     Returns
     -------
     shifts : ndarray (2D)
-        The shifts to apply to each column to straighten the trace.
+        If plot_3308 is False, return the shifts to apply to each 
+        column to straighten the trace.
     smooth_coms : ndarray (1D)
         If plot_3308 is True, the y positions of the smoothed center
         of mass trace.

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -89,12 +89,13 @@ def find_column_median_shifts(data, meta, m, plot_3308=False):
     shifts[column_coms < 0] = 0
     shifts[column_coms > nb_rows] = 0
 
-    if not plot_3308:
-        # return shifts to straighten trace
-        return shifts, new_center
-    else:
+    if plot_3308:
         # return empirical smoothed center of mass trace
         return smooth_coms, new_center
+    
+    # return shifts to straighten trace
+    return shifts, new_center
+
 
 def roll_columns(data, shifts):
     '''For each column of each integration, rolls the columns by the


### PR DESCRIPTION
NIRISS/SOSS median flux plots have the nominally-computed spectral trace from PASTASOSS overplotted on them. While NIRSpec, NIRCam, and MIRI don't have precomputed spectral traces, we can still overplot the empirically-identified center-of-mass spectral trace as found in `straighten.find_median_column_shifts()`. This PR takes the smoothed trace and overplots in on Fig. 3308 for non-NIRISS instruments.

An example plot looks like this (NRS2 data): 
<img width="2434" height="1234" alt="fig3308_file0_MedianFrame" src="https://github.com/user-attachments/assets/7e4cac67-0e07-4789-889a-37e90e63dffd" />
