### PR TITLE
Add isort import sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,11 @@ repos:
       - id: check-added-large-files
       - id: debug-statements
 
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+
   - repo: https://github.com/pycqa/flake8
     rev: 7.3.0
     hooks:

--- a/demos/HST/run_eureka_wfc3.py
+++ b/demos/HST/run_eureka_wfc3.py
@@ -1,4 +1,5 @@
 import os
+
 import eureka.lib.plots
 import eureka.S3_data_reduction.s3_reduce as s3
 import eureka.S4_generate_lightcurves.s4_genLC as s4

--- a/demos/JWST/CalibratedStellarSpectra/run_eureka.py
+++ b/demos/JWST/CalibratedStellarSpectra/run_eureka.py
@@ -1,4 +1,5 @@
 import os
+
 import eureka.lib.plots
 import eureka.S1_detector_processing.s1_process as s1
 import eureka.S2_calibrations.s2_calibrate as s2

--- a/demos/JWST/Optimizer/run_eureka_optimization.py
+++ b/demos/JWST/Optimizer/run_eureka_optimization.py
@@ -1,4 +1,5 @@
 import os
+
 import eureka.lib.plots
 import eureka.optimizer.S1opt_optimizer as s1opt
 import eureka.optimizer.S3opt_optimizer as s3opt

--- a/demos/JWST/download_data_JWST_template.py
+++ b/demos/JWST/download_data_JWST_template.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-from astroquery.mast import Observations
-import eureka.lib.mastDownload as md
 from astropy.io import ascii
+from astroquery.mast import Observations
+
+import eureka.lib.mastDownload as md
 
 # Proposal/Program ID, can be string or int
 proposal_id = '02734'

--- a/demos/JWST/run_eureka.py
+++ b/demos/JWST/run_eureka.py
@@ -1,4 +1,5 @@
 import os
+
 import eureka.lib.plots
 import eureka.S1_detector_processing.s1_process as s1
 import eureka.S2_calibrations.s2_calibrate as s2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,14 +12,15 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('../../'))
 sys.path.insert(0, os.path.abspath('../../src/'))
 
-from eureka import __version__
-
 import sphinx_rtd_theme
+
+from eureka import __version__
 
 # -- Project information -----------------------------------------------------
 
