### PR TITLE
NIRISS S1 GLBS warnings + docs

### DIFF
--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -42,7 +42,7 @@ dq_sat_percentile   50      # Percentile of the entire time series to use to def
 dq_sat_columns      [[0, 0], [0,0], [0,0], [0,0], [0,0]]  #for dq_sat_mode = defined, user defined saturated columns
 
 # Background subtraction
-grouplevel_bg       True    # NOTE: NIRISS users should always set this to `False`, as group-level background subtraction is handled in Stage 3 for this instrument
+grouplevel_bg       True    # NOTE: NIRISS users should always set this to `False`, as group-level background subtraction is not supported for NIRISS.
 ncpu                6
 bg_y1               6
 bg_y2               26

--- a/demos/JWST/S1_nirx_template.ecf
+++ b/demos/JWST/S1_nirx_template.ecf
@@ -42,7 +42,7 @@ dq_sat_percentile   50      # Percentile of the entire time series to use to def
 dq_sat_columns      [[0, 0], [0,0], [0,0], [0,0], [0,0]]  #for dq_sat_mode = defined, user defined saturated columns
 
 # Background subtraction
-grouplevel_bg       True
+grouplevel_bg       True    # NOTE: NIRISS users should always set this to `False`, as group-level background subtraction is handled in Stage 3 for this instrument
 ncpu                6
 bg_y1               6
 bg_y2               26

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -132,7 +132,7 @@ Boolean, an experimental step which removes the 390 Hz periodic noise in MIRI/LR
 
 grouplevel_bg
 '''''''''''''
-Boolean, runs background subtraction at the group level (GLBS) prior to ramp fitting.
+Boolean, runs background subtraction at the group level (GLBS) prior to ramp fitting. NOTE: NIRISS users should always set this to `False`, as group-level background subtraction is handled in Stage 3 for this instrument.
 
 ncpu
 ''''

--- a/docs/source/ecf.rst
+++ b/docs/source/ecf.rst
@@ -132,7 +132,7 @@ Boolean, an experimental step which removes the 390 Hz periodic noise in MIRI/LR
 
 grouplevel_bg
 '''''''''''''
-Boolean, runs background subtraction at the group level (GLBS) prior to ramp fitting. NOTE: NIRISS users should always set this to `False`, as group-level background subtraction is handled in Stage 3 for this instrument.
+Boolean, runs background subtraction at the group level (GLBS) prior to ramp fitting. NOTE: NIRISS users should always set this to `False`, as group-level background subtraction is not supported for NIRISS. Standard background subtraction is performed in Stage 3.
 
 ncpu
 ''''

--- a/src/eureka/S1_detector_processing/s1_meta.py
+++ b/src/eureka/S1_detector_processing/s1_meta.py
@@ -277,7 +277,7 @@ class S1MetaClass(MetaClass):
         self.grouplevel_bg = getattr(self, 'grouplevel_bg', False)
         if self.grouplevel_bg:
             warnings.warn('grouplevel_bg must be False for Stage 1 NIRISS ' 
-                          'analyses! Group level background subtraction is ' 
+                          'analyses! Standard background subtraction is ' 
                           'performed in Stage 3 instead. ' 
                           ''
                           'Setting grouplevel_bg to False...')

--- a/src/eureka/S1_detector_processing/s1_meta.py
+++ b/src/eureka/S1_detector_processing/s1_meta.py
@@ -1,5 +1,6 @@
 # pylint: disable=attribute-defined-outside-init
 from ..lib.readECF import MetaClass
+import warnings
 
 
 class S1MetaClass(MetaClass):
@@ -271,5 +272,15 @@ class S1MetaClass(MetaClass):
         '''Set Stage 1 specific defaults for NIRISS.
         '''
         self.orders = getattr(self, 'orders', [1, 2])
+
+        # NIRISS grouplevel_bg must be False in Stage 1
+        self.grouplevel_bg = getattr(self, 'grouplevel_bg', False)
+        if self.grouplevel_bg:
+            warnings.warn('grouplevel_bg must be False for Stage 1 NIRISS ' 
+                          'analyses! Group level background subtraction is ' 
+                          'performed in Stage 3 instead. ' 
+                          ''
+                          'Setting grouplevel_bg to False...')
+            self.grouplevel_bg = False
 
         self.set_NIR_defaults()

--- a/src/eureka/S1_detector_processing/s1_meta.py
+++ b/src/eureka/S1_detector_processing/s1_meta.py
@@ -1,6 +1,7 @@
 # pylint: disable=attribute-defined-outside-init
-from ..lib.readECF import MetaClass
 import warnings
+
+from ..lib.readECF import MetaClass
 
 
 class S1MetaClass(MetaClass):
@@ -276,9 +277,9 @@ class S1MetaClass(MetaClass):
         # NIRISS grouplevel_bg must be False in Stage 1
         self.grouplevel_bg = getattr(self, 'grouplevel_bg', False)
         if self.grouplevel_bg:
-            warnings.warn('grouplevel_bg must be False for Stage 1 NIRISS ' 
-                          'analyses! Standard background subtraction is ' 
-                          'performed in Stage 3 instead. ' 
+            warnings.warn('grouplevel_bg must be False for Stage 1 NIRISS '
+                          'analyses! Standard background subtraction is '
+                          'performed in Stage 3 instead. '
                           ''
                           'Setting grouplevel_bg to False...')
             self.grouplevel_bg = False


### PR DESCRIPTION
Handles #830 (plus other mentions of the same) to warn users against setting `grouplevel_bg` to `True` in their Stage 1 ECFs when running Stage 1 on NIRISS data. Additionally, checks for and corrects this when setting the Stage 1 NIRISS defaults. 