@@ -65,6 +66,7 @@ nbsphinx_prolog = """
 html_theme = 'sphinx_rtd_theme'
 
 import sphinx_rtd_theme
+
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - ipykernel >=6.0.0
   - ipympl >=0.9.3
   - ipython >=7.0.0
+  - isort
   - jupyter >=1.0.0
   - libblas =*=*openblas*
   - liblapack =*=*openblas*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,11 @@ namespaces = false
 [tool.setuptools_scm]
 write_to = "src/eureka/version.py"
 
+[tool.isort]
+line_length = 79
+known_first_party = ["eureka"]
+src_paths = ["src"]
+
 [tool.unidep]
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
@@ -138,6 +143,7 @@ jupyter = [
     "jupyter>=1.0.0", # Base metapackage
 ]
 dev = [
+    "isort",
     "pre-commit",
     { conda = "python-build", pip = "build" },
     "twine",

--- a/src/eureka/S1_detector_processing/__init__.py
+++ b/src/eureka/S1_detector_processing/__init__.py
@@ -1,8 +1,2 @@
-from . import bias_sub
-from . import group_level
-from . import ramp_fitting
-from . import remove390
-from . import s1_meta
-from . import s1_process
-from . import superbias
-from . import update_saturation
+from . import (bias_sub, group_level, ramp_fitting, remove390, s1_meta,
+               s1_process, superbias, update_saturation)

--- a/src/eureka/S1_detector_processing/bias_sub.py
+++ b/src/eureka/S1_detector_processing/bias_sub.py
@@ -2,12 +2,14 @@
 # This is based on the superbias_step from the JWST pipeline v1.8.0
 # adapted by Kevin Stevenson, Feb 2023
 
-import numpy as np
 import logging
+
+import numpy as np
 from jwst.lib import reffile_utils
-from .group_level import mask_trace
+
 from ..lib.astropytable import savetable_S1
 from ..lib.smooth import smooth
+from .group_level import mask_trace
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/eureka/S1_detector_processing/group_level.py
+++ b/src/eureka/S1_detector_processing/group_level.py
@@ -1,10 +1,9 @@
+import astraeus.xarrayIO as xrio
 import numpy as np
-
-import scipy.signal as sgn
 import scipy.ndimage as spn
+import scipy.signal as sgn
 
 from ..S3_data_reduction import background as bkg
-import astraeus.xarrayIO as xrio
 
 
 def GLBS(input_model, log, meta):

--- a/src/eureka/S1_detector_processing/ramp_fitting.py
+++ b/src/eureka/S1_detector_processing/ramp_fitting.py
@@ -4,33 +4,28 @@
 # Copyright (c) Association of Universities for Research in Astronomy (AURA)
 # SPDX-License-Identifier: BSD-3-Clause
 
-import numpy as np
-from functools import partial
+import logging
 import warnings
+from functools import partial
 
-from stcal.ramp_fitting import ramp_fit, utils
+import numpy as np
 import stcal.ramp_fitting.ols_fit
-from stcal.ramp_fitting.ramp_fit import suppress_one_good_group_ramps
-from stcal.ramp_fitting.ols_fit import discard_miri_groups
-
-from stcal.ramp_fitting.likely_fit import LIKELY_MIN_NGROUPS
-
-from jwst.stpipe import Step
 from jwst import datamodels
-
 from jwst.datamodels import dqflags
-
-from jwst.ramp_fitting.ramp_fit_step import get_reference_file_subarrays, \
-    create_image_model, create_integration_model, set_groupdq
-
 from jwst.firstframe.firstframe_step import FirstFrameStep
 from jwst.lastframe.lastframe_step import LastFrameStep
+from jwst.ramp_fitting.ramp_fit_step import (create_image_model,
+                                             create_integration_model,
+                                             get_reference_file_subarrays,
+                                             set_groupdq)
+from jwst.stpipe import Step
+from stcal.ramp_fitting import ramp_fit, utils
+from stcal.ramp_fitting.likely_fit import LIKELY_MIN_NGROUPS
+from stcal.ramp_fitting.ols_fit import discard_miri_groups
+from stcal.ramp_fitting.ramp_fit import suppress_one_good_group_ramps
 
-from . import update_saturation
-from . import group_level
-from . import remove390
+from . import group_level, remove390, update_saturation
 
-import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 

--- a/src/eureka/S1_detector_processing/remove390.py
+++ b/src/eureka/S1_detector_processing/remove390.py
@@ -1,13 +1,12 @@
-import numpy as np
-import matplotlib.pyplot as plt
-import os
-from tqdm import tqdm
 import multiprocessing as mp
+import os
 
+import matplotlib.pyplot as plt
+import numpy as np
 from astropy.stats import sigma_clip
-
-from scipy.signal import lombscargle
 from scipy.optimize import minimize
+from scipy.signal import lombscargle
+from tqdm import tqdm
 
 from ..lib import plots
 from ..lib.smooth import medfilt

--- a/src/eureka/S1_detector_processing/s1_process.py
+++ b/src/eureka/S1_detector_processing/s1_process.py
@@ -1,17 +1,17 @@
 import os
 import time as time_pkg
-import numpy as np
 from copy import deepcopy
-from astropy.io import fits
 
+import numpy as np
+from astropy.io import fits
 from jwst.pipeline.calwebb_detector1 import Detector1Pipeline
 
-from .ramp_fitting import Eureka_RampFitStep
-from .superbias import Eureka_SuperBiasStep
-from .s1_meta import S1MetaClass
-
-from ..lib import logedit, util
+from ..lib import logedit
 from ..lib import manageevent as me
+from ..lib import util
+from .ramp_fitting import Eureka_RampFitStep
+from .s1_meta import S1MetaClass
+from .superbias import Eureka_SuperBiasStep
 
 
 def rampfitJWST(eventlabel, ecf_path=None, input_meta=None):

--- a/src/eureka/S1_detector_processing/superbias.py
+++ b/src/eureka/S1_detector_processing/superbias.py
@@ -2,14 +2,17 @@
 # adapted by Kevin Stevenson, Feb 2023
 
 
-from jwst.stpipe import Step
-from jwst import datamodels
-# from jwst.superbias import bias_sub
-from . import bias_sub
 # import numpy as np
 # from functools import partial
 # import warnings
 import logging
+
+from jwst import datamodels
+from jwst.stpipe import Step
+
+# from jwst.superbias import bias_sub
+from . import bias_sub
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 

--- a/src/eureka/S2_calibrations/__init__.py
+++ b/src/eureka/S2_calibrations/__init__.py
@@ -1,2 +1,1 @@
-from . import s2_calibrate
-from . import s2_meta
+from . import s2_calibrate, s2_meta

--- a/src/eureka/S2_calibrations/s2_calibrate.py
+++ b/src/eureka/S2_calibrations/s2_calibrate.py
@@ -1,20 +1,21 @@
-import os
 import inspect
+import os
 import time as time_pkg
 from copy import deepcopy
-import numpy as np
-import matplotlib.pyplot as plt
-from astropy.io import fits
 from functools import partial
-from jwst import datamodels
-from jwst.pipeline.calwebb_spec2 import Spec2Pipeline
-from jwst.pipeline.calwebb_image2 import Image2Pipeline
-from jwst.assign_wcs import nirspec as nrs
 
-from .s2_meta import S2MetaClass
-from ..lib import logedit, util
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy.io import fits
+from jwst import datamodels
+from jwst.assign_wcs import nirspec as nrs
+from jwst.pipeline.calwebb_image2 import Image2Pipeline
+from jwst.pipeline.calwebb_spec2 import Spec2Pipeline
+
+from ..lib import logedit
 from ..lib import manageevent as me
-from ..lib import plots
+from ..lib import plots, util
+from .s2_meta import S2MetaClass
 
 _orig_nrs_wcs_set_input = nrs.nrs_wcs_set_input
 

--- a/src/eureka/S3_data_reduction/__init__.py
+++ b/src/eureka/S3_data_reduction/__init__.py
@@ -1,17 +1,3 @@
-from . import background
-from . import bright2flux
-from . import hst_scan
-from . import miri
-from . import nircam
-from . import niriss_profiles
-from . import niriss_python
-from . import niriss
-from . import nirspec
-from . import optspex
-from . import plots_s3
-from . import s3_meta
-from . import s3_reduce
-from . import sigrej
-from . import source_pos
-from . import straighten
-from . import wfc3
+from . import (background, bright2flux, hst_scan, miri, nircam, niriss,
+               niriss_profiles, niriss_python, nirspec, optspex, plots_s3,
+               s3_meta, s3_reduce, sigrej, source_pos, straighten, wfc3)

--- a/src/eureka/S3_data_reduction/background.py
+++ b/src/eureka/S3_data_reduction/background.py
@@ -1,9 +1,10 @@
-import numpy as np
-from tqdm import tqdm
 import multiprocessing as mp
-import matplotlib.pyplot as plt
 import os
 from copy import deepcopy
+
+import matplotlib.pyplot as plt
+import numpy as np
+from tqdm import tqdm
 
 from ..lib import plots
 from . import plots_s3

--- a/src/eureka/S3_data_reduction/bright2flux.py
+++ b/src/eureka/S3_data_reduction/bright2flux.py
@@ -1,10 +1,11 @@
+import crds
 import numpy as np
 import scipy.interpolate as spi
-from scipy.constants import arcsec
-from astropy.io import fits
-from ..lib.util import supersample
-import crds
 import xarray as xr
+from astropy.io import fits
+from scipy.constants import arcsec
+
+from ..lib.util import supersample
 
 
 def rate2count(data):

--- a/src/eureka/S3_data_reduction/hst_scan.py
+++ b/src/eureka/S3_data_reduction/hst_scan.py
@@ -1,5 +1,6 @@
 import numpy as np
 from astropy.io import fits
+
 try:
     import image_registration as imr
     imported_image_registration = True

--- a/src/eureka/S3_data_reduction/miri.py
+++ b/src/eureka/S3_data_reduction/miri.py
@@ -1,7 +1,9 @@
+import astraeus.xarrayIO as xrio
 import numpy as np
 from astropy.io import fits
-import astraeus.xarrayIO as xrio
-from . import background, nircam, straighten, plots_s3
+
+from . import background, nircam, plots_s3, straighten
+
 try:
     from jwst import datamodels
 except ImportError:

--- a/src/eureka/S3_data_reduction/nircam.py
+++ b/src/eureka/S3_data_reduction/nircam.py
@@ -1,11 +1,11 @@
 # NIRCam specific rountines go here
+import astraeus.xarrayIO as xrio
 import numpy as np
 from astropy.io import fits
-import astraeus.xarrayIO as xrio
 
-from . import sigrej, background, optspex, straighten, plots_s3
-from ..lib.util import read_time, supersample
 from ..lib import meanerr as me
+from ..lib.util import read_time, supersample
+from . import background, optspex, plots_s3, sigrej, straighten
 
 __all__ = ['read', 'straighten_trace', 'flag_ff', 'flag_bg', 'flag_bg_phot',
            'fit_bg', 'cut_aperture', 'standard_spectrum', 'clean_median_flux',

--- a/src/eureka/S3_data_reduction/niriss.py
+++ b/src/eureka/S3_data_reduction/niriss.py
@@ -1,15 +1,16 @@
 # NIRISS specific rountines go here
+import astraeus.xarrayIO as xrio
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
-import astraeus.xarrayIO as xrio
 from jwst.photom.photom import find_row
-from . import nircam, sigrej, optspex, plots_s3
-from ..lib.util import read_time, supersample
 from pastasoss import get_soss_traces, rotate
-from .straighten import roll_columns
+
+from ..lib.util import read_time, supersample
+from . import nircam, optspex, plots_s3, sigrej
 from .background import fitbg
 from .bright2flux import retrieve_ancil
+from .straighten import roll_columns
 
 __all__ = ['read', 'get_wave', 'straighten_trace', 'flag_ff', 'flag_bg',
            'clean_median_flux', 'fit_bg', 'cut_aperture', 'standard_spectrum',

--- a/src/eureka/S3_data_reduction/niriss_profiles.py
+++ b/src/eureka/S3_data_reduction/niriss_profiles.py
@@ -5,8 +5,8 @@ the optimal extraction of the data.
 """
 
 import numpy as np
-from scipy.special import gamma
 from astropy.modeling.models import Moffat1D
+from scipy.special import gamma
 
 __all__ = ['moffat_2poly_piecewise', 'moffat_1poly_piecewise',
            'gaussian_1poly_piecewise', 'gaussian_2poly_piecewise',

--- a/src/eureka/S3_data_reduction/nirspec.py
+++ b/src/eureka/S3_data_reduction/nirspec.py
@@ -1,9 +1,10 @@
 # NIRSpec specific rountines go here
+import astraeus.xarrayIO as xrio
 import numpy as np
 from astropy.io import fits
-import astraeus.xarrayIO as xrio
-from . import nircam, sigrej, straighten, plots_s3
+
 from ..lib.util import read_time, supersample
+from . import nircam, plots_s3, sigrej, straighten
 
 __all__ = ['read', 'straighten_trace', 'flag_ff', 'flag_bg',
            'fit_bg', 'cut_aperture', 'standard_spectrum', 'clean_median_flux',

--- a/src/eureka/S3_data_reduction/optspex.py
+++ b/src/eureka/S3_data_reduction/optspex.py
@@ -1,13 +1,14 @@
-import numpy as np
+import multiprocessing as mp
+
 import matplotlib.pyplot as plt
+import numpy as np
 import scipy.interpolate as spi
 import scipy.ndimage as spn
 from astropy.stats import sigma_clip
 from tqdm import tqdm
-import multiprocessing as mp
 
 from ..lib import gaussian as g
-from ..lib import smooth, plots
+from ..lib import plots, smooth
 from . import plots_s3
 
 

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -1,21 +1,23 @@
-import numpy as np
 import os
-from tqdm import tqdm
+import warnings
+
+import imageio
+import matplotlib.patches as patches
 import matplotlib.pyplot as plt
+import numpy as np
 import scipy.interpolate as spi
 import scipy.stats as stats
-from scipy.interpolate import interp1d
 from matplotlib.colors import LogNorm
-import matplotlib.patches as patches
 from matplotlib.path import Path
 from mpl_toolkits import axes_grid1
-import imageio
-import warnings
+from scipy.interpolate import interp1d
+from tqdm import tqdm
+
 warnings.filterwarnings("ignore", message='Ignoring specified arguments in '
                                           'this call because figure with num')
 
+from ..lib import plots, util
 from .source_pos import gauss
-from ..lib import util, plots
 
 
 @plots.apply_style

--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -24,23 +24,21 @@
 
 import os
 import time as time_pkg
-import numpy as np
 from copy import deepcopy
+
 import astraeus.xarrayIO as xrio
-from tqdm import tqdm
+import numpy as np
 import psutil
 from stdatamodels.jwst.datamodels import CubeModel
+from tqdm import tqdm
 
-from . import optspex
-from . import plots_s3, source_pos
-from . import background as bg
-from . import bright2flux as b2f
-
-from .s3_meta import S3MetaClass
-from ..lib import logedit
+from ..lib import apphot, centerdriver, logedit
 from ..lib import manageevent as me
 from ..lib import util
-from ..lib import centerdriver, apphot
+from . import background as bg
+from . import bright2flux as b2f
+from . import optspex, plots_s3, source_pos
+from .s3_meta import S3MetaClass
 
 
 def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):

--- a/src/eureka/S3_data_reduction/sigrej.py
+++ b/src/eureka/S3_data_reduction/sigrej.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from ..lib import medstddev as msd
 
 

--- a/src/eureka/S3_data_reduction/source_pos.py
+++ b/src/eureka/S3_data_reduction/source_pos.py
@@ -1,9 +1,11 @@
 # Determine source position for data where it's not in the header (MIRI)
 
+import multiprocessing as mp
+
 import numpy as np
 from scipy.optimize import curve_fit
 from tqdm import tqdm
-import multiprocessing as mp
+
 from . import plots_s3
 
 

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -1,8 +1,9 @@
 import numpy as np
+from scipy.optimize import curve_fit
+
 from ..lib import smooth
 from . import plots_s3
 from .source_pos import gauss
-from scipy.optimize import curve_fit
 
 
 def find_column_median_shifts(data, meta, m):

--- a/src/eureka/S3_data_reduction/wfc3.py
+++ b/src/eureka/S3_data_reduction/wfc3.py
@@ -1,18 +1,20 @@
 
 # WFC3 specific rountines go here
-import os
-import numpy as np
 import multiprocessing as mp
-from astropy.io import fits
+import os
+
+import astraeus.xarrayIO as xrio
+import numpy as np
 import scipy.interpolate as spi
 import scipy.ndimage as spni
-import astraeus.xarrayIO as xrio
+from astropy.io import fits
 from tqdm import tqdm
 
-from . import sigrej, source_pos, background, plots_s3, nircam
-from . import hst_scan as hst
-from . import bright2flux as b2f
 from ..lib import suntimecorr, utc_tt, util
+from . import background
+from . import bright2flux as b2f
+from . import hst_scan as hst
+from . import nircam, plots_s3, sigrej, source_pos
 
 
 def preparation_step(meta, log):

--- a/src/eureka/S4_generate_lightcurves/__init__.py
+++ b/src/eureka/S4_generate_lightcurves/__init__.py
@@ -1,6 +1,1 @@
-from . import drift
-from . import generate_LD
-from . import plots_s4
-from . import s4_genLC
-from . import s4_meta
-from . import wfc3
+from . import drift, generate_LD, plots_s4, s4_genLC, s4_meta, wfc3

--- a/src/eureka/S4_generate_lightcurves/drift.py
+++ b/src/eureka/S4_generate_lightcurves/drift.py
@@ -1,9 +1,10 @@
 import numpy as np
 import scipy.signal as sps
+from astropy.convolution import Box1DKernel, convolve
 from tqdm import tqdm
+
 from ..lib import gaussian as g
 from . import plots_s4
-from astropy.convolution import convolve, Box1DKernel
 
 
 def highpassfilt(signal, highpassWidth):

--- a/src/eureka/S4_generate_lightcurves/generate_LD.py
+++ b/src/eureka/S4_generate_lightcurves/generate_LD.py
@@ -1,6 +1,6 @@
-from exotic_ld import StellarLimbDarkening
 import numpy as np
 import pandas as pd
+from exotic_ld import StellarLimbDarkening
 
 from . import plots_s4
 

--- a/src/eureka/S4_generate_lightcurves/outliers.py
+++ b/src/eureka/S4_generate_lightcurves/outliers.py
@@ -1,6 +1,7 @@
 import numpy as np
 from astropy.stats import sigma_clip
-from ..lib import util, smooth
+
+from ..lib import smooth, util
 
 
 def get_outliers(meta, spec):

--- a/src/eureka/S4_generate_lightcurves/plots_s4.py
+++ b/src/eureka/S4_generate_lightcurves/plots_s4.py
@@ -1,9 +1,11 @@
-import numpy as np
 import os
-import matplotlib.pyplot as plt
-from ..lib import util
-from ..lib import plots
 import warnings
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ..lib import plots, util
+
 warnings.filterwarnings("ignore", message='Ignoring specified arguments in '
                                           'this call because figure with num')
 

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -16,21 +16,21 @@
 
 import os
 import time as time_pkg
-import numpy as np
 from copy import deepcopy
-import scipy.interpolate as spi
+
 import astraeus.xarrayIO as xrio
+import numpy as np
+import scipy.interpolate as spi
 from astropy.convolution import Box1DKernel
 from tqdm import tqdm
 
-from . import plots_s4, drift, generate_LD, wfc3
-from .outliers import get_outliers
-from .s4_meta import S4MetaClass
-from ..lib import logedit
+from ..lib import clipping, logedit
 from ..lib import manageevent as me
 from ..lib import util
-from ..lib import clipping
 from ..version import version
+from . import drift, generate_LD, plots_s4, wfc3
+from .outliers import get_outliers
+from .s4_meta import S4MetaClass
 
 
 def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):

--- a/src/eureka/S4_generate_lightcurves/s4_meta.py
+++ b/src/eureka/S4_generate_lightcurves/s4_meta.py
@@ -1,5 +1,7 @@
-import numpy as np
 from glob import glob
+
+import numpy as np
+
 from ..lib.readECF import MetaClass
 
 

--- a/src/eureka/S4cal_StellarSpectra/__init__.py
+++ b/src/eureka/S4cal_StellarSpectra/__init__.py
@@ -1,3 +1,1 @@
-from . import plots_s4cal
-from . import s4cal_meta
-from . import s4cal_StellarSpec
+from . import plots_s4cal, s4cal_meta, s4cal_StellarSpec

--- a/src/eureka/S4cal_StellarSpectra/plots_s4cal.py
+++ b/src/eureka/S4cal_StellarSpectra/plots_s4cal.py
@@ -1,7 +1,9 @@
-import numpy as np
 import os
+
 import matplotlib.pyplot as plt
-from ..lib import util, plots
+import numpy as np
+
+from ..lib import plots, util
 
 colors = ['xkcd:bright blue', 'xkcd:soft green', 'orange', 'purple']
 

--- a/src/eureka/S4cal_StellarSpectra/s4cal_StellarSpec.py
+++ b/src/eureka/S4cal_StellarSpectra/s4cal_StellarSpec.py
@@ -2,19 +2,21 @@
 
 # Generic Stage 4cal Calibrated Stellar Spectra pipeline
 
-import numpy as np
 import os
 import time as time_pkg
 from copy import deepcopy
+
 import astraeus.xarrayIO as xrio
+import numpy as np
 import scipy.interpolate as spi
 
-from ..version import version
+from ..lib import logedit
 from ..lib import manageevent as me
-from ..lib import util, logedit
+from ..lib import util
 from ..S3_data_reduction.sigrej import sigrej
+from ..version import version
+from .plots_s4cal import plot_stellarSpec, plot_whitelc
 from .s4cal_meta import S4cal_MetaClass
-from .plots_s4cal import plot_whitelc, plot_stellarSpec
 
 
 def medianCalSpec(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):

--- a/src/eureka/S5_lightcurve_fitting/__init__.py
+++ b/src/eureka/S5_lightcurve_fitting/__init__.py
@@ -1,14 +1,5 @@
 """
 Package to fit models to light curve data
 """
-from . import fitters
-from . import lightcurve
-from . import likelihood
-from . import limb_darkening_fit
-from . import modelgrid
-from . import models
-from . import plots_s5
-from . import s5_fit
-from . import s5_meta
-from . import simulations
-from . import utils
+from . import (fitters, lightcurve, likelihood, limb_darkening_fit, modelgrid,
+               models, plots_s5, s5_fit, s5_meta, simulations, utils)

--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -20,10 +20,8 @@ from scipy.optimize import minimize
 from ..lib import astropytable, util
 from ..lib.split_channels import get_trim
 from . import plots_s5 as plots
-from .likelihood import (
-    computeRedChiSq, ln_like, lnprob, ptform,
-    update_uncertainty
-)
+from .likelihood import (computeRedChiSq, ln_like, lnprob, ptform,
+                         update_uncertainty)
 
 
 def _get_dynesty_checkpoint_file(meta, lc, fittername):

--- a/src/eureka/S5_lightcurve_fitting/lightcurve.py
+++ b/src/eureka/S5_lightcurve_fitting/lightcurve.py
@@ -1,13 +1,14 @@
-import numpy as np
 import os
-import matplotlib.pyplot as plt
 from copy import copy
 
-from . import models as m
-from . import fitters
-from .utils import COLORS, color_gen
+import matplotlib.pyplot as plt
+import numpy as np
+
 from ..lib import plots, util
 from ..lib.split_channels import get_trim, split
+from . import fitters
+from . import models as m
+from .utils import COLORS, color_gen
 
 
 class LightCurve(m.Model):

--- a/src/eureka/S5_lightcurve_fitting/likelihood.py
+++ b/src/eureka/S5_lightcurve_fitting/likelihood.py
@@ -1,5 +1,6 @@
-import numpy as np
 import copy
+
+import numpy as np
 from scipy.stats import norm
 
 from ..lib.split_channels import get_trim

--- a/src/eureka/S5_lightcurve_fitting/limb_darkening_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/limb_darkening_fit.py
@@ -7,22 +7,24 @@ import inspect
 import warnings
 
 import astropy.table as at
-from astropy.utils.exceptions import AstropyWarning
+import bokeh.plotting as bkp
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from astropy.utils.exceptions import AstropyWarning
+from bokeh.models import Range1d
 from scipy.optimize import curve_fit
 from svo_filters import svo
-import bokeh.plotting as bkp
-from bokeh.models import Range1d
+
 try:
     from bokeh.models.widgets import Panel, Tabs
 except ImportError:
     from bokeh.models.layouts import TabPanel as Panel
     from bokeh.models.layouts import Tabs
 
-from . import utils
 from ..lib import plots
+from . import utils
+
 # from . import modelgrid
 
 warnings.simplefilter('ignore', category=AstropyWarning)

--- a/src/eureka/S5_lightcurve_fitting/modelgrid.py
+++ b/src/eureka/S5_lightcurve_fitting/modelgrid.py
@@ -3,21 +3,21 @@
 """
 A module for creating and managing grids of model spectra
 """
-from functools import partial
-from glob import glob
 import multiprocessing
 import os
 import pickle
-from importlib.resources import files
 import time
 import warnings
+from functools import partial
+from glob import glob
+from importlib.resources import files
 
-from astropy.io import fits
-from astropy.utils.exceptions import AstropyWarning
 import astropy.table as at
 import astropy.units as q
 import h5py
 import numpy as np
+from astropy.io import fits
+from astropy.utils.exceptions import AstropyWarning
 from scipy.interpolate import RegularGridInterpolator
 from scipy.ndimage import zoom
 

--- a/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/AstroModel.py
@@ -1,12 +1,13 @@
-import numpy as np
-import astropy.constants as const
-from copy import copy
 import inspect
+from copy import copy
 
-from .Model import Model
-from .KeplerOrbit import KeplerOrbit
-from ..limb_darkening_fit import ld_profile
+import astropy.constants as const
+import numpy as np
+
 from ...lib.split_channels import split
+from ..limb_darkening_fit import ld_profile
+from .KeplerOrbit import KeplerOrbit
+from .Model import Model
 
 
 class PlanetParams():

--- a/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
@@ -9,8 +9,8 @@ except ImportError:
 
 from ...lib.split_channels import split
 from ..limb_darkening_fit import ld_profile
-from . import Model
 from .AstroModel import PlanetParams, correct_light_travel_time, get_ecl_midpt
+from .Model import Model
 
 
 class BatmanTransitModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/BatmanModels.py
@@ -1,14 +1,16 @@
-import numpy as np
 import inspect
+
+import numpy as np
+
 try:
     import batman
 except ImportError:
     print("Could not import batman. Functionality may be limited.")
 
+from ...lib.split_channels import split
+from ..limb_darkening_fit import ld_profile
 from . import Model
 from .AstroModel import PlanetParams, correct_light_travel_time, get_ecl_midpt
-from ..limb_darkening_fit import ld_profile
-from ...lib.split_channels import split
 
 
 class BatmanTransitModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/CatwomanModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/CatwomanModel.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 try:
     import catwoman
 except ImportError:

--- a/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/CentroidModel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
+from ...lib.split_channels import get_trim, split
 from .Model import Model
-from ...lib.split_channels import split, get_trim
 
 
 class CentroidModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/CommonModeModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/CommonModeModel.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from .Model import Model
-from ...lib.split_channels import split, get_trim
 from ...lib import astropytable
+from ...lib.split_channels import get_trim, split
+from .Model import Model
 
 
 class CommonModeModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/DampedOscillator.py
+++ b/src/eureka/S5_lightcurve_fitting/models/DampedOscillator.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from .Model import Model
 from ...lib.split_channels import split
+from .Model import Model
 
 
 class DampedOscillatorModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/ExpRampModel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
+from ...lib.split_channels import get_trim, split
 from .Model import Model
-from ...lib.split_channels import split, get_trim
 
 
 class ExpRampModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/FleckModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/FleckModel.py
@@ -1,7 +1,6 @@
-import numpy as np
 import astropy.units as unit
-
 import fleck
+import numpy as np
 
 from .BatmanModels import BatmanTransitModel
 

--- a/src/eureka/S5_lightcurve_fitting/models/GPModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/GPModel.py
@@ -1,11 +1,11 @@
-import numpy as np
-import george
-from george import kernels
 import celerite2
+import george
+import numpy as np
+from george import kernels
 
-from .Model import Model
-from ..likelihood import update_uncertainty
 from ...lib.split_channels import split
+from ..likelihood import update_uncertainty
+from .Model import Model
 
 try:
     import tinygp

--- a/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HSTRampModel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
+from ...lib.split_channels import get_trim, split
 from .Model import Model
-from ...lib.split_channels import split, get_trim
 
 
 class HSTRampModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/HarmonicaModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HarmonicaModel.py
@@ -1,12 +1,13 @@
 import numpy as np
+
 try:
     from harmonica import HarmonicaTransit
 except ImportError:
     print("Could not import harmonica. Functionality may be limited.")
 
-from .BatmanModels import BatmanTransitModel
-from .AstroModel import PlanetParams
 from ...lib.split_channels import split
+from .AstroModel import PlanetParams
+from .BatmanModels import BatmanTransitModel
 
 
 class HarmonicaTransitModel(BatmanTransitModel):

--- a/src/eureka/S5_lightcurve_fitting/models/KeplerOrbit.py
+++ b/src/eureka/S5_lightcurve_fitting/models/KeplerOrbit.py
@@ -1,6 +1,6 @@
-import numpy as np
-import matplotlib.pyplot as plt
 import astropy.constants as const
+import matplotlib.pyplot as plt
+import numpy as np
 import scipy.optimize
 
 from ...lib import plots

--- a/src/eureka/S5_lightcurve_fitting/models/LorentzianModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/LorentzianModel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from .Model import Model
 from ...lib.split_channels import split
+from .Model import Model
 
 
 class LorentzianModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/Model.py
+++ b/src/eureka/S5_lightcurve_fitting/models/Model.py
@@ -1,13 +1,14 @@
-import numpy as np
-import matplotlib.pyplot as plt
 import copy
 import os
 
-from ..utils import COLORS
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ...lib import plots
 from ...lib.readEPF import Parameters
 from ...lib.split_channels import split
-from ...lib import plots
 from ...lib.util import resolve_param_key
+from ..utils import COLORS
 
 
 class Model:

--- a/src/eureka/S5_lightcurve_fitting/models/PoetModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/PoetModels.py
@@ -1,10 +1,10 @@
-import numpy as np
 import batman as bm
+import numpy as np
 
-from .Model import Model
-from .AstroModel import PlanetParams, get_ecl_midpt
-from .BatmanModels import BatmanTransitModel, BatmanEclipseModel
 from ...lib.split_channels import split
+from .AstroModel import PlanetParams, get_ecl_midpt
+from .BatmanModels import BatmanEclipseModel, BatmanTransitModel
+from .Model import Model
 
 
 class PoetTransitModel(BatmanTransitModel):

--- a/src/eureka/S5_lightcurve_fitting/models/PolynomialModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/PolynomialModel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
+from ...lib.split_channels import get_trim, split
 from .Model import Model
-from ...lib.split_channels import split, get_trim
 
 
 class PolynomialModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/QuasiLambertianPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/models/QuasiLambertianPhaseCurve.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from .Model import Model
-from .AstroModel import PlanetParams, get_ecl_midpt, true_anomaly
 from ...lib.split_channels import split
+from .AstroModel import PlanetParams, get_ecl_midpt, true_anomaly
+from .Model import Model
 
 
 class QuasiLambertianPhaseCurve(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
+++ b/src/eureka/S5_lightcurve_fitting/models/SinusoidPhaseCurve.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from .Model import Model
-from .AstroModel import PlanetParams, get_ecl_midpt, true_anomaly
 from ...lib.split_channels import split
+from .AstroModel import PlanetParams, get_ecl_midpt, true_anomaly
+from .Model import Model
 
 
 class SinusoidPhaseCurveModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/StepModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/StepModel.py
@@ -1,7 +1,7 @@
 import numpy as np
 
+from ...lib.split_channels import get_trim, split
 from .Model import Model
-from ...lib.split_channels import split, get_trim
 
 
 class StepModel(Model):

--- a/src/eureka/S5_lightcurve_fitting/models/__init__.py
+++ b/src/eureka/S5_lightcurve_fitting/models/__init__.py
@@ -1,18 +1,18 @@
-from .Model import Model, CompositeModel
 from .AstroModel import AstroModel, PlanetParams
-from .BatmanModels import BatmanTransitModel, BatmanEclipseModel
+from .BatmanModels import BatmanEclipseModel, BatmanTransitModel
 from .CatwomanModel import CatwomanTransitModel
-from .CommonModeModel import CommonModeModel
-from .FleckModel import FleckTransitModel
 from .CentroidModel import CentroidModel
+from .CommonModeModel import CommonModeModel
 from .DampedOscillator import DampedOscillatorModel
 from .ExpRampModel import ExpRampModel
+from .FleckModel import FleckTransitModel
 from .GPModel import GPModel
 from .HarmonicaModel import HarmonicaTransitModel
 from .HSTRampModel import HSTRampModel
 from .KeplerOrbit import KeplerOrbit
 from .LorentzianModel import LorentzianModel
-from .PoetModels import PoetTransitModel, PoetEclipseModel, PoetPCModel
+from .Model import CompositeModel, Model
+from .PoetModels import PoetEclipseModel, PoetPCModel, PoetTransitModel
 from .PolynomialModel import PolynomialModel
 from .QuasiLambertianPhaseCurve import QuasiLambertianPhaseCurve
 from .SinusoidPhaseCurve import SinusoidPhaseCurveModel

--- a/src/eureka/S5_lightcurve_fitting/plots_s5.py
+++ b/src/eureka/S5_lightcurve_fitting/plots_s5.py
@@ -1,23 +1,27 @@
 import os
 import sys
-import numpy as np
 from copy import deepcopy
+
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib import rcParams
+
 try:
     from mc3.stats import time_avg
 except ModuleNotFoundError:
     print("Could not import MC3. No RMS time-averaging plots will be made.")
-import corner
-from scipy import stats
-import fleck
 import astropy.units as unit
+import corner
+import fleck
+from scipy import stats
+
 try:
     from harmonica import HarmonicaTransit
 except ModuleNotFoundError:
     # Harmonica hasn't been installed
     pass
 import warnings
+
 warnings.filterwarnings("ignore", message='Ignoring specified arguments in '
                                           'this call because figure with num')
 

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -1,18 +1,20 @@
-import numpy as np
 import os
 import time as time_pkg
-from glob import glob
 from copy import deepcopy
-import astraeus.xarrayIO as xrio
+from glob import glob
 
-from .s5_meta import S5MetaClass
+import astraeus.xarrayIO as xrio
+import numpy as np
+
+from ..lib import logedit
+from ..lib import manageevent as me
+from ..lib import util
+from ..lib.readEPF import Parameters
+from ..lib.util import resolve_param_key
+from ..version import version
 from . import lightcurve
 from . import models as m
-from ..lib import manageevent as me
-from ..lib import util, logedit
-from ..lib.util import resolve_param_key
-from ..lib.readEPF import Parameters
-from ..version import version
+from .s5_meta import S5MetaClass
 
 
 def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):

--- a/src/eureka/S5_lightcurve_fitting/simulations.py
+++ b/src/eureka/S5_lightcurve_fitting/simulations.py
@@ -1,5 +1,6 @@
 import numpy as np
 from bokeh.plotting import figure, show
+
 try:
     import batman
 except ImportError:

--- a/src/eureka/S5_lightcurve_fitting/utils.py
+++ b/src/eureka/S5_lightcurve_fitting/utils.py
@@ -8,14 +8,14 @@ import glob
 import itertools
 import os
 import re
-import requests
 import shutil
 import urllib
 
-from astropy.io import fits
 import bokeh.palettes as bpal
-from scipy.interpolate import RegularGridInterpolator
 import numpy as np
+import requests
+from astropy.io import fits
+from scipy.interpolate import RegularGridInterpolator
 from svo_filters import svo
 
 # Supported profiles

--- a/src/eureka/S6_planet_spectra/__init__.py
+++ b/src/eureka/S6_planet_spectra/__init__.py
@@ -1,6 +1,4 @@
 """
 Package to plot transmission/emission spectra after fitting
 """
-from . import plots_s6
-from . import s6_spectra
-from . import s6_meta
+from . import plots_s6, s6_meta, s6_spectra

--- a/src/eureka/S6_planet_spectra/plots_s6.py
+++ b/src/eureka/S6_planet_spectra/plots_s6.py
@@ -1,9 +1,11 @@
-from copy import deepcopy
-import numpy as np
 import os
-import matplotlib.pyplot as plt
 import re
 import warnings
+from copy import deepcopy
+
+import matplotlib.pyplot as plt
+import numpy as np
+
 warnings.filterwarnings("ignore", message='Ignoring specified arguments in '
                                           'this call because figure with num')
 

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -1,16 +1,16 @@
 
-import numpy as np
-from copy import deepcopy
-import pandas as pd
-from astropy import units, constants
 import os
-import time as time_pkg
-from copy import copy
-from glob import glob
-from tqdm import tqdm
 import re
-from matplotlib.pyplot import rcParams
+import time as time_pkg
+from copy import copy, deepcopy
+from glob import glob
+
+import numpy as np
+import pandas as pd
 from astraeus import xarrayIO as xrio
+from astropy import constants, units
+from matplotlib.pyplot import rcParams
+from tqdm import tqdm
 
 try:
     from harmonica import HarmonicaTransit
@@ -18,11 +18,12 @@ except ModuleNotFoundError:
     # Harmonica hasn't been installed
     pass
 
-from .s6_meta import S6MetaClass
-from . import plots_s6 as plots
+from ..lib import astropytable, logedit
 from ..lib import manageevent as me
-from ..lib import util, logedit, astropytable
+from ..lib import util
 from ..version import version
+from . import plots_s6 as plots
+from .s6_meta import S6MetaClass
 
 
 def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):

--- a/src/eureka/__init__.py
+++ b/src/eureka/__init__.py
@@ -1,5 +1,6 @@
-import os
 import logging
+import os
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -9,11 +10,14 @@ except ModuleNotFoundError:
     __version__ = get_version(root=f'..{os.sep}..{os.sep}',
                               relative_to=__file__)
 
-from astropy.utils.exceptions import AstropyDeprecationWarning
 import warnings
+
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
 warnings.simplefilter('ignore', category=AstropyDeprecationWarning)
 
 from . import lib
+
 try:
     import jwst
     success = True
@@ -24,11 +28,9 @@ except ModuleNotFoundError:
 if success:
     from . import S1_detector_processing
     from . import S2_calibrations
-from . import S3_data_reduction
-from . import S4_generate_lightcurves
-from . import S4cal_StellarSpectra
-from . import S5_lightcurve_fitting
-from . import S6_planet_spectra
+
+from . import (S3_data_reduction, S4_generate_lightcurves,
+               S4cal_StellarSpectra, S5_lightcurve_fitting, S6_planet_spectra)
 
 __all__ = ["lib", "S3_data_reduction", "S4_generate_lightcurves",
            "S4cal_StellarSpectra", "S5_lightcurve_fitting",

--- a/src/eureka/lib/__init__.py
+++ b/src/eureka/lib/__init__.py
@@ -1,26 +1,5 @@
-from . import apphot
-from . import astropytable
-from . import centerdriver
-from . import centroid
-from . import citations
-from . import clipping
-from . import disk
-from . import gaussian_min
-from . import gaussian
-from . import gelmanrubin
-from . import imageedit
-from . import interp2d
-from . import logedit
-from . import manageevent
-from . import medstddev
-from . import naninterp1d
-from . import plots
-from . import readECF
-from . import readEPF
-from . import smooth
-from . import sort_nicely
-from . import splinterp
-from . import split_channels
-from . import suntimecorr
-from . import utc_tt
-from . import util
+from . import (apphot, astropytable, centerdriver, centroid, citations,
+               clipping, disk, gaussian, gaussian_min, gelmanrubin, imageedit,
+               interp2d, logedit, manageevent, medstddev, naninterp1d, plots,
+               readECF, readEPF, smooth, sort_nicely, splinterp,
+               split_channels, suntimecorr, utc_tt, util)

--- a/src/eureka/lib/apphot.py
+++ b/src/eureka/lib/apphot.py
@@ -1,14 +1,16 @@
-import numpy as np
-from shapely.geometry import Polygon, Point
-from shapely.affinity import rotate
 from functools import partial
-from photutils.aperture import (aperture_photometry, CircularAperture,
-                                EllipticalAperture, RectangularAperture,
-                                CircularAnnulus, EllipticalAnnulus,
-                                RectangularAnnulus)
+
+import numpy as np
+from photutils.aperture import (CircularAnnulus, CircularAperture,
+                                EllipticalAnnulus, EllipticalAperture,
+                                RectangularAnnulus, RectangularAperture,
+                                aperture_photometry)
+from shapely.affinity import rotate
+from shapely.geometry import Point, Polygon
+
 from . import disk as di
-from . import meanerr as me
 from . import interp2d as i2d
+from . import meanerr as me
 
 
 def apphot(data, meta, i):

--- a/src/eureka/lib/astropytable.py
+++ b/src/eureka/lib/astropytable.py
@@ -1,6 +1,6 @@
-from astropy.table import QTable
-from astropy.io import ascii
 import numpy as np
+from astropy.io import ascii
+from astropy.table import QTable
 
 from .split_channels import get_trim
 

--- a/src/eureka/lib/centerdriver.py
+++ b/src/eureka/lib/centerdriver.py
@@ -1,8 +1,9 @@
 import numpy as np
-from . import imageedit as ie
+
+from ..S3_data_reduction import plots_s3
 from . import gaussian as g
 from . import gaussian_min as gmin
-from ..S3_data_reduction import plots_s3
+from . import imageedit as ie
 
 
 def centerdriver(method, data, meta, i=None, m=None):

--- a/src/eureka/lib/centroid.py
+++ b/src/eureka/lib/centroid.py
@@ -1,6 +1,6 @@
 import numpy as np
-from . import gaussian as g
 
+from . import gaussian as g
 
 # Stellar Centroiding Routines
 # ----------------------------

--- a/src/eureka/lib/clipping.py
+++ b/src/eureka/lib/clipping.py
@@ -1,9 +1,9 @@
 import numpy as np
-from scipy.special import erf
-from astropy.modeling.models import Gaussian1D, custom_model
-from astropy.modeling.fitting import LevMarLSQFitter
 from astropy.convolution import Box1DKernel, convolve
+from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.models import Gaussian1D, custom_model
 from astropy.stats import sigma_clip
+from scipy.special import erf
 
 __all__ = ['clip_outliers', 'gauss_removal']
 

--- a/src/eureka/lib/gaussian.py
+++ b/src/eureka/lib/gaussian.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.optimize as so
+
 from . import disk as d
 
 

--- a/src/eureka/lib/gaussian_min.py
+++ b/src/eureka/lib/gaussian_min.py
@@ -1,8 +1,9 @@
-from scipy.optimize import minimize
-import numpy as np
 import sys
-from photutils.centroids import (centroid_com, centroid_1dg,  # noqa: F401
-                                 centroid_2dg, centroid_sources)
+
+import numpy as np
+from photutils.centroids import (centroid_1dg, centroid_2dg,  # noqa: F401
+                                 centroid_com, centroid_sources)
+from scipy.optimize import minimize
 
 
 def evalgauss(params, x, y, x0, y0):

--- a/src/eureka/lib/manageevent.py
+++ b/src/eureka/lib/manageevent.py
@@ -1,13 +1,13 @@
-import numpy as np
-import h5py as h5
-import pickle
-import os
 import glob
+import os
+import pickle
 import re
-import astraeus.xarrayIO as xrio
 
-from . import readECF
-from . import util
+import astraeus.xarrayIO as xrio
+import h5py as h5
+import numpy as np
+
+from . import readECF, util
 
 
 def filter_allapers_inputdir(meta):

--- a/src/eureka/lib/mastDownload.py
+++ b/src/eureka/lib/mastDownload.py
@@ -1,11 +1,12 @@
 
-import numpy as np
+import os
 import re
 import shutil
-import os
-from astroquery.mast import Observations
+
 import astropy.io.fits as pf
+import numpy as np
 from astropy.io import ascii
+from astroquery.mast import Observations
 
 
 def columnNames():

--- a/src/eureka/lib/medstddev.py
+++ b/src/eureka/lib/medstddev.py
@@ -1,5 +1,6 @@
-import numpy as np
 import warnings
+
+import numpy as np
 
 
 def medstddev(data, mask=None, medi=False, axis=0):

--- a/src/eureka/lib/plots.py
+++ b/src/eureka/lib/plots.py
@@ -1,8 +1,9 @@
 import os
-import matplotlib
-from matplotlib import rcdefaults, rcParams, font_manager
-from matplotlib import style as mpl_style
 from functools import wraps
+
+import matplotlib
+from matplotlib import font_manager, rcdefaults, rcParams
+from matplotlib import style as mpl_style
 
 # Global configuration dictionary (used by decorator and set_rc)
 _current_style = {

--- a/src/eureka/lib/readECF.py
+++ b/src/eureka/lib/readECF.py
@@ -1,7 +1,8 @@
 import os
-import time as time_pkg
-import crds
 import shlex
+import time as time_pkg
+
+import crds
 # Required in case user passes in a numpy object (e.g. np.inf)
 import numpy as np
 

--- a/src/eureka/lib/readEPF.py
+++ b/src/eureka/lib/readEPF.py
@@ -1,6 +1,7 @@
-import numpy as np
-import os
 import inspect
+import os
+
+import numpy as np
 
 
 class Parameter:

--- a/src/eureka/lib/suntimecorr.py
+++ b/src/eureka/lib/suntimecorr.py
@@ -1,6 +1,8 @@
-import numpy as np
 import re
+
+import numpy as np
 from scipy.constants import c
+
 from .splinterp import splinterp
 
 

--- a/src/eureka/lib/utc_tt.py
+++ b/src/eureka/lib/utc_tt.py
@@ -1,8 +1,9 @@
-import numpy as np
-import urllib
 import os
 import re
 import time
+import urllib
+
+import numpy as np
 
 
 def leapdates(rundir, log):

--- a/src/eureka/optimizer/S1opt_optimizer.py
+++ b/src/eureka/optimizer/S1opt_optimizer.py
@@ -1,9 +1,10 @@
 
-import os
 import json
-import numpy as np
-from copy import deepcopy
+import os
 import time as time_pkg
+from copy import deepcopy
+
+import numpy as np
 
 import eureka.S1_detector_processing.s1_process as s1
 import eureka.S2_calibrations.s2_calibrate as s2
@@ -11,12 +12,13 @@ import eureka.S3_data_reduction.s3_reduce as s3
 import eureka.S4_generate_lightcurves.s4_genLC as s4
 from eureka.S1_detector_processing.s1_meta import S1MetaClass
 from eureka.S2_calibrations.s2_meta import S2MetaClass
-from eureka.S3_data_reduction.s3_meta import S3MetaClass
 from eureka.S3_data_reduction import plots_s3
+from eureka.S3_data_reduction.s3_meta import S3MetaClass
 from eureka.S4_generate_lightcurves.s4_meta import S4MetaClass
-from .S1opt_meta import S1optMetaClass
-from . import objective_funcs, optimizers
+
 from ..lib import logedit, util
+from . import objective_funcs, optimizers
+from .S1opt_meta import S1optMetaClass
 
 
 def wrapper(eventlabel, ecf_path=None, initial_run=True, final_run=True):

--- a/src/eureka/optimizer/S3opt_meta.py
+++ b/src/eureka/optimizer/S3opt_meta.py
@@ -1,7 +1,8 @@
 import numpy as np
-from ..lib.readECF import MetaClass
-from ..lib import util
+
 from ..lib import manageevent as me
+from ..lib import util
+from ..lib.readECF import MetaClass
 
 
 class S3optMetaClass(MetaClass):

--- a/src/eureka/optimizer/__init__.py
+++ b/src/eureka/optimizer/__init__.py
@@ -1,5 +1,2 @@
 # -*- coding: utf-8 -*-
-from . import S3opt_meta
-from . import S3opt_optimizer
-from . import optimizers
-from . import objective_funcs
+from . import S3opt_meta, S3opt_optimizer, objective_funcs, optimizers

--- a/src/eureka/optimizer/optimizers.py
+++ b/src/eureka/optimizer/optimizers.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import eureka.optimizer.objective_funcs as of
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 # Some bits of code to help VS Code run tests automatically
 
 import os
+
 # VS Code runs tests from the root directory, so need to chdir into
 # the tests directory
 if os.getcwd().split(os.sep)[-1] != "tests":

--- a/tests/test_MIRI.py
+++ b/tests/test_MIRI.py
@@ -1,16 +1,17 @@
-import sys
 import os
-from importlib import reload
+import sys
 import time as time_pkg
 from copy import deepcopy
+from importlib import reload
 
 import numpy as np
 
 sys.path.insert(0, '..'+os.sep+'src'+os.sep)
+import eureka.lib.plots
+from eureka.lib.citations import CITATIONS
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import COMMON_IMPORTS, pathdirectory
-from eureka.lib.citations import CITATIONS
-import eureka.lib.plots
+
 try:
     from eureka.S1_detector_processing import s1_process as s1
     from eureka.S2_calibrations import s2_calibrate as s2

--- a/tests/test_NIRCam.py
+++ b/tests/test_NIRCam.py
@@ -1,7 +1,7 @@
-import sys
 import os
-from importlib import reload
+import sys
 import time as time_pkg
+from importlib import reload
 
 import numpy as np
 

--- a/tests/test_NIRISS.py
+++ b/tests/test_NIRISS.py
@@ -1,7 +1,7 @@
-import sys
 import os
-from importlib import reload
+import sys
 import time as time_pkg
+from importlib import reload
 
 import numpy as np
 

--- a/tests/test_NIRSpec.py
+++ b/tests/test_NIRSpec.py
@@ -1,7 +1,7 @@
-import sys
 import os
-from importlib import reload
+import sys
 import time as time_pkg
+from importlib import reload
 
 import numpy as np
 

--- a/tests/test_Photometry_NIRCam.py
+++ b/tests/test_Photometry_NIRCam.py
@@ -1,7 +1,7 @@
-import sys
 import os
-from importlib import reload
+import sys
 import time as time_pkg
+from importlib import reload
 
 import numpy as np
 

--- a/tests/test_S3opt.py
+++ b/tests/test_S3opt.py
@@ -1,10 +1,10 @@
-import sys
 import os
+import sys
 from importlib import reload
 
 sys.path.insert(0, '..'+os.sep+'src'+os.sep)
-from eureka.S2_calibrations import s2_calibrate as s2
 import eureka.optimizer.S3opt_optimizer as s3opt
+from eureka.S2_calibrations import s2_calibrate as s2
 
 
 def test_S3opt(capsys):

--- a/tests/test_S4cal.py
+++ b/tests/test_S4cal.py
@@ -1,7 +1,7 @@
-import sys
 import os
-from importlib import reload
+import sys
 import time as time_pkg
+from importlib import reload
 
 sys.path.insert(0, '..'+os.sep+'src'+os.sep)
 from eureka.lib.readECF import MetaClass

--- a/tests/test_WFC3.py
+++ b/tests/test_WFC3.py
@@ -1,16 +1,17 @@
-import sys
 import os
-from importlib import reload
+import sys
 import time as time_pkg
+from importlib import reload
 
 import numpy as np
 
 sys.path.insert(0, '..'+os.sep+'src'+os.sep)
+import eureka.lib.plots
 from eureka.lib.readECF import MetaClass
 from eureka.lib.util import COMMON_IMPORTS, pathdirectory
-import eureka.lib.plots
 from eureka.S3_data_reduction import s3_reduce as s3
 from eureka.S4_generate_lightcurves import s4_genLC as s4
+
 try:
     import image_registration
     imported_image_registration = True

--- a/tests/test_allapers_inputdir.py
+++ b/tests/test_allapers_inputdir.py
@@ -4,10 +4,9 @@ import sys
 import pytest
 
 sys.path.insert(0, '..'+os.sep+'src'+os.sep)
-from eureka.S4_generate_lightcurves.s4_meta import S4MetaClass
 from eureka.lib import manageevent as me
 from eureka.lib.readECF import MetaClass
-
+from eureka.S4_generate_lightcurves.s4_meta import S4MetaClass
 
 EVENTLABEL = 'testevent'
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,15 +1,17 @@
-import numpy as np
-import sys
 import os
+import sys
 from types import SimpleNamespace
 
+import numpy as np
+
 sys.path.insert(0, '..'+os.sep+'src'+os.sep)
-from eureka.lib import util
-from eureka.lib.readECF import MetaClass
-from eureka.lib.medstddev import medstddev
-from eureka.optimizer import objective_funcs
-from astropy.io import fits
 import astraeus.xarrayIO as xrio
+from astropy.io import fits
+
+from eureka.lib import util
+from eureka.lib.medstddev import medstddev
+from eureka.lib.readECF import MetaClass
+from eureka.optimizer import objective_funcs
 
 
 def test_trim(capsys):

--- a/tests/test_lightcurve_fitting.py
+++ b/tests/test_lightcurve_fitting.py
@@ -1,17 +1,17 @@
 #! /usr/bin/env python
-import pytest
-import numpy as np
 import os
 import sys
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import numpy as np
+import pytest
+
 sys.path.insert(0, '..'+os.sep+'src'+os.sep)
-from eureka.S5_lightcurve_fitting import fitters, models, simulations
-from eureka.lib.readEPF import Parameters, Parameter
-from eureka.S5_lightcurve_fitting.s5_meta import S5MetaClass
 from eureka.lib import logedit
-from eureka.S5_lightcurve_fitting import s5_fit
+from eureka.lib.readEPF import Parameter, Parameters
+from eureka.S5_lightcurve_fitting import fitters, models, s5_fit, simulations
+from eureka.S5_lightcurve_fitting.s5_meta import S5MetaClass
 
 
 class testingMetaClass(S5MetaClass):


### PR DESCRIPTION
## Summary

This PR adds `isort` to the project tooling and applies the resulting import-ordering changes across the repository.

The large file count is expected: almost all changed files only have mechanical import sorting from `isort`. Reviewers can focus on the small set of manual changes listed below.

## Manual changes

- `.pre-commit-config.yaml`
  - Adds the `pycqa/isort` pre-commit hook so import ordering is checked locally and in pre-commit workflows.

- `pyproject.toml`
  - Adds the project `isort` configuration:
    - `line_length = 79`
    - `known_first_party = ["eureka"]`
    - `src_paths = ["src"]`
  - Adds `isort` to the `dev` dependency group.

- `src/eureka/S5_lightcurve_fitting/models/BatmanModels.py`
  - Changes the `Model` import from the package-level import to the explicit class import:
    - from `from . import Model`
    - to `from .Model import Model`
  - This avoids importing the module object when the code needs the `Model` class. This file also has normal `isort` cleanup around the imports.

## Generated changes

All other modified Python files are mechanical import-ordering changes produced by running `isort` with the new project configuration. These should not change runtime behavior.

## Verification

Ran:

```bash
python -m isort src tests demos docs/source/conf.py --check-only
git diff --check origin/main..HEAD
```

Both checks passed.
