### PR TITLE
Add focused unit test coverage

### DIFF
--- a/src/eureka/S3_data_reduction/bright2flux.py
+++ b/src/eureka/S3_data_reduction/bright2flux.py
@@ -113,9 +113,9 @@ def dn2electrons(data, meta, log):
         # Get the gain subarray
         gain = gain[meta.ywindow[0]:meta.ywindow[1],
                     meta.xwindow[0]:meta.xwindow[1]]
+        gain = xr.DataArray(gain, dims=("y", "x"))
 
     # Convert to electrons
-    gain = xr.DataArray(gain, dims=("y", "x"))
     data['flux'] *= gain
     data['err'] *= gain
     # v0 is a variance-like quantity, so square the conversion

--- a/src/eureka/S3_data_reduction/sigrej.py
+++ b/src/eureka/S3_data_reduction/sigrej.py
@@ -77,6 +77,8 @@ def sigrej(data, sigma, mask=None, estsig=None, ival=False, axis=0,
     # Default mask: only non-finite values are bad
     if mask is None:
         mask = ~np.isfinite(data)
+    else:
+        mask = np.copy(mask)
 
     # Apply the mask
     data = np.ma.masked_where(mask, data)

--- a/src/eureka/S3_data_reduction/straighten.py
+++ b/src/eureka/S3_data_reduction/straighten.py
@@ -112,7 +112,7 @@ def roll_columns(data, shifts):
         all_idcs = list(np.ogrid[[slice(0, n) for n in arr.shape]])
 
         # make the shifts positive
-        shifts_i = shifts[i]
+        shifts_i = np.copy(shifts[i])
         shifts_i[shifts_i < 0] += arr.shape[-1]
 
         # apply the shifts

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -206,80 +206,7 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                 # Too many figures requested, so reduce it
                 meta.nplots = meta.n_int
 
-            # Determine wavelength bins
-            if meta.wave_input is not None:
-                # bins defined by file input. 2 columns: low and high edges
-                meta.wave_low, meta.wave_hi = np.genfromtxt(meta.wave_input).T
-                meta.wave = (meta.wave_low + meta.wave_hi)/2
-                meta.nspecchan = len(meta.wave)
-                log.writelog(f'  Using input file to create {meta.nspecchan} '
-                             'channels.', mute=(not meta.verbose))
-            elif meta.nspecchan is None and meta.npixelbins is not None:
-                # User wants bins defined by the given number of pixels
-                mask = (wave_1d >= meta.wave_min)
-                if not np.any(mask):
-                    raise ValueError(f"No wavelengths ≥ {meta.wave_min}")
-                istart = np.nonzero(mask)[0][0]
-
-                mask = (wave_1d >= meta.wave_max)
-                if not np.any(mask):
-                    raise ValueError(f"No wavelengths ≥ {meta.wave_max}")
-                iend = np.nonzero(mask)[0][0]
-                # Shift bins by some number of pixels (only useful for MIRI)
-                istart += meta.npixelshift
-                iend += meta.npixelshift
-                edges = wave_1d[istart:iend+meta.npixelbins:meta.npixelbins]
-                dwav = np.ediff1d(
-                    wave_1d[istart:iend+meta.npixelbins])[::meta.npixelbins]/2
-                if len(edges) != len(dwav):
-                    edges = edges[:len(dwav)]
-                meta.wave_low = (edges-dwav)[:-1]
-                meta.wave_hi = (edges-dwav)[1:]
-                meta.wave = (meta.wave_low + meta.wave_hi)/2
-                meta.nspecchan = len(meta.wave)
-                log.writelog(f'  Creating {meta.nspecchan} channels of '
-                             f'width {meta.npixelbins} pixels each.',
-                             mute=(not meta.verbose))
-            elif meta.nspecchan is None:
-                # User wants unbinned spectra
-                dwav = np.ediff1d(wave_1d)/2
-                # Approximate the first neg_dwav as the same as the second
-                neg_dwav = np.append(dwav[0], dwav)
-                # Approximate the last pos_dwav as the same as the second last
-                pos_dwav = np.append(dwav, dwav[-1])
-                indices = np.logical_and(wave_1d >= meta.wave_min,
-                                         wave_1d <= meta.wave_max)
-                neg_dwav = neg_dwav[indices]
-                pos_dwav = pos_dwav[indices]
-                meta.wave = wave_1d[indices]
-                meta.wave_low = meta.wave-neg_dwav
-                meta.wave_hi = meta.wave+pos_dwav
-                meta.nspecchan = len(meta.wave)
-                log.writelog(f'  Creating {meta.nspecchan} channels at '
-                             f'native resolution.', mute=(not meta.verbose))
-            elif meta.wave_hi is None or meta.wave_low is None:
-                binsize = (meta.wave_max - meta.wave_min)/meta.nspecchan
-                meta.wave_low = np.round(np.linspace(meta.wave_min,
-                                                     meta.wave_max-binsize,
-                                                     meta.nspecchan), 3)
-                meta.wave_hi = np.round(np.linspace(meta.wave_min+binsize,
-                                                    meta.wave_max,
-                                                    meta.nspecchan), 3)
-                meta.wave = (meta.wave_low + meta.wave_hi)/2
-                log.writelog('  Using defined wave_hi and wave_low arrays.',
-                             mute=(not meta.verbose))
-            else:
-                # wave_low and wave_hi were passed in - make them arrays
-                meta.wave_low = np.array(meta.wave_low)
-                meta.wave_hi = np.array(meta.wave_hi)
-                meta.wave = (meta.wave_low + meta.wave_hi)/2
-                if (meta.nspecchan is not None
-                        and meta.nspecchan != len(meta.wave)):
-                    log.writelog(f'WARNING: Your nspecchan value of '
-                                 f'{meta.nspecchan} differs from the size of '
-                                 f'wave_hi ({len(meta.wave)}). Using the '
-                                 f'latter instead.')
-                    meta.nspecchan = len(meta.wave)
+            meta = compute_wavelength_bins(meta, wave_1d, log)
 
             # Define light curve DataArray
             if meta.photometry:
@@ -501,33 +428,17 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                     else:
                         log.writelog(
                             "    No indices found in this wavelength range.")
-                    # Make masked arrays for easy summing
-                    optspec_ma = np.ma.masked_where(
-                        spec.optmask.values[:, index],
-                        spec.optspec.values[:, index])
-                    opterr_ma = np.ma.masked_where(
-                        spec.optmask.values[:, index],
-                        spec.opterr.values[:, index])
-                    # Compute mean flux for each spectroscopic channel
-                    # Sumation leads to outliers when there are masked points
-                    lc['data'][i] = np.ma.mean(optspec_ma, axis=1)
-                    # Add uncertainties in quadrature
-                    # then divide by number of good points to get
-                    # proper uncertainties
-                    lc['err'][i] = (np.sqrt(np.ma.sum(opterr_ma**2, axis=1)) /
-                                    np.ma.MaskedArray.count(opterr_ma, axis=1))
+                    lc_data, lc_err = compute_spectral_lightcurve(
+                        spec.optspec.values, spec.opterr.values,
+                        spec.optmask.values, index)
+                    lc['data'][i] = lc_data
+                    lc['err'][i] = lc_err
                     if 'skylev' in list(spec.keys()):
-                        # if bg level/error was saved in S3, make bg lcs
-                        skylev_ma = np.ma.masked_where(
-                            spec.optmask.values[:, index],
-                            spec.skylev.values[:, index])
-                        skyerr_ma = np.ma.masked_where(
-                            spec.optmask.values[:, index],
-                            spec.skyerr.values[:, index])
-                        lc['skylev'][i] = np.ma.mean(skylev_ma, axis=1)
-                        lc['skyerr'][i] = (np.sqrt(np.ma.sum(
-                            skyerr_ma**2, axis=1)) /
-                            np.ma.MaskedArray.count(skyerr_ma, axis=1))
+                        lc_skylev, lc_skyerr = compute_spectral_lightcurve(
+                            spec.skylev.values, spec.skyerr.values,
+                            spec.optmask.values, index)
+                        lc['skylev'][i] = lc_skylev
+                        lc['skyerr'][i] = lc_skyerr
 
                 else:
                     lc['data'][i] = spec.aplev.values
@@ -593,23 +504,12 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
 
                 log.writelog(f"  White-light Bandpass = {meta.wave_min:.3f} - "
                              f"{meta.wave_max:.3f}")
-                # Make masked arrays for easy summing
-                optspec_ma = np.ma.masked_where(spec.optmask.values[:, index],
-                                                spec.optspec.values[:, index])
-                opterr_ma = np.ma.masked_where(spec.optmask.values[:, index],
-                                               spec.opterr.values[:, index])
-                # Compute mean flux for each spectroscopic channel
-                # Sumation leads to outliers when there are masked points
-                lc.flux_white[:] = np.ma.mean(optspec_ma, axis=1).data
-                # Add uncertainties in quadrature
-                # then divide by number of good points to get
-                # proper uncertainties
-                lc.err_white[:] = (np.sqrt(np.ma.sum(opterr_ma**2,
-                                                     axis=1)) /
-                                   np.ma.MaskedArray.count(opterr_ma,
-                                                           axis=1)).data
-                lc.mask_white[:] = np.ma.getmaskarray(np.ma.mean(optspec_ma,
-                                                                 axis=1))
+                lc_data, lc_err, lc_mask = compute_spectral_lightcurve(
+                    spec.optspec.values, spec.opterr.values,
+                    spec.optmask.values, index, return_mask=True)
+                lc.flux_white[:] = lc_data.data
+                lc.err_white[:] = lc_err.data
+                lc.mask_white[:] = lc_mask
 
                 if 'skylev' in list(spec.keys()):
                     # if bg level/error was saved in S3, make bg lcs
@@ -625,16 +525,11 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                     lc['skyerr_white'].attrs['time_units'] = time_units
                     lc['skyerr_white'].attrs['flux_units'] = flux_units
 
-                    skylev_ma = np.ma.masked_where(
-                        spec.optmask.values[:, index],
-                        spec.skylev.values[:, index])
-                    skyerr_ma = np.ma.masked_where(
-                        spec.optmask.values[:, index],
-                        spec.skyerr.values[:, index])
-                    lc['skylev_white'][:] = np.ma.mean(skylev_ma, axis=1).data
-                    lc['skyerr_white'][:] = (np.sqrt(np.ma.sum(
-                        skyerr_ma**2, axis=1)) /
-                        np.ma.MaskedArray.count(skyerr_ma, axis=1)).data
+                    lc_skylev, lc_skyerr = compute_spectral_lightcurve(
+                        spec.skylev.values, spec.skyerr.values,
+                        spec.optmask.values, index)
+                    lc['skylev_white'][:] = lc_skylev.data
+                    lc['skyerr_white'][:] = lc_skyerr.data
 
                 # Do 1D sigma clipping (along time axis) on binned spectra
                 if meta.clip_binned:
@@ -739,6 +634,98 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
             log.closelog()
 
     return spec, lc, meta
+
+
+def compute_wavelength_bins(meta, wave_1d, log):
+    """Populate Stage 4 wavelength bin edges using the genlc conventions."""
+    if meta.wave_input is not None:
+        # bins defined by file input. 2 columns: low and high edges
+        meta.wave_low, meta.wave_hi = np.genfromtxt(meta.wave_input).T
+        meta.wave = (meta.wave_low + meta.wave_hi)/2
+        meta.nspecchan = len(meta.wave)
+        log.writelog(f'  Using input file to create {meta.nspecchan} '
+                     'channels.', mute=(not meta.verbose))
+    elif meta.nspecchan is None and meta.npixelbins is not None:
+        # User wants bins defined by the given number of pixels
+        mask = (wave_1d >= meta.wave_min)
+        if not np.any(mask):
+            raise ValueError(f"No wavelengths ≥ {meta.wave_min}")
+        istart = np.nonzero(mask)[0][0]
+
+        mask = (wave_1d >= meta.wave_max)
+        if not np.any(mask):
+            raise ValueError(f"No wavelengths ≥ {meta.wave_max}")
+        iend = np.nonzero(mask)[0][0]
+        # Shift bins by some number of pixels (only useful for MIRI)
+        istart += meta.npixelshift
+        iend += meta.npixelshift
+        edges = wave_1d[istart:iend+meta.npixelbins:meta.npixelbins]
+        dwav = np.ediff1d(
+            wave_1d[istart:iend+meta.npixelbins])[::meta.npixelbins]/2
+        if len(edges) != len(dwav):
+            edges = edges[:len(dwav)]
+        meta.wave_low = (edges-dwav)[:-1]
+        meta.wave_hi = (edges-dwav)[1:]
+        meta.wave = (meta.wave_low + meta.wave_hi)/2
+        meta.nspecchan = len(meta.wave)
+        log.writelog(f'  Creating {meta.nspecchan} channels of '
+                     f'width {meta.npixelbins} pixels each.',
+                     mute=(not meta.verbose))
+    elif meta.nspecchan is None:
+        # User wants unbinned spectra
+        dwav = np.ediff1d(wave_1d)/2
+        # Approximate the first neg_dwav as the same as the second
+        neg_dwav = np.append(dwav[0], dwav)
+        # Approximate the last pos_dwav as the same as the second last
+        pos_dwav = np.append(dwav, dwav[-1])
+        indices = np.logical_and(wave_1d >= meta.wave_min,
+                                 wave_1d <= meta.wave_max)
+        neg_dwav = neg_dwav[indices]
+        pos_dwav = pos_dwav[indices]
+        meta.wave = wave_1d[indices]
+        meta.wave_low = meta.wave-neg_dwav
+        meta.wave_hi = meta.wave+pos_dwav
+        meta.nspecchan = len(meta.wave)
+        log.writelog(f'  Creating {meta.nspecchan} channels at '
+                     f'native resolution.', mute=(not meta.verbose))
+    elif meta.wave_hi is None or meta.wave_low is None:
+        binsize = (meta.wave_max - meta.wave_min)/meta.nspecchan
+        meta.wave_low = np.round(np.linspace(meta.wave_min,
+                                             meta.wave_max-binsize,
+                                             meta.nspecchan), 3)
+        meta.wave_hi = np.round(np.linspace(meta.wave_min+binsize,
+                                            meta.wave_max,
+                                            meta.nspecchan), 3)
+        meta.wave = (meta.wave_low + meta.wave_hi)/2
+        log.writelog('  Using defined wave_hi and wave_low arrays.',
+                     mute=(not meta.verbose))
+    else:
+        # wave_low and wave_hi were passed in - make them arrays
+        meta.wave_low = np.array(meta.wave_low)
+        meta.wave_hi = np.array(meta.wave_hi)
+        meta.wave = (meta.wave_low + meta.wave_hi)/2
+        if (meta.nspecchan is not None
+                and meta.nspecchan != len(meta.wave)):
+            log.writelog(f'WARNING: Your nspecchan value of '
+                         f'{meta.nspecchan} differs from the size of '
+                         f'wave_hi ({len(meta.wave)}). Using the '
+                         f'latter instead.')
+            meta.nspecchan = len(meta.wave)
+
+    return meta
+
+
+def compute_spectral_lightcurve(optspec, opterr, optmask, index,
+                                return_mask=False):
+    """Average spectral columns and propagate errors for one S4 bandpass."""
+    optspec_ma = np.ma.masked_where(optmask[:, index], optspec[:, index])
+    opterr_ma = np.ma.masked_where(optmask[:, index], opterr[:, index])
+    lc_data = np.ma.mean(optspec_ma, axis=1)
+    lc_err = (np.sqrt(np.ma.sum(opterr_ma**2, axis=1)) /
+              np.ma.MaskedArray.count(opterr_ma, axis=1))
+    if return_mask:
+        return lc_data, lc_err, np.ma.getmaskarray(lc_data)
+    return lc_data, lc_err
 
 
 def load_specific_s3_meta_info(meta):

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -638,13 +638,14 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
 
 def compute_wavelength_bins(meta, wave_1d, log):
     """Populate Stage 4 wavelength bin edges using the genlc conventions."""
+    mute = not getattr(meta, 'verbose', True)
     if meta.wave_input is not None:
         # bins defined by file input. 2 columns: low and high edges
         meta.wave_low, meta.wave_hi = np.genfromtxt(meta.wave_input).T
         meta.wave = (meta.wave_low + meta.wave_hi)/2
         meta.nspecchan = len(meta.wave)
         log.writelog(f'  Using input file to create {meta.nspecchan} '
-                     'channels.', mute=(not meta.verbose))
+                     'channels.', mute=mute)
     elif meta.nspecchan is None and meta.npixelbins is not None:
         # User wants bins defined by the given number of pixels
         mask = (wave_1d >= meta.wave_min)
@@ -669,8 +670,7 @@ def compute_wavelength_bins(meta, wave_1d, log):
         meta.wave = (meta.wave_low + meta.wave_hi)/2
         meta.nspecchan = len(meta.wave)
         log.writelog(f'  Creating {meta.nspecchan} channels of '
-                     f'width {meta.npixelbins} pixels each.',
-                     mute=(not meta.verbose))
+                     f'width {meta.npixelbins} pixels each.', mute=mute)
     elif meta.nspecchan is None:
         # User wants unbinned spectra
         dwav = np.ediff1d(wave_1d)/2
@@ -687,7 +687,7 @@ def compute_wavelength_bins(meta, wave_1d, log):
         meta.wave_hi = meta.wave+pos_dwav
         meta.nspecchan = len(meta.wave)
         log.writelog(f'  Creating {meta.nspecchan} channels at '
-                     f'native resolution.', mute=(not meta.verbose))
+                     f'native resolution.', mute=mute)
     elif meta.wave_hi is None or meta.wave_low is None:
         binsize = (meta.wave_max - meta.wave_min)/meta.nspecchan
         meta.wave_low = np.round(np.linspace(meta.wave_min,
@@ -698,7 +698,7 @@ def compute_wavelength_bins(meta, wave_1d, log):
                                             meta.nspecchan), 3)
         meta.wave = (meta.wave_low + meta.wave_hi)/2
         log.writelog('  Using defined wave_hi and wave_low arrays.',
-                     mute=(not meta.verbose))
+                     mute=mute)
     else:
         # wave_low and wave_hi were passed in - make them arrays
         meta.wave_low = np.array(meta.wave_low)

--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -775,15 +775,15 @@ def initialize_emcee_walkers(meta, log, ndim, lsq_sol, freepars, prior1,
     if len(ind_max) > 0 or len(ind_max_LU) > 0:
         log.writelog('Warning: >=1 params hit the upper bound in the lsq fit. '
                      'Setting to the middle of the interval.')
-        freepars[u][ind_max] = pmid[u][ind_max]
-        freepars[lu][ind_max_LU] = (np.exp(prior2[lu][ind_max_LU]) +
-                                    np.exp(prior1[lu][ind_max_LU]))/2.
+        freepars[u[ind_max]] = pmid[u[ind_max]]
+        freepars[lu[ind_max_LU]] = (np.exp(prior2[lu[ind_max_LU]]) +
+                                    np.exp(prior1[lu[ind_max_LU]]))/2.
     if len(ind_min) > 0 or len(ind_min_LU) > 0:
         log.writelog('Warning: >=1 params hit the lower bound in the lsq fit. '
                      'Setting to the middle of the interval.')
-        freepars[u][ind_min] = pmid[u][ind_min]
-        freepars[lu][ind_min_LU] = (np.exp(prior2[lu][ind_min_LU]) +
-                                    np.exp(prior1[lu][ind_min_LU]))/2.
+        freepars[u[ind_min]] = pmid[u[ind_min]]
+        freepars[lu[ind_min_LU]] = (np.exp(prior2[lu[ind_min_LU]]) +
+                                    np.exp(prior1[lu[ind_min_LU]]))/2.
 
     # Generate the walker positions
     pos = np.array([freepars + step_size*np.random.randn(ndim)

--- a/src/eureka/S5_lightcurve_fitting/models/HarmonicaModel.py
+++ b/src/eureka/S5_lightcurve_fitting/models/HarmonicaModel.py
@@ -89,7 +89,7 @@ class HarmonicaTransitModel(BatmanTransitModel):
                              a=pl_params.a,
                              inc=pl_params.inc * np.pi / 180.,
                              ecc=pl_params.ecc,
-                             omega=pl_params.w)
+                             omega=pl_params.w * np.pi / 180.)
                 ht.set_stellar_limb_darkening(
                     pl_params.u, limb_dark_law=pl_params.limb_dark)
                 ht.set_planet_transmission_string(pl_params.ab)

--- a/src/eureka/S5_lightcurve_fitting/models/PoetModels.py
+++ b/src/eureka/S5_lightcurve_fitting/models/PoetModels.py
@@ -2,7 +2,7 @@ import numpy as np
 import batman as bm
 
 from .Model import Model
-from .AstroModel import PlanetParams, get_ecl_midpt
+from .AstroModel import PlanetParams, get_ecl_midpt, true_anomaly
 from .BatmanModels import BatmanTransitModel, BatmanEclipseModel
 from ...lib.split_channels import split
 
@@ -179,16 +179,26 @@ class TransitModel():
         else:
             tref = params.t_secondary
 
-        # Compute distance, z, of planet and star midpoints
-        self.z = self.ars \
-            * np.sqrt(np.sin(2*np.pi*(t-tref)/self.per)**2
-                      + (np.cos(self.inc*np.pi/180)
-                         * np.cos(2*np.pi*(t-tref)/self.per))**2)
+        if params.ecc == 0:
+            # Compute distance, z, of planet and star midpoints
+            self.z = self.ars \
+                * np.sqrt(np.sin(2*np.pi*(t-tref)/self.per)**2
+                          + (np.cos(self.inc*np.pi/180)
+                             * np.cos(2*np.pi*(t-tref)/self.per))**2)
 
-        # Ignore close approach on other side of the orbit
-        phase = (t - tref) % self.per
-        mask = (phase > self.per / 4) & (phase < self.per * 3 / 4)
-        self.z[mask] = self.ars
+            # Ignore close approach on other side of the orbit
+            phase = (t - tref) % self.per
+            mask = (phase > self.per / 4) & (phase < self.per * 3 / 4)
+            self.z[mask] = self.ars
+        else:
+            true_anom = true_anomaly(params, t)
+            radius = (self.ars*(1-params.ecc**2) /
+                      (1+params.ecc*np.cos(true_anom)))
+            omega = params.w*np.pi/180
+            inc = self.inc*np.pi/180
+            self.z = radius*np.sqrt(
+                1-(np.sin(inc)*np.sin(true_anom+omega))**2
+            )
 
     def light_curve(self, params):
         """

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -1114,10 +1114,18 @@ def make_longparamlist(meta, params, chanrng):
     order = {par: i for i, par in enumerate(params.dict.keys())}
 
     # Strip both _ch# and _wl# to get base names
+    def _base_order(base):
+        matches = [
+            idx for key, idx in order.items()
+            if key == base or key.startswith(f"{base}_ch")
+            or key.startswith(f"{base}_wl")
+        ]
+        return min(matches)
+
     paramtitles = sorted(
         np.unique([k.split("_ch")[0].split("_wl")[0]
                    for k in params.dict.keys()]),
-        key=order.get,
+        key=_base_order,
     )
 
     # Track whether the user defined any wavelength-specific variants

--- a/src/eureka/lib/gaussian.py
+++ b/src/eureka/lib/gaussian.py
@@ -122,7 +122,7 @@ def gaussian(x, width=1.0, center=0.0, height=None, bgpars=[0.0, 0.0, 0.0]):
 
     # Define height if needed:
     if height is None:
-        height = np.product(1. / (width * r2pi))
+        height = np.prod(1. / (width * r2pi))
     ponent = 0.0
 
     for i in np.arange(ndim):
@@ -569,7 +569,7 @@ def gaussians(x, param):
         if not isinstance(width, np.ndarray):
             width += np.zeros(ndim)
         if height is None:
-            height = np.product(1.0 / (width * np.sqrt(2.0 * np.pi)))
+            height = np.prod(1.0 / (width * np.sqrt(2.0 * np.pi)))
         ponent = 0.0
         for i in np.arange(ndim):
             ponent += ((x[i] - center[i]) / width[i])**2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,11 @@
-# conftest.py
+from pathlib import Path
+
+
+def is_unit_test(item):
+    """Return True for tests stored under tests/unit."""
+    return 'unit' in Path(str(item.fspath)).parts
+
+
 def pytest_collection_modifyitems(session, config, items):
     """Modifies test items to ensure test functions run in a given order
 
@@ -22,10 +29,14 @@ def pytest_collection_modifyitems(session, config, items):
                       "test_MIRI", "test_NIRCam", "test_NIRSpec",
                       "test_NIRCamPhotometry", "test_NIRCamPhotometry_hex",
                       "test_WFC3"]
-    item_names = [item.name for item in items]
-    function_mapping = {item.name: item for item in items
+    unit_items = [item for item in items if is_unit_test(item)]
+    unit_items.sort(key=lambda item: (str(item.fspath), item.name))
+    non_unit_items = [item for item in items if not is_unit_test(item)]
+
+    item_names = [item.name for item in non_unit_items]
+    function_mapping = {item.name: item for item in non_unit_items
                         if item.name in function_order}
-    extra_functions = [item for item in items
+    extra_functions = [item for item in non_unit_items
                        if item.name not in function_order]
 
     sorted_items = []
@@ -34,4 +45,4 @@ def pytest_collection_modifyitems(session, config, items):
             sorted_items.append(function_mapping[func_])
     sorted_items.extend(extra_functions)
 
-    items[:] = sorted_items
+    items[:] = unit_items + sorted_items

--- a/tests/unit/s5_model_helpers.py
+++ b/tests/unit/s5_model_helpers.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from eureka.S5_lightcurve_fitting import models
+from eureka.lib.readEPF import Parameters
+
+
+def _params(**values):
+    params = Parameters()
+    for name, value in values.items():
+        setattr(params, name, (value, 'free'))
+    return params
+
+
+def _transit_params(ecc=0.0, w=90.0):
+    params = _params(limb_dark='quadratic', u1=0.1, u2=0.2, rp=0.08,
+                     per=3.0, t0=0.0, inc=88.5, a=12.0, ecc=ecc, w=w,
+                     spotcon=1.0, spotnpts=3000)
+    params.limb_dark.ptype = 'fixed'
+    return params
+
+
+def _transit_model(model_class, params, time):
+    model = model_class(
+        parameters=params, paramtitles=list(params.dict.keys()),
+        num_planets=1, ld_from_S4=False, ld_from_file=False
+    )
+    model.time = time
+    return model.eval()
+
+
+class _ConstantModel(models.Model):
+    def __init__(self, values, modeltype='systematic', name='constant',
+                 **kwargs):
+        super().__init__(name=name, modeltype=modeltype, **kwargs)
+        self.values = np.ma.array(values)
+
+    def eval(self, channel=None, **kwargs):
+        return self.values
+
+
+class _FakeGPModel(models.Model):
+    def __init__(self, values, **kwargs):
+        super().__init__(name='fake GP', modeltype='GP', **kwargs)
+        self.values = np.ma.array(values)
+        self.seen_fit = None
+
+    def eval(self, fit, channel=None, **kwargs):
+        self.seen_fit = np.ma.copy(fit)
+        return self.values

--- a/tests/unit/test_lib_units.py
+++ b/tests/unit/test_lib_units.py
@@ -302,10 +302,14 @@ def test_metaclass_reads_ecf_values_and_normalizes_paths(tmp_path):
 
     assert meta.answer == 42
     assert meta.values == [1, 2, 3]
-    assert meta.inputdir.endswith(os.path.join('root', 'input') + os.sep)
-    assert meta.outputdir.endswith(os.path.join('root', 'output') + os.sep)
-    assert meta.inputdir_raw == 'input'
-    assert meta.outputdir_raw == 'output'
+    assert os.path.normpath(meta.inputdir).endswith(
+        os.path.join('root', 'input')
+    )
+    assert os.path.normpath(meta.outputdir).endswith(
+        os.path.join('root', 'output')
+    )
+    assert os.path.normpath(meta.inputdir_raw) == 'input'
+    assert os.path.normpath(meta.outputdir_raw) == 'output'
 
 
 def test_metaclass_missing_file_requires_kwargs(tmp_path):

--- a/tests/unit/test_lib_units.py
+++ b/tests/unit/test_lib_units.py
@@ -1,0 +1,314 @@
+import os
+import sys
+import warnings
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from astropy.utils.exceptions import AstropyUserWarning
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', 'src')))
+from eureka.S5_lightcurve_fitting import models
+from eureka.lib import (
+    clipping, gaussian, imageedit, interp2d, meanerr, naninterp1d, readECF,
+    smooth, sort_nicely, util,
+)
+from eureka.lib.readEPF import Parameters
+from eureka.lib.split_channels import get_trim, split
+
+
+class _Log:
+    def __init__(self):
+        self.messages = []
+
+    def writelog(self, message, **kwargs):
+        self.messages.append(message)
+
+
+def test_gaussian_1d_matches_analytic_pdf_and_background():
+    """Pin the 1D Gaussian normalization and polynomial background terms."""
+    x = np.array([-1.0, 0.0, 1.0])
+    width = 2.0
+    center = 0.5
+    bgpars = [0.25, 0.0, 1.5]
+
+    result = gaussian.gaussian(x, width=width, center=center, bgpars=bgpars)
+    expected = (
+        np.exp(-0.5*((x-center)/width)**2)/(width*np.sqrt(2*np.pi))
+        + bgpars[0]*x + bgpars[2]
+    )
+
+    np.testing.assert_allclose(result, expected)
+
+
+def test_gaussian_2d_uses_independent_widths_centers_and_plane_background():
+    """Check 2D Gaussian axes and planar background dimensions."""
+    yx = np.indices((3, 4), dtype=float)
+    width = np.array([1.5, 2.0])
+    center = np.array([1.0, 2.0])
+    height = 3.0
+    bgpars = [0.1, -0.2, 5.0]
+
+    result = gaussian.gaussian(
+        yx, width=width, center=center, height=height, bgpars=bgpars
+    )
+    exponent = ((yx[0]-center[0])/width[0])**2
+    exponent += ((yx[1]-center[1])/width[1])**2
+    expected = height*np.exp(-0.5*exponent)
+    expected += yx[0]*bgpars[0] + yx[1]*bgpars[1] + bgpars[2]
+
+    np.testing.assert_allclose(result, expected)
+
+
+def test_meanerr_returns_weighted_mean_uncertainty_and_status_bits():
+    """Weighted means should ignore bad data and report status bits."""
+    data = np.array([10.0, 12.0, np.nan, 30.0])
+    derr = np.array([1.0, 2.0, 1.0, 0.0])
+    mask = np.array([False, False, False, True])
+
+    mean, err, status = meanerr.meanerr(
+        data, derr, mask=mask, err=True, status=True
+    )
+
+    weights = np.array([1/1.0**2, 1/2.0**2])
+    expected_mean = np.average(data[:2], weights=weights)
+    expected_err = np.sqrt(1/np.sum(weights))
+    np.testing.assert_allclose((mean, err), (expected_mean, expected_err))
+    assert status == 7
+
+
+def test_naninterp1d_interpolates_edges_and_all_nan_fallback():
+    """NaN interpolation should fill edges and all-NaN arrays."""
+    data = np.array([np.nan, 2.0, np.nan, 6.0, np.nan])
+
+    result = naninterp1d.naninterp1d(data.copy())
+
+    np.testing.assert_allclose(result, [2.0, 2.0, 4.0, 6.0, 6.0])
+    np.testing.assert_allclose(
+        naninterp1d.naninterp1d(np.array([np.nan, np.nan]), replace_val=-1),
+        [-1, -1],
+    )
+
+
+def test_sort_nicely_orders_embedded_integers_in_place():
+    """Natural sorting should order filenames by embedded integer values."""
+    filenames = ['spec10.fits', 'spec2.fits', 'spec1.fits', 'spec11.fits']
+
+    returned = sort_nicely.sort_nicely(filenames)
+
+    assert returned is filenames
+    assert filenames == ['spec1.fits', 'spec2.fits', 'spec10.fits',
+                         'spec11.fits']
+
+
+def test_split_channels_returns_channel_slices():
+    """Channel splitting should follow cumulative integration counts."""
+    first = np.arange(10)
+    second = first + 100
+
+    assert get_trim([3, 4, 3], 1) == (3, 7)
+    split_first, split_second = split([first, second], [3, 4, 3], 1)
+
+    np.testing.assert_array_equal(split_first, [3, 4, 5, 6])
+    np.testing.assert_array_equal(split_second, [103, 104, 105, 106])
+
+
+def test_binData_masks_bad_values_and_scales_mean_error():
+    """Binning should ignore bad values and scale mean errors consistently."""
+    data = np.array([1.0, 2.0, np.nan, 4.0, 10.0, 14.0])
+
+    result = util.binData(data, nbin=2, err=True)
+
+    expected = np.ma.array([np.mean([1.0, 2.0])/np.sqrt(3),
+                            np.mean([4.0, 10.0, 14.0])/np.sqrt(3)])
+    np.testing.assert_allclose(result, expected)
+
+
+def test_normalize_spectrum_preserves_masks_and_scales_errors():
+    """Spectrum normalization should preserve masks while scaling errors."""
+    meta = SimpleNamespace(inst='nircam')
+    optspec = np.array([[2.0, 4.0], [4.0, 8.0], [6.0, np.nan]])
+    opterr = np.full_like(optspec, 0.2)
+    optmask = np.zeros_like(optspec, dtype=bool)
+    optmask[1, 0] = True
+
+    normspec, normerr = util.normalize_spectrum(
+        meta, optspec, opterr=opterr, optmask=optmask
+    )
+
+    expected_norm = np.ma.array(
+        [[0.5, 2/3], [1.0, 4/3], [1.5, np.nan]],
+        mask=[[False, False], [True, False], [False, True]],
+    )
+    expected_err = np.ma.array(
+        [[0.05, 1/30], [0.05, 1/30], [0.05, 1/30]],
+        mask=expected_norm.mask,
+    )
+    np.testing.assert_allclose(normspec, expected_norm)
+    np.testing.assert_allclose(normerr, expected_err)
+    np.testing.assert_array_equal(np.ma.getmaskarray(normspec),
+                                  expected_norm.mask)
+
+
+def test_get_mad_1d_uses_median_absolute_first_difference_in_ppm():
+    """MAD estimates use first differences and return ppm-scale values."""
+    data = np.ma.array([1.0, 1.1, 1.4, 1.45, 1.95])
+
+    assert util.get_mad_1d(data, ind_min=1, ind_max=5) == pytest.approx(300000)
+
+
+def test_smooth_flat_window_matches_manual_convolution_result_length():
+    """Flat smoothing should match the explicit padded convolution."""
+    x = np.arange(1.0, 10.0)
+    window_len = 5
+    padded = np.r_[
+        2*np.ma.median(x[0:window_len//5])-x[window_len:1:-1],
+        x,
+        2*np.ma.median(x[-window_len//5:])-x[-1:-window_len:-1],
+    ]
+    expected = np.ma.convolve(
+        np.ones(window_len)/window_len, padded, mode='same'
+    )[window_len-1:-window_len+1]
+
+    result = smooth.smooth(x, window_len=window_len, window='flat')
+
+    np.testing.assert_allclose(result, expected)
+    assert result.shape == x.shape
+
+
+def test_polynomial_model_evaluates_centered_time_coefficients():
+    """The polynomial systematic is evaluated around each channel midpoint."""
+    params = Parameters()
+    params.c0 = 1.0, 'free'
+    params.c1 = 2.0, 'free'
+    params.c2 = -0.5, 'free'
+    model = models.PolynomialModel(parameters=params, nchannel=1)
+    model.time = np.array([0.0, 1.0, 2.0])
+
+    result = model.eval()
+
+    local_time = np.array([-1.0, 0.0, 1.0])
+    expected = 1.0 + 2.0*local_time - 0.5*local_time**2
+    np.testing.assert_allclose(result, expected)
+
+
+def test_polynomial_model_keeps_time_mask_in_output():
+    """Masked time samples should remain masked in polynomial evaluations."""
+    params = Parameters()
+    params.c0 = 1.0, 'free'
+    params.c1 = 2.0, 'free'
+    model = models.PolynomialModel(parameters=params, nchannel=1)
+    model.time = np.ma.array([0.0, np.nan, 2.0], mask=[False, True, False])
+
+    result = model.eval()
+
+    np.testing.assert_array_equal(np.ma.getmaskarray(result),
+                                  [False, True, False])
+
+
+def test_clip_outliers_masks_or_replaces_known_time_series_outlier():
+    """Outlier clipping should flag spikes and replacement modes."""
+    data = np.ones(21)
+    data[10] = 10.0
+    log = _Log()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', AstropyUserWarning)
+        clipped, outliers, noutliers = clipping.clip_outliers(
+            data, log, wavelength=2.0, sigma=2, box_width=3, maxiters=3,
+            fill_value='mask'
+        )
+
+    assert noutliers == 3
+    expected_outliers = np.zeros(21, dtype=bool)
+    expected_outliers[9:12] = True
+    np.testing.assert_array_equal(outliers, expected_outliers)
+    np.testing.assert_array_equal(np.ma.getmaskarray(clipped), outliers)
+    assert 'Identified 3 outliers' in log.messages[0]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', AstropyUserWarning)
+        filled, outliers, noutliers = clipping.clip_outliers(
+            data, _Log(), wavelength=2.0, sigma=2, box_width=3, maxiters=3,
+            fill_value=-99
+        )
+    assert noutliers == 3
+    assert not np.ma.is_masked(filled[3])
+    assert filled[10] == -99
+
+
+def test_trimimage_pads_out_of_bounds_pixels_and_carries_mask_uncertainty():
+    """Image trimming should preserve in-bounds pixels and mask padding."""
+    data = np.arange(25).reshape(5, 5)
+    mask = np.zeros_like(data, dtype=bool)
+    mask[0, 0] = True
+    uncd = np.ones_like(data, dtype=float)
+    uncd[0:2, 0:3] = 5
+
+    subim, submask, subunc = imageedit.trimimage(
+        data, c=(0, 1), r=(1, 2), mask=mask, uncd=uncd
+    )
+
+    expected = np.array([[0, 0, 0, 0, 0],
+                         [0, 0, 1, 2, 3],
+                         [0, 5, 6, 7, 8]], dtype=float)
+    np.testing.assert_allclose(subim, expected)
+    np.testing.assert_array_equal(submask[0], np.ones(5, dtype=bool))
+    assert submask[1, 1]
+    assert np.all(subunc[0] == 5)
+
+
+def test_pasteimage_handles_partial_overlap_at_image_edge():
+    """Pasting should only write the overlapping part of a subimage."""
+    data = np.zeros((5, 5), dtype=int)
+    subim = np.arange(9).reshape(3, 3)
+
+    result = imageedit.pasteimage(data, subim, dy_=(1, 4), syx=(1, 1))
+
+    expected = np.zeros((5, 5), dtype=int)
+    expected[0:3, 3:5] = subim[:, 0:2]
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_interp2d_oversamples_plane_and_preserves_original_pixel_values():
+    """2D interpolation should preserve a plane at original pixel locations."""
+    image = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    result = interp2d.interp2d(image, expand=3)
+
+    assert result.shape == (4, 4)
+    np.testing.assert_allclose(result[0, 0], 1.0)
+    np.testing.assert_allclose(result[0, -1], 2.0)
+    np.testing.assert_allclose(result[-1, 0], 3.0)
+    np.testing.assert_allclose(result[-1, -1], 4.0)
+    np.testing.assert_allclose(result[1, 1], 2.0)
+
+
+def test_metaclass_reads_ecf_values_and_normalizes_paths(tmp_path):
+    """ECF parsing should evaluate values and join paths to topdir."""
+    ecf = tmp_path/'S3_demo.ecf'
+    ecf.write_text(
+        'topdir "./root"\n'
+        'inputdir "input"\n'
+        'outputdir "output"\n'
+        'eventlabel "demo"\n'
+        'answer 42\n'
+        'values [1, 2, 3]\n'
+    )
+
+    meta = readECF.MetaClass(folder=str(tmp_path), file='S3_demo.ecf',
+                             stage=3)
+
+    assert meta.answer == 42
+    assert meta.values == [1, 2, 3]
+    assert meta.inputdir.endswith(os.path.join('root', 'input') + os.sep)
+    assert meta.outputdir.endswith(os.path.join('root', 'output') + os.sep)
+    assert meta.inputdir_raw == 'input'
+    assert meta.outputdir_raw == 'output'
+
+
+def test_metaclass_missing_file_requires_kwargs(tmp_path):
+    """MetaClass should fail clearly when an ECF file is missing."""
+    with pytest.raises(ValueError, match='does not exist'):
+        readECF.MetaClass(folder=str(tmp_path), file='missing.ecf')

--- a/tests/unit/test_s3_units.py
+++ b/tests/unit/test_s3_units.py
@@ -1,0 +1,458 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import xarray as xr
+from scipy.constants import arcsec
+
+os.environ.setdefault('MPLCONFIGDIR', '/tmp')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', 'src')))
+from eureka.S3_data_reduction import (
+    background, bright2flux, optspex, sigrej, source_pos, straighten,
+)
+from eureka.lib import util
+
+
+class _Log:
+    def __init__(self):
+        self.messages = []
+
+    def writelog(self, message, **kwargs):
+        self.messages.append(message)
+
+
+class _Values:
+    def __init__(self, values):
+        self.values = np.asarray(values)
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+
+def _trace_image(center=7.3, sigma=1.2, ny=15, nx=6, background=0.1):
+    y = np.arange(ny, dtype=float)
+    profile = background + np.exp(-0.5*((y-center)/sigma)**2)
+    return np.repeat(profile[:, None], nx, axis=1)
+
+
+def test_source_pos_weighted_recovers_synthetic_trace_centroid_and_width():
+    """Validate flux-weighted source centroids on a known Gaussian trace."""
+    flux = np.ma.array(_trace_image(center=7.25, sigma=1.1, background=0.0))
+    meta = SimpleNamespace(src_pos_type='weighted', spec_hw=4, isplots_S3=0)
+
+    rounded, exact, width, integ = source_pos.source_pos(
+        flux, meta, shdr={}, m=0, n=3, plot=False
+    )
+
+    assert rounded == 7
+    assert exact == pytest.approx(7.25, abs=0.08)
+    assert width == pytest.approx(1.1, abs=0.12)
+    assert integ == 3
+
+
+def test_source_pos_gaussian_recovers_synthetic_trace_centroid_and_width():
+    """Validate Gaussian-fit source centroids on a known synthetic trace."""
+    flux = np.ma.array(_trace_image(center=6.65, sigma=1.35))
+    meta = SimpleNamespace(src_pos_type='gaussian', spec_hw=5, isplots_S3=0)
+
+    rounded, exact, width, integ = source_pos.source_pos(
+        flux, meta, shdr={}, m=0, n=2, plot=False
+    )
+
+    assert rounded == 7
+    assert exact == pytest.approx(6.65, abs=0.03)
+    assert width == pytest.approx(1.35, abs=0.03)
+    assert integ == 2
+
+
+def test_source_pos_header_subtracts_detector_window_offset():
+    """Guard the FITS-header source position convention after window trims."""
+    meta = SimpleNamespace(src_pos_type='header', ywindow=[100, 120])
+
+    rounded, exact, width, integ = source_pos.source_pos(
+        np.ones((3, 3)), meta, shdr={'SRCYPOS': 112.4}, m=0, n=5,
+        plot=False
+    )
+
+    assert rounded == 12
+    assert exact == pytest.approx(12.4)
+    assert width == pytest.approx(0.0)
+    assert integ == 5
+
+
+def test_source_pos_header_requires_srcypos_keyword():
+    """Ensure header-based source positions fail clearly without SRCYPOS."""
+    meta = SimpleNamespace(src_pos_type='header', ywindow=[0, 10])
+
+    with pytest.raises(AttributeError, match='SRCYPOS'):
+        source_pos.source_pos(np.ones((3, 3)), meta, shdr={}, m=0, n=0,
+                              plot=False)
+
+
+def test_source_pos_wrapper_records_centroids_for_all_integrations():
+    """Check wrapper bookkeeping for per-integration centroids."""
+    flux = np.stack([
+        _trace_image(center=6.2, sigma=1.0, background=0.0, nx=4),
+        _trace_image(center=8.1, sigma=1.0, background=0.0, nx=4),
+    ])
+    data = xr.Dataset(
+        {
+            'flux': (('time', 'y', 'x'), flux),
+            'mask': (('time', 'y', 'x'), np.zeros_like(flux, dtype=bool)),
+        },
+        coords={'time': [0.0, 1.0], 'y': np.arange(15), 'x': np.arange(4)},
+        attrs={'shdr': {}},
+    )
+    meta = SimpleNamespace(src_pos_type='weighted', spec_hw=4, isplots_S3=0,
+                           ncpu=1, int_start=0, n_int=2, verbose=False)
+
+    data, _, _ = source_pos.source_pos_wrapper(
+        data, meta, _Log(), m=0, integ=None
+    )
+
+    np.testing.assert_allclose(data.centroid_y.values, [6.2, 8.1], atol=0.02)
+    np.testing.assert_allclose(data.centroid_sy.values, [1.0, 1.0],
+                               atol=0.02)
+    assert data.centroid_y.attrs['units'] == 'pixels'
+    assert data.centroid_sy.attrs['units'] == 'pixels'
+
+
+def test_sigrej_flags_outlier_and_returns_final_statistics_without_mutating():
+    """Protect sigma rejection outputs and the promise not to mutate masks."""
+    data = np.array([
+        [[1.0], [5.0]],
+        [[1.0], [5.0]],
+        [[1.0], [5.0]],
+        [[1.0], [5.0]],
+        [[10.0], [5.0]],
+    ])
+    input_mask = np.zeros_like(data, dtype=bool)
+
+    mask, ival, fmean, fstddev, fmedian, fmedstddev = sigrej.sigrej(
+        data, sigma=[3], mask=input_mask, estsig=[1.0], axis=0,
+        ival=True, fmean=True, fstddev=True, fmedian=True, fmedstddev=True
+    )
+
+    expected_mask = np.zeros_like(data, dtype=bool)
+    expected_mask[-1, 0, 0] = True
+    np.testing.assert_array_equal(mask, expected_mask)
+    np.testing.assert_array_equal(input_mask, np.zeros_like(input_mask))
+    np.testing.assert_allclose(ival[0, 0, :, 0], [1.0, 5.0])
+    np.testing.assert_allclose(fmean[:, 0], [1.0, 5.0])
+    np.testing.assert_allclose(fstddev[:, 0], [0.0, 0.0])
+    np.testing.assert_allclose(fmedian[:, 0], [1.0, 5.0])
+    np.testing.assert_allclose(fmedstddev[:, 0], [0.0, 0.0])
+
+
+def test_sigrej_default_mask_flags_nonfinite_values():
+    """Ensure non-finite data are masked without an input mask."""
+    data = np.array([[1.0, 2.0], [np.nan, 2.1], [1.1, np.inf]])
+
+    mask = sigrej.sigrej(data, sigma=[5], axis=0)
+
+    np.testing.assert_array_equal(mask, [[False, False],
+                                         [True, False],
+                                         [False, True]])
+
+
+def test_fitbg_recovers_linear_background_while_ignoring_source_region():
+    """Verify column background fits exclude the source aperture region."""
+    y, x = np.indices((4, 9), dtype=float)
+    expected = 10 + 2*y + 0.5*x
+    data = expected.copy()
+    data[:, 3:6] += 100
+    mask = np.zeros_like(data, dtype=bool)
+    meta = SimpleNamespace(bg_method='std', outputdir='')
+
+    bg, outmask = background.fitbg(
+        data, meta, mask, x1=3, x2=5, deg=1, threshold=5, isplots=0
+    )
+
+    np.testing.assert_allclose(bg, expected, atol=1e-12)
+    np.testing.assert_array_equal(outmask, mask)
+
+
+def test_fitbg_masks_background_outlier_before_refitting_polynomial():
+    """Check background outliers are rejected before final fitting."""
+    y, x = np.indices((4, 20), dtype=float)
+    expected = 10 + 2*y + 0.5*x
+    data = expected.copy()
+    data[:, 8:12] += 100
+    data[2, 16] += 200
+    mask = np.zeros_like(data, dtype=bool)
+    meta = SimpleNamespace(bg_method='median', outputdir='')
+
+    bg, outmask = background.fitbg(
+        data, meta, mask, x1=8, x2=11, deg=1, threshold=5, isplots=0
+    )
+
+    assert outmask[2, 16]
+    np.testing.assert_allclose(bg, expected, atol=1e-12)
+
+
+def test_fitbg2_uses_explicit_background_mask_regions():
+    """Validate complex background masks for orders/source regions."""
+    y, x = np.indices((4, 9), dtype=float)
+    expected = 10 + 2*y + 0.5*x
+    data = expected.copy()
+    data[:, 3:6] += 100
+    mask = np.zeros_like(data, dtype=bool)
+    bgmask = np.zeros_like(data, dtype=bool)
+    bgmask[:, 3:6] = True
+    meta = SimpleNamespace(bg_method='std', outputdir='')
+
+    bg, returned_bgmask = background.fitbg2(
+        data, meta, mask, bgmask, deg=1, threshold=5, isplots=0
+    )
+
+    np.testing.assert_allclose(bg, expected, atol=1e-12)
+    np.testing.assert_array_equal(returned_bgmask, bgmask)
+
+
+def test_bgsubtraction_skip_adds_zero_background_without_changing_flux():
+    """Ensure skipped background subtraction records a zero bg product."""
+    flux = np.ones((2, 3, 4))
+    data = xr.Dataset(
+        {
+            'flux': (('time', 'y', 'x'), flux.copy()),
+            'mask': (('time', 'y', 'x'), np.zeros_like(flux, dtype=bool)),
+        },
+        coords={'time': [0, 1], 'y': np.arange(3), 'x': np.arange(4)},
+    )
+    data['flux'].attrs['flux_units'] = 'electrons'
+    meta = SimpleNamespace(bg_deg=None, skip_bg=False, verbose=False)
+
+    result = background.BGsubtraction(data, meta, _Log(), m=0)
+
+    np.testing.assert_allclose(result.flux.values, flux)
+    np.testing.assert_allclose(result.bg.values, np.zeros_like(flux))
+    assert result.bg.attrs['flux_units'] == 'electrons'
+
+
+def test_standard_spectrum_replaces_masked_pixels_with_spectral_neighbors():
+    """Verify box extraction repairs masked pixels from neighbors."""
+    apdata = np.array([[[1.0, 2.0, 100.0, 4.0, 5.0],
+                        [10.0, 20.0, 30.0, 40.0, 50.0]]])
+    aperr = np.ones_like(apdata)
+    apmask = np.zeros_like(apdata, dtype=bool)
+    apmask[0, 0, 2] = True
+
+    stdspec, stdvar = optspex.standard_spectrum(apdata, apmask, aperr)
+
+    cleaned_first_row = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    expected_spec = cleaned_first_row + apdata[0, 1]
+    np.testing.assert_allclose(stdspec[0], expected_spec)
+    np.testing.assert_allclose(stdvar[0], np.full(5, 2.0))
+
+
+def test_profile_meddata_clips_negative_values_and_normalizes_columns():
+    """Profiles used for optimal extraction must be positive and normalized."""
+    meddata = np.array([[-1.0, 2.0, 1.0],
+                        [3.0, 2.0, 1.0],
+                        [1.0, 6.0, 2.0]])
+
+    profile = optspex.profile_meddata(meddata)
+
+    expected = np.array([[0.0, 0.2, 0.25],
+                         [0.75, 0.2, 0.25],
+                         [0.25, 0.6, 0.5]])
+    np.testing.assert_allclose(profile, expected)
+    np.testing.assert_allclose(np.ma.sum(profile, axis=0), np.ones(3))
+
+
+def test_optimize_meddata_recovers_spectrum_and_masks_cosmic_ray():
+    """Check optimal extraction recovers flux after masking a cosmic ray."""
+    profile = np.array([[0.2, 0.3, 0.25],
+                        [0.5, 0.4, 0.5],
+                        [0.3, 0.3, 0.25]])
+    spectrum = np.array([100.0, 200.0, 300.0])
+    subdata = profile*spectrum
+    subdata[1, 1] += 200
+    mask = np.zeros_like(subdata, dtype=bool)
+    meta = SimpleNamespace(isplots_S3=0, int_end=99)
+
+    optspec, opterr, optmask, integ, order = optspex.optimize(
+        meta, subdata, mask, bg=np.zeros_like(subdata),
+        spectrum=spectrum.copy(), Q=1.0, v0=np.ones_like(subdata),
+        p7thresh=5, fittype='meddata', meddata=profile, n=4, order=2
+    )
+
+    np.testing.assert_allclose(optspec, spectrum)
+    assert np.all(opterr > 0)
+    assert optmask[1, 1]
+    assert integ == 4
+    assert order == 2
+
+
+def test_get_clean_interpolates_masked_pixels_and_removes_median_outlier():
+    """Median-frame cleaning should repair masked and sigma-clipped pixels."""
+    data = xr.Dataset(coords={'y': np.arange(2), 'x': np.arange(5)})
+    medflux = np.ma.array(
+        [[1.0, 2.0, 100.0, 4.0, 5.0],
+         [10.0, 11.0, 12.0, 13.0, 14.0]],
+        mask=[[False, False, False, False, False],
+              [False, False, True, False, False]],
+    )
+    mederr = np.ones((2, 5))
+    meta = SimpleNamespace(window_len=3, median_thresh=2)
+
+    clean = optspex.get_clean(data, meta, _Log(), medflux, mederr)
+
+    np.testing.assert_allclose(clean, [[1, 2, 3, 4, 5],
+                                       [10, 11, 12, 13, 14]])
+
+
+def test_rate2count_uses_effective_integration_time_header():
+    """Confirm rate-to-count conversion uses the effective integration time."""
+    data = xr.Dataset(
+        {
+            'flux': (('y', 'x'), np.ones((2, 2))),
+            'err': (('y', 'x'), np.full((2, 2), 2.0)),
+            'v0': (('y', 'x'), np.full((2, 2), 3.0)),
+        },
+        attrs={'mhdr': {'EFFINTTM': 5.0}},
+    )
+
+    result = bright2flux.rate2count(data)
+
+    np.testing.assert_allclose(result.flux.values, np.full((2, 2), 5.0))
+    np.testing.assert_allclose(result.err.values, np.full((2, 2), 10.0))
+    np.testing.assert_allclose(result.v0.values, np.full((2, 2), 15.0))
+
+
+def test_rate2count_requires_time_header():
+    """Fail clearly when no exposure-time keyword supports rate conversion."""
+    data = xr.Dataset(
+        {
+            'flux': (('y', 'x'), np.ones((2, 2))),
+            'err': (('y', 'x'), np.ones((2, 2))),
+            'v0': (('y', 'x'), np.ones((2, 2))),
+        },
+        attrs={'mhdr': {}},
+    )
+
+    with pytest.raises(ValueError, match='No FITS header keys'):
+        bright2flux.rate2count(data)
+
+
+def test_bright2flux_scales_flux_error_and_variance_by_pixel_area():
+    """Pin the MJy/sr to Jy/pixel scaling for flux-like arrays."""
+    data = xr.Dataset(
+        {
+            'flux': (('y', 'x'), np.ones((2, 2))),
+            'err': (('y', 'x'), np.full((2, 2), 2.0)),
+            'v0': (('y', 'x'), np.full((2, 2), 3.0)),
+        }
+    )
+    pixel_area = np.array([[1.0, 2.0], [3.0, 4.0]])
+    factor = arcsec**2 * 1e6 * pixel_area
+
+    result = bright2flux.bright2flux(data, pixel_area)
+
+    np.testing.assert_allclose(result.flux.values, factor)
+    np.testing.assert_allclose(result.err.values, 2*factor)
+    np.testing.assert_allclose(result.v0.values, 3*factor)
+
+
+def test_dn2electrons_scales_flux_error_and_variance_with_scalar_gain():
+    """Scalar DN-to-electron gain should square only variance-like arrays."""
+    data = xr.Dataset(
+        {
+            'flux': (('y', 'x'), np.ones((2, 2))),
+            'err': (('y', 'x'), np.full((2, 2), 2.0)),
+            'v0': (('y', 'x'), np.full((2, 2), 3.0)),
+        },
+        attrs={'mhdr': {'SUBSTRT1': 1, 'SUBSTRT2': 1, 'SUBSIZE1': 2,
+                        'SUBSIZE2': 2},
+               'shdr': {'DISPAXIS': 1}},
+    )
+    meta = SimpleNamespace(gain=4.0, gainfile=None)
+
+    result = bright2flux.dn2electrons(data, meta, _Log())
+
+    np.testing.assert_allclose(result.flux.values, np.full((2, 2), 4.0))
+    np.testing.assert_allclose(result.err.values, np.full((2, 2), 8.0))
+    np.testing.assert_allclose(result.v0.values, np.full((2, 2), 48.0))
+
+
+def test_dn2electrons_applies_supersampled_array_gain_window():
+    """Array gains should be supersampled and trimmed to the data window."""
+    data = xr.Dataset(
+        {
+            'flux': (('y', 'x'), np.ones((2, 2))),
+            'err': (('y', 'x'), np.ones((2, 2))),
+            'v0': (('y', 'x'), np.ones((2, 2))),
+        },
+        attrs={'mhdr': {'SUBSTRT1': 1, 'SUBSTRT2': 1, 'SUBSIZE1': 2,
+                        'SUBSIZE2': 2},
+               'shdr': {'DISPAXIS': 1}},
+    )
+    meta = SimpleNamespace(gain=[[2.0, 3.0], [4.0, 5.0]], gainfile=None,
+                           expand=1, ywindow=[0, 2], xwindow=[0, 2])
+
+    result = bright2flux.dn2electrons(data, meta, _Log())
+
+    gain = np.array([[2.0, 3.0], [4.0, 5.0]])
+    np.testing.assert_allclose(result.flux.values, gain)
+    np.testing.assert_allclose(result.err.values, gain)
+    np.testing.assert_allclose(result.v0.values, gain**2)
+
+
+def test_interp_masked_helper_replaces_bad_pixels_without_touching_good_ones():
+    """Bad-pixel interpolation should only alter masked pixels."""
+    flux = np.array([[1.0, 2.0, 3.0],
+                     [4.0, 0.0, 6.0],
+                     [7.0, 8.0, 9.0]])
+    mask = np.zeros_like(flux, dtype=bool)
+    mask[1, 1] = True
+    grid_x, grid_y = np.mgrid[0:2:complex(0, 3), 0:2:complex(0, 3)]
+
+    interpolated, integ = util.interp_masked_helper(
+        flux, mask, grid_x, grid_y, 'linear', i=7
+    )
+
+    np.testing.assert_allclose(interpolated[~mask], flux[~mask])
+    assert interpolated[1, 1] == pytest.approx(5.0)
+    assert integ == 7
+
+
+def test_find_column_median_shifts_aligns_trace_to_detector_center():
+    """Protect trace-straightening shift signs for a curved synthetic trace."""
+    ny = 11
+    centers = np.array([4]*5 + [5]*5 + [6]*5)
+    y = np.arange(ny)[:, None]
+    image = np.exp(-0.5*((y-centers[None, :])/0.7)**2)
+    meta = SimpleNamespace(calibrated_spectra=False, isplots_S3=0)
+
+    shifts, new_center = straighten.find_column_median_shifts(image, meta, m=0)
+
+    assert new_center == 4
+    np.testing.assert_array_equal(shifts, [0]*5 + [-1]*5 + [-2]*5)
+
+
+def test_roll_columns_applies_per_column_shifts_without_mutating_shifts():
+    """Ensure per-column rolling preserves reusable shift arrays."""
+    data = np.arange(2*4*3).reshape(2, 4, 3)
+    shifts = np.array([[0, 1, -1], [1, -1, 0]])
+    original_shifts = shifts.copy()
+
+    rolled = straighten.roll_columns(data, shifts)
+
+    expected = np.stack([
+        np.column_stack([
+            np.roll(data[0, :, 0], 0),
+            np.roll(data[0, :, 1], 1),
+            np.roll(data[0, :, 2], -1),
+        ]),
+        np.column_stack([
+            np.roll(data[1, :, 0], 1),
+            np.roll(data[1, :, 1], -1),
+            np.roll(data[1, :, 2], 0),
+        ]),
+    ])
+    np.testing.assert_array_equal(rolled, expected)
+    np.testing.assert_array_equal(shifts, original_shifts)
+

--- a/tests/unit/test_s3_units.py
+++ b/tests/unit/test_s3_units.py
@@ -354,7 +354,7 @@ def test_bright2flux_scales_flux_error_and_variance_by_pixel_area():
 
     np.testing.assert_allclose(result.flux.values, factor)
     np.testing.assert_allclose(result.err.values, 2*factor)
-    np.testing.assert_allclose(result.v0.values, 3*factor)
+    np.testing.assert_allclose(result.v0.values, 3*factor**2)
 
 
 def test_dn2electrons_scales_flux_error_and_variance_with_scalar_gain():
@@ -455,4 +455,3 @@ def test_roll_columns_applies_per_column_shifts_without_mutating_shifts():
     ])
     np.testing.assert_array_equal(rolled, expected)
     np.testing.assert_array_equal(shifts, original_shifts)
-

--- a/tests/unit/test_s4_units.py
+++ b/tests/unit/test_s4_units.py
@@ -1,0 +1,215 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from astropy.convolution import Box1DKernel, convolve
+
+os.environ.setdefault('MPLCONFIGDIR', '/tmp')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', 'src')))
+from eureka.S4_generate_lightcurves import drift, outliers, s4_genLC
+
+
+class _Log:
+    def __init__(self):
+        self.messages = []
+
+    def writelog(self, message, **kwargs):
+        self.messages.append(message)
+
+
+class _Values:
+    def __init__(self, values):
+        self.values = np.asarray(values)
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+
+def _trace_image(center=7.3, sigma=1.2, ny=15, nx=6, background=0.1):
+    y = np.arange(ny, dtype=float)
+    profile = background + np.exp(-0.5*((y-center)/sigma)**2)
+    return np.repeat(profile[:, None], nx, axis=1)
+
+
+def test_highpassfilt_matches_boxcar_convolution_with_extend_boundary():
+    """The S4 high-pass helper should match its documented boxcar smoothing."""
+    signal = np.array([1.0, 2.0, 10.0, 2.0, 1.0])
+    width = 3
+
+    result = drift.highpassfilt(signal, width)
+
+    expected = convolve(signal, Box1DKernel(width), boundary='extend')
+    np.testing.assert_allclose(result, expected)
+
+
+def test_spec1d_measures_integer_spectral_drifts_and_sign_convention():
+    """Protect the S4 drift sign convention with known pixel shifts."""
+    base = np.exp(-0.5*((np.arange(80)-40)/5)**2)
+    input_shifts = np.array([0, 2, -3])
+    spectra = np.vstack([np.roll(base, shift) for shift in input_shifts])
+    meta = SimpleNamespace(
+        drift_postclip=None,
+        n_int=3,
+        drift_iref=0,
+        drift_preclip=0,
+        sub_continuum=False,
+        sub_mean=False,
+        drift_range=10,
+        verbose=False,
+        isplots_S4=0,
+        nplots=0,
+        drift_hw=6,
+    )
+
+    drift1d, driftwidth, driftmask = drift.spec1D(spectra, meta, _Log())
+
+    np.testing.assert_allclose(drift1d, input_shifts, atol=5e-3)
+    assert np.all(driftwidth > 0)
+    np.testing.assert_array_equal(driftmask, [False, False, False])
+
+
+def test_get_outliers_flags_noisy_spectral_column_and_returns_plot_payload():
+    """Verify MAD-based S4 column flagging on a synthetic noisy light curve."""
+    nints = 20
+    nwave = 15
+    wave = np.linspace(1.0, 2.0, nwave)
+    optspec = np.ones((nints, nwave))
+    opterr = np.full_like(optspec, 0.01)
+    optmask = np.zeros_like(optspec, dtype=bool)
+    noisy_col = 7
+    optspec[:, noisy_col] = 1 + 0.08*((-1)**np.arange(nints))
+    spec = SimpleNamespace(
+        wave_1d=_Values(wave),
+        optspec=_Values(optspec),
+        opterr=_Values(opterr),
+        optmask=_Values(optmask),
+        x=np.arange(nwave),
+    )
+    meta = SimpleNamespace(
+        wave_min=wave[0],
+        wave_max=wave[-1],
+        inst='nircam',
+        mad_box_width=5,
+        mad_sigma=3,
+        maxiters=3,
+    )
+
+    flagged, pp = outliers.get_outliers(meta, spec)
+
+    np.testing.assert_array_equal(flagged, [noisy_col])
+    assert pp['mad'][noisy_col] > 1e5
+    assert pp['x_mad_outliers'].tolist() == [noisy_col]
+    assert set(pp) == {
+        'x', 'x_mask', 'x_mad_outliers', 'x_dev_outliers', 'mad', 'dev',
+        'masked_mad', 'masked_dev', 'smoothed_mad', 'residual_mad',
+        'smoothed_dev', 'residual_dev'
+    }
+
+
+def test_compute_wavelength_bins_builds_native_bins_and_pixel_bins():
+    """S4 wavelength bin helper should preserve native and pixel-bin logic."""
+    wave = np.array([1.0, 1.1, 1.2, 1.3, 1.4])
+    native_meta = SimpleNamespace(wave_input=None, nspecchan=None,
+                                  npixelbins=None, wave_min=1.1,
+                                  wave_max=1.3, wave_low=None, wave_hi=None)
+
+    native = s4_genLC.compute_wavelength_bins(native_meta, wave, _Log())
+
+    np.testing.assert_allclose(native.wave, [1.1, 1.2, 1.3])
+    np.testing.assert_allclose(native.wave_low, [1.05, 1.15, 1.25])
+    np.testing.assert_allclose(native.wave_hi, [1.15, 1.25, 1.35])
+    assert native.nspecchan == 3
+
+    pixel_meta = SimpleNamespace(wave_input=None, nspecchan=None,
+                                 npixelbins=2, npixelshift=0, wave_min=1.0,
+                                 wave_max=1.4, wave_low=None, wave_hi=None)
+    pixel = s4_genLC.compute_wavelength_bins(pixel_meta, wave, _Log())
+
+    np.testing.assert_allclose(pixel.wave_low, [0.95])
+    np.testing.assert_allclose(pixel.wave_hi, [1.15])
+    np.testing.assert_allclose(pixel.wave, [1.05])
+    assert pixel.nspecchan == 1
+
+
+def test_compute_wavelength_bins_respects_explicit_edges_and_warnings():
+    """Explicit S4 wavelength edges should override mismatched nspecchan."""
+    log = _Log()
+    meta = SimpleNamespace(wave_input=None, nspecchan=3, npixelbins=None,
+                           wave_min=1.0, wave_max=1.4,
+                           wave_low=[1.0, 1.2], wave_hi=[1.2, 1.4])
+
+    result = s4_genLC.compute_wavelength_bins(
+        meta, np.array([1.0, 1.2, 1.4]), log
+    )
+
+    np.testing.assert_allclose(result.wave, [1.1, 1.3])
+    assert result.nspecchan == 2
+    assert any('differs from the size' in message for message in log.messages)
+
+
+def test_compute_wavelength_bins_reads_edges_from_input_file(tmp_path):
+    """S4 wavelength bins should support two-column edge files."""
+    wave_file = tmp_path/'wave_bins.txt'
+    np.savetxt(wave_file, np.array([[1.0, 1.2], [1.2, 1.5]]))
+    log = _Log()
+    meta = SimpleNamespace(wave_input=str(wave_file), nspecchan=None,
+                           npixelbins=None, wave_min=1.0, wave_max=1.5,
+                           wave_low=None, wave_hi=None)
+
+    result = s4_genLC.compute_wavelength_bins(
+        meta, np.array([1.0, 1.2, 1.5]), log
+    )
+
+    np.testing.assert_allclose(result.wave_low, [1.0, 1.2])
+    np.testing.assert_allclose(result.wave_hi, [1.2, 1.5])
+    np.testing.assert_allclose(result.wave, [1.1, 1.35])
+    assert result.nspecchan == 2
+    assert 'input file' in log.messages[0]
+
+
+def test_compute_wavelength_bins_raises_when_pixel_range_is_missing():
+    """Pixel-defined bins should fail when bounds are outside data."""
+    meta = SimpleNamespace(wave_input=None, nspecchan=None, npixelbins=2,
+                           npixelshift=0, wave_min=0.9, wave_max=2.0,
+                           wave_low=None, wave_hi=None)
+
+    with pytest.raises(ValueError, match='No wavelengths'):
+        s4_genLC.compute_wavelength_bins(meta, np.array([1.0, 1.1]), _Log())
+
+
+def test_compute_spectral_lightcurve_averages_masked_columns_and_errors():
+    """S4 spectral binning should average flux and propagate uncertainties."""
+    optspec = np.array([[10.0, 12.0, 14.0],
+                        [20.0, 22.0, 24.0]])
+    opterr = np.array([[1.0, 2.0, 3.0],
+                       [2.0, 4.0, 6.0]])
+    optmask = np.array([[False, True, False],
+                        [False, False, False]])
+
+    lc_data, lc_err, lc_mask = s4_genLC.compute_spectral_lightcurve(
+        optspec, opterr, optmask, np.array([0, 1, 2]), return_mask=True
+    )
+
+    np.testing.assert_allclose(lc_data, [12.0, 22.0])
+    np.testing.assert_allclose(lc_err, [np.sqrt(10)/2, np.sqrt(56)/3])
+    np.testing.assert_array_equal(lc_mask, [False, False])
+
+
+def test_compute_spectral_lightcurve_masks_fully_masked_integrations():
+    """Fully masked bandpasses should produce masked flux and errors."""
+    optspec = np.array([[10.0, 12.0], [20.0, 22.0]])
+    opterr = np.array([[1.0, 2.0], [2.0, 4.0]])
+    optmask = np.array([[True, True], [False, True]])
+
+    lc_data, lc_err, lc_mask = s4_genLC.compute_spectral_lightcurve(
+        optspec, opterr, optmask, np.array([0, 1]), return_mask=True
+    )
+
+    np.testing.assert_array_equal(np.ma.getmaskarray(lc_data), [True, False])
+    np.testing.assert_array_equal(np.ma.getmaskarray(lc_err), [True, False])
+    assert lc_data[1] == pytest.approx(20.0)
+    assert lc_err[1] == pytest.approx(2.0)
+    np.testing.assert_array_equal(lc_mask, [True, False])

--- a/tests/unit/test_s5_core_model_units.py
+++ b/tests/unit/test_s5_core_model_units.py
@@ -1,0 +1,191 @@
+import os
+import sys
+
+import numpy as np
+import pytest
+
+os.environ.setdefault('MPLCONFIGDIR', '/tmp')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', 'src')))
+from eureka.S5_lightcurve_fitting import models
+from eureka.S5_lightcurve_fitting.models.AstroModel import (
+    PlanetParams, correct_light_travel_time,
+)
+from eureka.S5_lightcurve_fitting.models.KeplerOrbit import KeplerOrbit
+from tests.unit.s5_model_helpers import (
+    _ConstantModel, _FakeGPModel, _params,
+)
+
+
+def test_model_validates_channel_metadata_lengths():
+    """Catch inconsistent multichannel metadata before model evaluation."""
+    with pytest.raises(ValueError, match='fitted_channels must have length'):
+        models.Model(nchannel_fitted=2, fitted_channels=[0])
+
+
+def test_model_update_changes_parameter_values_and_attributes():
+    params = _params(c0=1.0, c1=2.0)
+    model = models.Model(parameters=params, freenames=['c0', 'c1'])
+
+    model.update([3.0, 4.0])
+
+    assert params.c0.value == 3.0
+    assert params.c1.value == 4.0
+    assert params.dict['c0'][0] == 3.0
+    assert params.dict['c1'][0] == 4.0
+
+
+def test_composite_model_multiplies_components_by_type_and_propagates_time():
+    systematic = _ConstantModel([2.0, 3.0], modeltype='systematic')
+    physical = _ConstantModel([0.5, 0.25], modeltype='physical')
+    composite = models.CompositeModel([systematic, physical])
+    composite.time = np.array([0.0, 1.0])
+
+    np.testing.assert_allclose(composite.eval(), [1.0, 0.75])
+    np.testing.assert_allclose(composite.syseval(), [2.0, 3.0])
+    phys_flux, phys_time, nints = composite.physeval()
+    np.testing.assert_allclose(phys_flux, [0.5, 0.25])
+    np.testing.assert_allclose(phys_time, [0.0, 1.0])
+    assert nints is None
+    np.testing.assert_allclose(systematic.time, [0.0, 1.0])
+    np.testing.assert_allclose(physical.time, [0.0, 1.0])
+
+
+def test_model_multiplication_combines_parameters_and_evaluates_product():
+    params1 = _params(a=1.0)
+    params2 = _params(b=2.0)
+    model1 = _ConstantModel([2.0, 2.0], parameters=params1)
+    model2 = _ConstantModel([0.5, 0.25], parameters=params2)
+
+    composite = model1*model2
+
+    assert 'a' in composite.parameters.dict
+    assert 'b' in composite.parameters.dict
+    composite.time = np.array([0.0, 1.0])
+    np.testing.assert_allclose(composite.eval(), [1.0, 0.5])
+
+
+def test_model_interp_restores_original_time_and_nints():
+    """Interpolation should be a temporary evaluation, not persistent state."""
+    params = _params(c0=1.0, c1=2.0)
+    model = models.PolynomialModel(parameters=params, nints=[3])
+    original_time = np.array([0.0, 1.0, 2.0])
+    model.time = original_time
+
+    result = model.interp(np.array([10.0, 11.0]), [2])
+
+    np.testing.assert_allclose(result, [0.0, 2.0])
+    np.testing.assert_allclose(model.time, original_time)
+    assert model.nints == [3]
+
+
+def test_composite_model_includes_gp_prediction_when_requested():
+    """GP components add residual structure only when explicitly requested."""
+    systematic = _ConstantModel([2.0, 3.0], modeltype='systematic')
+    gp = _FakeGPModel([0.1, -0.2])
+    composite = models.CompositeModel([systematic, gp])
+    composite.time = np.array([0.0, 1.0])
+
+    no_gp = composite.eval()
+    with_gp = composite.eval(incl_GP=True)
+
+    np.testing.assert_allclose(no_gp, [2.0, 3.0])
+    np.testing.assert_allclose(with_gp, [2.1, 2.8])
+    np.testing.assert_allclose(gp.seen_fit, [2.0, 3.0])
+
+
+def test_planet_params_resolves_aliases_geometry_and_limb_darkening():
+    """Protect S5 aliases and derived orbital/limb-darkening conventions."""
+    params = _params(limb_dark='kipping2013', rprs=0.11, ars=15.0, b=0.3,
+                     per=3.0, t0=0.0, ecosw=0.03, esinw=0.04,
+                     fpfs=0.001, u1=0.25, u2=0.4, Rs=1.0)
+    model = models.Model(parameters=params)
+
+    planet = PlanetParams(model)
+
+    assert planet.rp == pytest.approx(0.11)
+    assert planet.a == pytest.approx(15.0)
+    assert planet.inc == pytest.approx(np.degrees(np.arccos(0.3/15.0)))
+    assert planet.ecc == pytest.approx(0.05)
+    assert planet.w == pytest.approx(np.degrees(np.arctan2(0.04, 0.03)))
+    assert planet.fp == pytest.approx(0.001)
+    np.testing.assert_allclose(planet.u_original, [0.25, 0.4])
+    np.testing.assert_allclose(
+        planet.u,
+        [2*np.sqrt(0.25)*0.4, np.sqrt(0.25)*(1-2*0.4)]
+    )
+
+
+def test_planet_params_prefers_wavelength_specific_over_channel_parameters():
+    """Wavelength-group parameters should override channel-level values."""
+    params = _params(rp=0.1, rp_ch1=0.2, rp_wl2=0.3, per=3.0, t0=0.0,
+                     inc=89.0, a=12.0, ecc=0.0, w=90.0)
+    model = models.Model(parameters=params, nchannel_fitted=1,
+                         fitted_channels=[1], wl_groups=[2])
+
+    planet = PlanetParams(model, channel=1)
+
+    assert planet.rp == pytest.approx(0.3)
+    assert planet.rprs == pytest.approx(0.3)
+
+
+def test_kepler_orbit_circular_true_anomaly_distance_and_xyz():
+    """Validate circular-orbit geometry against analytic phase positions."""
+    orbit = KeplerOrbit(a=12.0, Porb=3.0, inc=90.0, t0=0.0, e=0.0,
+                        argp=90.0)
+    time = np.array([0.0, 0.75, 1.5])
+
+    true_anom = orbit.true_anomaly(time)
+    distance = orbit.distance(time)
+    x, y, z = orbit.xyz(time)
+
+    np.testing.assert_allclose(true_anom, [0.0, np.pi/2, np.pi],
+                               atol=1e-12)
+    np.testing.assert_allclose(distance, 12.0)
+    np.testing.assert_allclose(np.sqrt(x*x+y*y+z*z), 12.0)
+    assert orbit.phase_eclipse == pytest.approx(0.5)
+
+
+def test_kepler_orbit_eccentric_distance_matches_conic_formula():
+    """Ensure eccentric Kepler distances obey the conic-section formula."""
+    orbit = KeplerOrbit(a=12.0, Porb=3.0, inc=88.5, t0=0.0, e=0.05,
+                        argp=45.0)
+    time = np.linspace(-0.1, 0.1, 7)
+
+    true_anom = orbit.true_anomaly(time)
+    distance = orbit.distance(time)
+    x, y, z = orbit.xyz(time)
+
+    expected_distance = 12.0*(1-0.05**2)/(1+0.05*np.cos(true_anom))
+    np.testing.assert_allclose(distance, expected_distance)
+    np.testing.assert_allclose(np.sqrt(x*x+y*y+z*z), expected_distance)
+
+
+def test_correct_light_travel_time_matches_circular_formula():
+    """Pin light-travel-time correction against the circular analytic case."""
+    params = _params(rp=0.1, per=3.0, t0=0.0, inc=89.0, a=12.0,
+                     ecc=0.0, w=90.0, Rs=1.0)
+    model = models.Model(parameters=params)
+    planet = PlanetParams(model)
+    time = np.array([0.0, 0.25, 0.5])
+
+    corrected = correct_light_travel_time(time, planet)
+
+    a_m = planet.a*planet.Rs*6.957e8
+    transit_x = a_m*np.sin(np.deg2rad(planet.inc))
+    old_x = transit_x*np.cos(2*np.pi*(time-planet.t0)/planet.per)
+    expected = time - ((transit_x-old_x)/299792458.0)/(3600*24)
+    np.testing.assert_allclose(corrected, expected, rtol=1e-7)
+
+
+def test_correct_light_travel_time_eccentric_is_zero_at_transit():
+    """Transit midtime should remain fixed by light-travel-time correction."""
+    params = _params(rp=0.1, per=3.0, t0=0.0, inc=89.0, a=12.0,
+                     ecc=0.05, w=45.0, Rs=1.0)
+    model = models.Model(parameters=params)
+    planet = PlanetParams(model)
+    time = np.array([planet.t0])
+
+    corrected = correct_light_travel_time(time, planet)
+
+    np.testing.assert_allclose(corrected, time, atol=1e-14)

--- a/tests/unit/test_s5_phase_gp_units.py
+++ b/tests/unit/test_s5_phase_gp_units.py
@@ -1,0 +1,108 @@
+import os
+import sys
+
+import numpy as np
+
+os.environ.setdefault('MPLCONFIGDIR', '/tmp')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', 'src')))
+from eureka.S5_lightcurve_fitting import models
+from eureka.S5_lightcurve_fitting.models.AstroModel import (
+    PlanetParams, true_anomaly,
+)
+from tests.unit.s5_model_helpers import _params
+
+
+def test_sinusoid_phase_curve_matches_circular_orbit_formula():
+    params = _params(per=2.0, t0=0.0, t_secondary=0.5, inc=89.0, a=10.0,
+                     ecc=0.0, w=90.0, AmpCos1=0.2, AmpSin1=0.1,
+                     AmpCos2=0.05, AmpSin2=-0.02)
+    model = models.SinusoidPhaseCurveModel(parameters=params, num_planets=1)
+    model.time = np.array([0.0, 0.5, 1.0])
+
+    result = model.eval()
+
+    phi = 2*np.pi/2.0*(model.time-0.5)
+    expected = (1 + 0.2*(np.cos(phi)-1) + 0.1*np.sin(phi) +
+                0.05*(np.cos(2*phi)-1) - 0.02*np.sin(2*phi))
+    np.testing.assert_allclose(result, expected)
+
+
+def test_sinusoid_phase_curve_force_positivity_penalty():
+    """Physically invalid negative phase curves should return fit penalties."""
+    params = _params(per=2.0, t0=0.0, t_secondary=0.0, inc=89.0, a=10.0,
+                     ecc=0.0, w=90.0, AmpCos1=2.0, AmpSin1=0.0,
+                     AmpCos2=0.0, AmpSin2=0.0)
+    model = models.SinusoidPhaseCurveModel(parameters=params, num_planets=1,
+                                           force_positivity=True)
+    model.time = np.array([0.0, 1.0])
+
+    result = model.eval()
+
+    assert np.all(result > 1e6)
+    np.testing.assert_allclose(result[0], result[1])
+
+
+def test_sinusoid_phase_curve_matches_eccentric_true_anomaly_formula():
+    """Guard eccentric phase-curve geometry against true-anomaly mistakes."""
+    params = _params(per=3.0, t0=0.0, inc=88.5, a=12.0, ecc=0.05,
+                     w=45.0, AmpCos1=0.2, AmpSin1=-0.1,
+                     AmpCos2=0.05, AmpSin2=0.03)
+    model = models.SinusoidPhaseCurveModel(parameters=params, num_planets=1)
+    model.time = np.array([-0.1, 0.0, 0.1])
+
+    result = model.eval()
+
+    planet = PlanetParams(model)
+    phi = true_anomaly(planet, model.time) + planet.w*np.pi/180 + np.pi/2
+    expected = (1 + 0.2*(np.cos(phi)-1) - 0.1*np.sin(phi) +
+                0.05*(np.cos(2*phi)-1) + 0.03*np.sin(2*phi))
+    np.testing.assert_allclose(result, expected)
+
+
+def test_quasi_lambertian_phase_curve_matches_circular_orbit_formula():
+    params = _params(per=2.0, t0=0.0, t_secondary=0.5, inc=89.0, a=10.0,
+                     ecc=0.0, w=90.0, quasi_gamma=2.0,
+                     quasi_offset=30.0)
+    model = models.QuasiLambertianPhaseCurve(parameters=params, num_planets=1)
+    model.time = np.array([0.0, 0.5, 1.0])
+
+    result = model.eval()
+
+    phi = 2*np.pi/2.0*(model.time-0.5)
+    expected = np.abs(np.cos((phi+30*np.pi/180)/2))**2
+    np.testing.assert_allclose(result, expected)
+
+
+def test_quasi_lambertian_phase_curve_matches_eccentric_true_anomaly():
+    """Check quasi-Lambertian phase on eccentric true-anomaly geometry."""
+    params = _params(per=3.0, t0=0.0, inc=88.5, a=12.0, ecc=0.05,
+                     w=45.0, quasi_gamma=1.5, quasi_offset=-20.0)
+    model = models.QuasiLambertianPhaseCurve(parameters=params, num_planets=1)
+    model.time = np.array([-0.1, 0.0, 0.1])
+
+    result = model.eval()
+
+    planet = PlanetParams(model)
+    phi = true_anomaly(planet, model.time) + planet.w*np.pi/180 + np.pi/2
+    expected = np.abs(np.cos((phi-20*np.pi/180)/2))**1.5
+    np.testing.assert_allclose(result, expected)
+
+
+def test_poet_phase_curve_matches_cosine_terms_and_eclipse_normalization():
+    """POET phase curves should normalize relative to eclipse center."""
+    params = _params(per=2.0, t0=0.0, t_secondary=0.5, inc=89.0, a=10.0,
+                     ecc=0.0, w=90.0, cos1_amp=0.2, cos1_off=90.0,
+                     cos2_amp=0.1, cos2_off=180.0)
+    model = models.PoetPCModel(parameters=params, num_planets=1)
+    model.time = np.array([0.0, 0.5, 1.0])
+
+    result = model.eval()
+
+    p = 2.0
+    t1 = 90*p/360 - 0.5
+    t2 = 180*p/360 - 0.5
+    expected = (0.2/2*np.cos(2*np.pi*(model.time+t1)/p) +
+                0.1/2*np.cos(4*np.pi*(model.time+t2)/p))
+    expected += 1 - expected[np.argmin(np.abs(model.time-0.5))]
+    np.testing.assert_allclose(result, expected)

--- a/tests/unit/test_s5_plumbing_units.py
+++ b/tests/unit/test_s5_plumbing_units.py
@@ -1,0 +1,428 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from astropy.table import Table
+from astropy.table import Table as AstropyTable
+
+os.environ.setdefault('MPLCONFIGDIR', '/tmp')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', 'src')))
+from eureka.S5_lightcurve_fitting import fitters, likelihood, s5_fit, utils
+from eureka.S5_lightcurve_fitting.lightcurve import LightCurve
+from eureka.S5_lightcurve_fitting import models
+from eureka.lib.readEPF import Parameters
+
+
+class _Log:
+    def __init__(self):
+        self.messages = []
+
+    def writelog(self, message, **kwargs):
+        self.messages.append(message)
+
+
+class _FlatModel(models.Model):
+    def __init__(self, parameters=None, freenames=None, values=None):
+        super().__init__(parameters=parameters, freenames=freenames)
+        self.values = np.ma.array([1.0, 1.0] if values is None else values)
+        self.modeltype = 'systematic'
+
+    def eval(self, channel=None, **kwargs):
+        return self.values
+
+
+class _LikelihoodGPModel(models.Model):
+    def __init__(self, loglike, **kwargs):
+        super().__init__(name='GP', modeltype='GP', **kwargs)
+        self.loglike = loglike
+        self.received_model_lc = None
+
+    def eval(self, fit, channel=None, **kwargs):
+        return np.zeros_like(fit)
+
+    def loglikelihood(self, model_lc):
+        self.received_model_lc = np.ma.copy(model_lc)
+        return self.loglike
+
+
+def _params(**values):
+    params = Parameters()
+    for name, spec in values.items():
+        setattr(params, name, spec)
+    return params
+
+
+def test_update_uncertainty_applies_scatter_mult_per_channel():
+    """Scatter multipliers should inflate each fitted channel locally."""
+    theta = np.array([2.0, 3.0])
+    unc = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    freenames = ['scatter_mult', 'scatter_mult_ch1']
+
+    result = likelihood.update_uncertainty(theta, [2, 3], unc, freenames, 2)
+
+    np.testing.assert_allclose(result, [0.2, 0.4, 0.9, 1.2, 1.5])
+    np.testing.assert_allclose(unc, [0.1, 0.2, 0.3, 0.4, 0.5])
+
+
+def test_update_uncertainty_applies_scatter_ppm_per_channel():
+    """Scatter-ppm parameters replace uncertainty per fitted channel."""
+    theta = np.array([100.0, 250.0])
+    unc = np.ones(5)
+    freenames = ['scatter_ppm', 'scatter_ppm_ch1']
+
+    result = likelihood.update_uncertainty(theta, [2, 3], unc, freenames, 2)
+
+    np.testing.assert_allclose(result, [100e-6, 100e-6,
+                                        250e-6, 250e-6, 250e-6])
+
+
+def test_lnprior_handles_uniform_log_uniform_normal_and_scatter_bounds():
+    """Priors should combine types and enforce positive scatter parameters."""
+    theta = np.array([0.5, 10.0, 1.5, 2.0])
+    prior1 = np.array([0.0, np.log(1.0), 1.0, 0.0])
+    prior2 = np.array([1.0, np.log(100.0), 0.5, 10.0])
+    priortype = np.array(['U', 'LU', 'N', 'U'])
+    freenames = ['a', 'b', 'c', 'scatter_mult']
+
+    result = likelihood.lnprior(theta, prior1, prior2, priortype, freenames)
+
+    expected_normal = -0.5*(((1.5-1.0)/0.5)**2 + np.log(2*np.pi*0.5**2))
+    assert result == pytest.approx(expected_normal)
+    assert likelihood.lnprior(np.array([1.5, 10, 1.5, 2.0]), prior1, prior2,
+                              priortype, freenames) == -np.inf
+    assert likelihood.lnprior(np.array([0.5, 0.5, 1.5, 2.0]), prior1, prior2,
+                              priortype, freenames) == -np.inf
+    assert likelihood.lnprior(np.array([0.5, 10, 1.5, 0.0]), prior1, prior2,
+                              priortype, freenames) == -np.inf
+
+
+def test_lnprior_rejects_unknown_prior_type_and_ptform_transforms():
+    """Unknown prior types should fail while valid dynesty transforms agree."""
+    with pytest.raises(ValueError, match='PriorType'):
+        likelihood.lnprior(np.array([1.0]), np.array([0.0]), np.array([1.0]),
+                           np.array(['bad']), ['x'])
+
+    result = likelihood.ptform(np.array([0.25, 0.5, 0.5]),
+                               np.array([2.0, 1.0, 10.0]),
+                               np.array([6.0, 100.0, 2.0]),
+                               np.array(['U', 'LU', 'N']))
+    np.testing.assert_allclose(result[:2], [3.0, 10.0])
+    assert result[2] == pytest.approx(10.0)
+
+
+def test_ln_like_and_lnprob_match_manual_gaussian_result():
+    """Likelihood should match a hand-computed Gaussian loglike."""
+    params = _params(c0=(1.0, 'free', 0.0, 2.0, 'U'))
+    component = _FlatModel(parameters=params, freenames=['c0'],
+                           values=np.array([1.0, 1.0]))
+    model = models.CompositeModel([component], parameters=params)
+    model.freenames = ['c0']
+    model.time = np.array([0.0, 1.0])
+    lc = SimpleNamespace(flux=np.array([1.1, 0.9]), unc=np.array([0.1, 0.2]),
+                         nints=[2], nchannel_fitted=1)
+
+    result = likelihood.ln_like(np.array([1.0]), lc, model, ['c0'])
+
+    residuals = lc.flux - np.array([1.0, 1.0])
+    expected = -0.5*np.sum((residuals/lc.unc_fit)**2 +
+                           np.log(2*np.pi*lc.unc_fit**2))
+    assert result == pytest.approx(expected)
+    assert likelihood.lnprob(np.array([1.0]), lc, model, np.array([0.0]),
+                             np.array([2.0]), np.array(['U']),
+                             ['c0']) == pytest.approx(expected)
+    assert likelihood.lnprob(np.array([3.0]), lc, model, np.array([0.0]),
+                             np.array([2.0]), np.array(['U']),
+                             ['c0']) == -np.inf
+
+
+def test_ln_like_gp_branch_sums_component_loglikelihoods():
+    """GP likelihoods should be delegated to and summed over GP components."""
+    params = _params(c0=(1.0, 'free', 0.0, 2.0, 'U'))
+    systematic = _FlatModel(parameters=params, freenames=['c0'],
+                            values=np.array([1.0, 1.0]))
+    gp1 = _LikelihoodGPModel(3.0)
+    gp2 = _LikelihoodGPModel(-0.5)
+    model = models.CompositeModel([systematic, gp1, gp2], parameters=params)
+    model.freenames = ['c0']
+    model.time = np.array([0.0, 1.0])
+    lc = SimpleNamespace(flux=np.array([1.1, 0.9]), unc=np.array([0.1, 0.2]),
+                         nints=[2], nchannel_fitted=1)
+
+    result = likelihood.ln_like(np.array([1.0]), lc, model, ['c0'])
+
+    assert result == pytest.approx(2.5)
+    np.testing.assert_allclose(gp1.received_model_lc, [1.0, 1.0])
+    np.testing.assert_allclose(gp2.received_model_lc, [1.0, 1.0])
+
+
+def test_compute_reduced_chi_squared_uses_unmasked_points_and_logs():
+    """Reduced chi-squared should count only unmasked flux samples."""
+    lc = SimpleNamespace(flux=np.ma.array([1.1, 0.9, 2.0],
+                                          mask=[False, False, True]),
+                         unc_fit=np.array([0.1, 0.2, 0.3]))
+    model = SimpleNamespace(eval=lambda incl_GP=False:
+                            np.ma.array([1.0, 1.0, 1.0]))
+    log = _Log()
+    meta = SimpleNamespace(verbose=True)
+
+    result = likelihood.computeRedChiSq(lc, log, model, meta, ['c0'])
+
+    expected = ((0.1/0.1)**2 + (-0.1/0.2)**2)/(2-1)
+    assert result == pytest.approx(expected)
+    assert 'Reduced Chi-squared' in log.messages[0]
+
+
+def test_compute_rms_returns_expected_bin_statistics():
+    data = np.array([1.0, -1.0, 1.0, -1.0])
+
+    rms, stderr, binsz, rmserr = likelihood.computeRMS(
+        data, maxnbins=2, isrmserr=True
+    )
+
+    np.testing.assert_array_equal(binsz, [1, 2])
+    np.testing.assert_allclose(rms, [1.0, 0.0])
+    assert stderr[0] == pytest.approx(np.std(data)/np.sqrt(1)*np.sqrt(4/3))
+    np.testing.assert_allclose(rmserr, [1/np.sqrt(8), 0.0])
+
+
+def test_make_longparamlist_clones_channel_params_and_sorts_freenames():
+    """Parameter expansion should clone channel-local fits in order."""
+    params = _params(c0=(1.0, 'free'), per=(3.0, 'shared'),
+                     inc=(89.0, 'fixed'), limb_dark=('uniform',
+                                                     'independent'))
+    meta = SimpleNamespace(multwhite=False, sharedp=True, wl_groups=[0, 0])
+
+    longparamlist, paramtitles, freenames, updated = (
+        s5_fit.make_longparamlist(meta, params, chanrng=2)
+    )
+
+    assert longparamlist == [
+        ['time_offset', 'c0', 'per', 'inc', 'limb_dark'],
+        ['time_offset', 'c0_ch1', 'per', 'inc_ch1', 'limb_dark'],
+    ]
+    assert paramtitles == ['time_offset', 'c0', 'per', 'inc', 'limb_dark']
+    assert freenames == ['c0', 'c0_ch1', 'per']
+    assert updated.c0_ch1.values == ['c0_ch1', 1.0, 'free']
+    assert updated.inc_ch1.values == ['inc_ch1', 89.0, 'fixed']
+
+
+def test_make_longparamlist_prefers_wavelength_groups_and_requires_base():
+    """Wavelength-group parameters need a base channel and take precedence."""
+    params = _params(c0=(1.0, 'free'), c0_wl2=(2.0, 'free'))
+    meta = SimpleNamespace(multwhite=False, sharedp=True, wl_groups=[0, 2])
+
+    longparamlist, _, freenames, _ = s5_fit.make_longparamlist(
+        meta, params, chanrng=2
+    )
+
+    assert longparamlist == [['time_offset', 'c0'],
+                             ['time_offset', 'c0_wl2']]
+    assert freenames == ['c0', 'c0_wl2']
+
+    missing_base = _params(depth_wl2=(0.1, 'free'))
+    with pytest.raises(AssertionError, match='required for wl=0'):
+        s5_fit.make_longparamlist(meta, missing_base, chanrng=2)
+
+
+def test_group_variables_extracts_priors_and_independent_values():
+    """Fitter setup should separate free and independent values."""
+    params = _params(c0=(1.0, 'free', 0.0, 2.0, 'U'),
+                     per=(3.0, 'fixed'),
+                     depth=(0.1, 'shared', -1.0, 1.0, 'N'),
+                     limb_dark=('uniform', 'independent'))
+    component = _FlatModel(parameters=params, freenames=['c0', 'depth'])
+    model = models.CompositeModel([component])
+    model.freenames = ['c0', 'depth']
+
+    freepars, prior1, prior2, priortype, indep_vars = (
+        fitters.group_variables(model)
+    )
+
+    np.testing.assert_allclose(freepars, [1.0, 0.1])
+    np.testing.assert_allclose(prior1, [0.0, -1.0])
+    np.testing.assert_allclose(prior2, [2.0, 1.0])
+    np.testing.assert_array_equal(priortype, ['U', 'N'])
+    assert indep_vars['per'] == 3.0
+    assert indep_vars['limb_dark'] == 'uniform'
+
+
+def test_lightcurve_initialization_validates_shapes_and_scatter_mult():
+    """LightCurve construction validates shapes and pre-inflates errors."""
+    params = _params(scatter_mult=(2.0, 'free'),
+                     scatter_mult_ch1=(3.0, 'free'))
+    log = _Log()
+
+    lc = LightCurve(time=np.arange(5), flux=np.ones(5), channel=0,
+                    nchannel=2, log=log, longparamlist=[[], []],
+                    parameters=params,
+                    freenames=['scatter_mult', 'scatter_mult_ch1'],
+                    unc=np.full(5, 0.1), multwhite=True, nints=[2, 3])
+
+    assert lc.nchannel_fitted == 2
+    np.testing.assert_allclose(lc.unc_fit, [0.2, 0.2, 0.3, 0.3, 0.3])
+
+    with pytest.raises(ValueError, match='Time and flux'):
+        LightCurve(time=np.arange(2), flux=np.ones(3), channel=0, nchannel=1,
+                   log=log, longparamlist=[[]], parameters=Parameters(),
+                   freenames=[], unc=np.ones(2))
+
+
+def test_lightcurve_fit_selects_fitter_and_rejects_unknown(monkeypatch):
+    """Fit dispatch should call requested and reject invalid fitters."""
+    lc = LightCurve(time=np.arange(2), flux=np.ones(2), channel=0, nchannel=1,
+                    log=_Log(), longparamlist=[[]], parameters=Parameters(),
+                    freenames=[], unc=np.ones(2))
+    model = SimpleNamespace()
+    meta = SimpleNamespace()
+    fit_result = SimpleNamespace(name='fit-result')
+
+    monkeypatch.setattr(fitters, 'lsqfitter',
+                        lambda *args, **kwargs: fit_result)
+
+    lc.fit(model, meta, _Log(), fitter='lsq')
+    assert lc.results[0].name == 'fit-result'
+
+    with pytest.raises(ValueError, match='not a valid fitter'):
+        lc.fit(model, meta, _Log(), fitter='bogus')
+
+
+def test_initialize_emcee_walkers_stays_within_uniform_and_log_priors():
+    """emcee walkers should start inside uniform and log-uniform bounds."""
+    np.random.seed(1234)
+    meta = SimpleNamespace(run_nwalkers=12, verbose=False)
+    freepars = np.array([0.5, 10.0, 1.0])
+    prior1 = np.array([0.0, np.log(1.0), 1.0])
+    prior2 = np.array([1.0, np.log(100.0), 0.1])
+    priortype = np.array(['U', 'LU', 'N'])
+
+    pos, nwalkers = fitters.initialize_emcee_walkers(
+        meta, _Log(), ndim=3, lsq_sol=None, freepars=freepars.copy(),
+        prior1=prior1, prior2=prior2, priortype=priortype
+    )
+
+    assert nwalkers == 12
+    assert pos.shape == (12, 3)
+    assert np.all((pos[:, 0] >= 0.0) & (pos[:, 0] <= 1.0))
+    assert np.all((np.log(pos[:, 1]) >= np.log(1.0)) &
+                  (np.log(pos[:, 1]) <= np.log(100.0)))
+    assert np.all(pos[:, 1] > 0)
+
+
+def test_initialize_emcee_walkers_moves_boundary_start_to_midpoint():
+    """Walker initialization should recover when LSQ lands on a bound."""
+    np.random.seed(4321)
+    meta = SimpleNamespace(run_nwalkers=8, verbose=False)
+    freepars = np.array([1.0])
+    prior1 = np.array([0.0])
+    prior2 = np.array([1.0])
+    priortype = np.array(['U'])
+
+    pos, nwalkers = fitters.initialize_emcee_walkers(
+        meta, _Log(), ndim=1, lsq_sol=None, freepars=freepars,
+        prior1=prior1, prior2=prior2, priortype=priortype
+    )
+
+    assert nwalkers == 8
+    assert freepars[0] == pytest.approx(0.5)
+    assert np.all((pos[:, 0] >= 0.0) & (pos[:, 0] <= 1.0))
+
+
+def test_save_fit_writes_fitparams_and_stage5_table(monkeypatch, tmp_path):
+    """Fit saving should write parameters and S5 table arrays."""
+    params = _params(c0=(1.0, 'free', 0.0, 2.0, 'U'))
+    component = _FlatModel(parameters=params, freenames=['c0'],
+                           values=np.array([1.0, 1.0]))
+    model = models.CompositeModel([component], parameters=params)
+    model.time = np.array([0.0, 1.0])
+    lc = SimpleNamespace(white=False, share=False, channel=1, nchannel=10,
+                         fitted_channels=np.array([1]),
+                         time=np.array([0.0, 1.0]),
+                         flux=np.array([1.1, 0.9]),
+                         unc_fit=np.array([0.1, 0.2]))
+    meta = SimpleNamespace(outputdir=str(tmp_path)+'/', expand=1, spec_hw=3,
+                           bg_hw=7, eventlabel='evt',
+                           wave_low=np.array([1.0, 2.0]),
+                           wave_hi=np.array([1.5, 2.5]),
+                           multwhite=True, nints=[2])
+    captured = {}
+
+    def fake_savetable(filename, meta_arg, time, wavelength, bin_width,
+                       lcdata, lcerr, individual_models, model_lc,
+                       residuals):
+        captured['filename'] = filename
+        captured['time'] = np.array(time)
+        captured['wavelength'] = np.array(wavelength)
+        captured['bin_width'] = np.array(bin_width)
+        captured['lcdata'] = np.array(lcdata)
+        captured['lcerr'] = np.array(lcerr)
+        captured['individual_models'] = individual_models
+        captured['model_lc'] = np.array(model_lc)
+        captured['residuals'] = np.array(residuals)
+
+    monkeypatch.setattr(fitters.astropytable, 'savetable_S5',
+                        fake_savetable)
+    results = AstropyTable({'Parameter': ['c0'], 'Mean': [1.0]})
+
+    fitters.save_fit(meta, lc, model, 'lsq', results, ['c0'])
+
+    fitparams = tmp_path/'S5_lsq_fitparams_ch01.csv'
+    assert fitparams.exists()
+    assert meta.tab_filename_s5.endswith('S5_evt_ap3_bg7_Table_Save_ch01.txt')
+    assert captured['filename'] == meta.tab_filename_s5
+    np.testing.assert_allclose(captured['wavelength'], [2.25])
+    np.testing.assert_allclose(captured['bin_width'], [0.25])
+    np.testing.assert_allclose(captured['model_lc'], [1.0, 1.0])
+    np.testing.assert_allclose(captured['residuals'], [0.1, -0.1])
+
+
+def test_utils_rebin_spec_preserves_integrated_flux_for_constant_spectrum():
+    """Rebinning should preserve flux for a constant spectrum."""
+    wave = np.linspace(1.0, 5.0, 5)
+    flux = np.ones_like(wave)
+    wavnew = np.array([1.5, 2.5, 3.5, 4.5])
+
+    rebinned = utils.rebin_spec((wave, flux), wavnew, oversamp=100)
+
+    np.testing.assert_allclose(rebinned, np.ones(4), rtol=2e-2)
+
+
+def test_utils_filter_table_numeric_string_and_wildcard_filters():
+    """Table filtering should handle numeric ranges and wildcard names."""
+    table = Table({'Teff': [1000, 1500, 2000],
+                   'name': ['WASP-1', 'HAT-2', 'WASP-3']})
+
+    filtered = utils.filter_table(table, Teff=('>1200', '<=2000'),
+                                  name='WASP*')
+
+    assert list(filtered['name']) == ['WASP-3']
+    with pytest.raises(KeyError):
+        utils.filter_table(table, missing='==1')
+    with pytest.raises(ValueError):
+        utils.filter_table(table, Teff=['!1000'])
+
+
+def test_utils_find_closest_returns_indices_or_values_and_outside_none():
+    """Grid-neighbor lookup should support indices, values, and misses."""
+    axis = np.array([0.0, 1.0, 2.0, 3.0])
+
+    assert [arr.tolist() for arr in utils.find_closest(axis, 1.4, n=1)] == [
+        [1, 2]
+    ]
+    assert [arr.tolist() for arr in utils.find_closest(axis, 1.4, n=1,
+                                                       values=True)] == [
+        [1.0, 2.0]
+    ]
+    assert utils.find_closest(axis, 9.0) is None
+
+
+def test_utils_calc_zoom_color_gen_and_target_url():
+    assert utils.calc_zoom(4, np.array([1.0, 2.0, 3.0])) == pytest.approx(2.0)
+    colors = utils.color_gen(['#111111', '#222222'])
+    assert [next(colors), next(colors), next(colors)] == [
+        '#111111', '#222222', '#111111'
+    ]
+    assert utils.build_target_url('WASP 12 b').endswith('WASP%2012%20b/'
+                                                        'properties/')

--- a/tests/unit/test_s5_systematic_model_units.py
+++ b/tests/unit/test_s5_systematic_model_units.py
@@ -1,0 +1,187 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+os.environ.setdefault('MPLCONFIGDIR', '/tmp')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', 'src')))
+from eureka.S5_lightcurve_fitting import models
+from tests.unit.s5_model_helpers import _params
+
+
+def test_exp_ramp_model_matches_double_exponential_formula():
+    params = _params(r0=0.2, r1=0.5, r2=-0.1, r3=0.25)
+    model = models.ExpRampModel(parameters=params)
+    model.time = np.array([10.0, 11.0, 12.0])
+
+    result = model.eval()
+
+    t = np.array([0.0, 1.0, 2.0])
+    expected = 1 + 0.2*np.exp(-0.5*t) - 0.1*np.exp(-0.25*t)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_exp_ramp_model_respects_wavelength_specific_parameter_precedence():
+    """Systematics should use wavelength-group parameters when available."""
+    params = _params(r0=0.1, r1=1.0, r2=0.0, r3=0.0,
+                     r0_ch1=0.2, r0_wl2=0.4)
+    model = models.ExpRampModel(parameters=params, nchannel_fitted=1,
+                                fitted_channels=[1], wl_groups=[2])
+    model.time = np.array([0.0, 1.0])
+
+    result = model.eval(channel=1)
+
+    expected = 1 + 0.4*np.exp(-np.array([0.0, 1.0]))
+    np.testing.assert_allclose(result, expected)
+
+
+def test_step_model_applies_sorted_steps_and_ignores_zero_amplitudes():
+    params = _params(step1=-0.1, steptime1=1.0,
+                     step2=0.5, steptime2=2.0,
+                     step3=0.0, steptime3=0.5)
+    model = models.StepModel(parameters=params)
+    model.time = np.array([10.0, 11.0, 12.0, 13.0])
+
+    result = model.eval()
+
+    np.testing.assert_allclose(result, [1.0, 0.9, 1.4, 1.4])
+
+
+def test_step_model_uses_channel_specific_parameters_in_multwhite_mode():
+    """Protect local time slicing and channel parameters in multwhite fits."""
+    params = _params(step1=0.1, steptime1=1.0,
+                     step1_ch1=0.5, steptime1_ch1=2.0)
+    model = models.StepModel(parameters=params, multwhite=True,
+                             nints=[3, 3], nchannel_fitted=2,
+                             fitted_channels=[0, 1])
+    model.time = np.array([0.0, 1.0, 2.0, 10.0, 11.0, 12.0])
+
+    result = model.eval()
+
+    np.testing.assert_allclose(result, [1.0, 1.1, 1.1, 1.0, 1.0, 1.5])
+
+
+def test_lorentzian_model_matches_symmetric_formula():
+    params = _params(lor_amp=0.4, lor_hwhm=2.0, lor_t0=0.0,
+                     lor_power=2.0)
+    model = models.LorentzianModel(parameters=params)
+    model.time = np.array([-1.0, 0.0, 1.0])
+
+    result = model.eval()
+
+    t = np.array([-1.0, 0.0, 1.0])
+    expected = 1 + 0.4/(1 + (2*t/2.0)**2)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_lorentzian_model_matches_asymmetric_amplitude_width_formula():
+    params = _params(lor_amp_lhs=0.2, lor_amp_rhs=0.6,
+                     lor_hwhm_lhs=1.0, lor_hwhm_rhs=2.0,
+                     lor_t0=0.0, lor_power=2.0)
+    model = models.LorentzianModel(parameters=params)
+    model.time = np.array([-1.0, 0.0, 2.0])
+
+    result = model.eval()
+
+    expected = np.array([
+        1 + 0.2/(1 + 1.0**2),
+        1 + 0.2,
+        1 + 0.2 - 0.6 + 0.6/(1 + 1.0**2),
+    ])
+    np.testing.assert_allclose(result, expected)
+
+
+def test_lorentzian_model_rejects_ambiguous_parameterization():
+    """Ambiguous symmetric/asymmetric Lorentzian inputs should fail early."""
+    params = _params(lor_amp=0.4, lor_amp_lhs=0.2, lor_hwhm=2.0)
+    model = models.LorentzianModel(parameters=params)
+    model.time = np.array([0.0])
+
+    with pytest.raises(ValueError, match='Ambiguous Lorentzian'):
+        model.eval()
+
+
+def test_centroid_model_matches_mean_centered_linear_decorrelation():
+    params = _params(xpos=0.3)
+    centroid = np.array([1.0, 2.0, 4.0])
+    model = models.CentroidModel('xpos', parameters=params)
+    model.centroid = centroid
+
+    result = model.eval()
+
+    expected = 1 + (centroid-centroid.mean())*0.3
+    np.testing.assert_allclose(result, expected)
+
+
+def test_centroid_model_validates_axis_name():
+    with pytest.raises(ValueError, match='CentroidModel requires'):
+        models.CentroidModel('angle')
+
+
+def test_hst_ramp_model_matches_orbit_modulo_formula():
+    params = _params(h0=0.2, h1=0.5, h2=0.1, h3=-0.01, h4=2.0, h5=0.25)
+    model = models.HSTRampModel(parameters=params)
+    model.time = np.array([5.0, 5.5, 6.25])
+
+    result = model.eval()
+
+    t = np.array([0.0, 0.5, 1.25])
+    t_batch = (t-0.25) % 2.0
+    expected = 1 + 0.2*np.exp(-0.5*t_batch) + 0.1*t_batch - 0.01*t_batch**2
+    np.testing.assert_allclose(result, expected)
+
+
+def test_damped_oscillator_model_matches_decay_formula_and_pre_t0_unity():
+    """The oscillator must remain unity before its configured start time."""
+    params = _params(osc_amp=0.2, osc_amp_decay=0.1,
+                     osc_per=2.0, osc_per_decay=0.0,
+                     osc_t0=1.0, osc_t1=1.0)
+    model = models.DampedOscillatorModel(parameters=params)
+    model.time = np.array([0.0, 1.0, 1.5, 2.0])
+
+    result = model.eval()
+
+    t = np.array([0.0, 1.0, 1.5, 2.0])
+    amp = 0.2*np.exp(-0.1*(t-1.0))
+    expected = 1 + amp*np.sin(2*np.pi*(t-1.0)/2.0)
+    expected[t < 1.0] = 1.0
+    np.testing.assert_allclose(result, expected)
+
+
+def test_polynomial_model_evaluates_each_multwhite_channel_locally():
+    params = _params(c0=1.0, c1=0.1, c1_ch1=0.5)
+    model = models.PolynomialModel(parameters=params, multwhite=True,
+                                   nints=[3, 3], nchannel_fitted=2,
+                                   fitted_channels=[0, 1])
+    model.time = np.array([0.0, 1.0, 2.0, 10.0, 11.0, 12.0])
+
+    result = model.eval()
+
+    expected = np.array([0.9, 1.0, 1.1, 0.5, 1.0, 1.5])
+    np.testing.assert_allclose(result, expected)
+
+
+def test_common_mode_model_reads_file_and_applies_quadratic_terms(tmp_path):
+    """Common-mode correction should read files and apply polynomial terms."""
+    from astropy.io import ascii
+    from astropy.table import QTable
+
+    common_mode_file = tmp_path/'common_mode.ecsv'
+    ascii.write(QTable({'white_model': [0.8, 1.0, 1.4]}),
+                common_mode_file, format='ecsv')
+    meta = SimpleNamespace(common_mode_file=str(common_mode_file),
+                           common_mode_name='white_model', verbose=False)
+    log = SimpleNamespace(writelog=lambda *args, **kwargs: None)
+    params = _params(cm1=0.5, cm2=0.25)
+    model = models.CommonModeModel(meta, log, parameters=params)
+    model.time = np.array([0.0, 1.0, 2.0])
+
+    result = model.eval()
+
+    cm_flux = np.array([0.8, 1.0, 1.4])
+    cm_flux -= cm_flux.mean()
+    expected = 1 + 0.5*cm_flux + 0.25*cm_flux**2
+    np.testing.assert_allclose(result, expected)

--- a/tests/unit/test_s5_transit_model_units.py
+++ b/tests/unit/test_s5_transit_model_units.py
@@ -1,0 +1,301 @@
+import os
+import sys
+
+import numpy as np
+import pytest
+
+os.environ.setdefault('MPLCONFIGDIR', '/tmp')
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', 'src')))
+from types import SimpleNamespace
+
+from eureka.S5_lightcurve_fitting import models
+from eureka.S5_lightcurve_fitting.models.AstroModel import (
+    PlanetParams, get_ecl_midpt,
+)
+from tests.unit.s5_model_helpers import (
+    _params, _transit_model, _transit_params,
+)
+
+
+def test_batman_transit_model_zero_radius_is_unity():
+    params = _params(limb_dark='uniform', rp=0.0, per=2.0, t0=0.0,
+                     inc=89.0, a=10.0, ecc=0.0, w=90.0)
+    model = models.BatmanTransitModel(parameters=params,
+                                      paramtitles=list(params.dict.keys()),
+                                      num_planets=1, ld_from_S4=False,
+                                      ld_from_file=False)
+    model.time = np.array([-0.1, 0.0, 0.1])
+
+    result = model.eval()
+
+    np.testing.assert_allclose(result, np.ones(3))
+
+
+def test_batman_transit_model_invalid_geometry_returns_penalty():
+    """Invalid transit geometry should return penalties rather than crash."""
+    params = _params(limb_dark='uniform', rp=0.1, per=2.0, t0=0.0,
+                     inc=95.0, a=10.0, ecc=0.0, w=90.0)
+    model = models.BatmanTransitModel(parameters=params,
+                                      paramtitles=list(params.dict.keys()),
+                                      num_planets=1, ld_from_S4=False,
+                                      ld_from_file=False)
+    model.time = np.array([0.0, 0.1])
+
+    result = model.eval()
+
+    np.testing.assert_allclose(result, [1e6, 1e6])
+
+
+def test_batman_eclipse_model_zero_planet_flux_is_zero():
+    params = _params(limb_dark='uniform', rp=0.1, fp=0.0, per=2.0, t0=0.0,
+                     t_secondary=1.0, inc=89.0, a=10.0, ecc=0.0, w=90.0)
+    log = SimpleNamespace(writelog=lambda *args, **kwargs: None)
+    model = models.BatmanEclipseModel(parameters=params,
+                                      paramtitles=list(params.dict.keys()),
+                                      num_planets=1, compute_ltt=False,
+                                      log=log)
+    model.time = np.array([0.9, 1.0, 1.1])
+
+    result = model.eval()
+
+    np.testing.assert_allclose(result, np.zeros(3))
+
+
+@pytest.mark.parametrize('ecc,w', [
+    (0.0, 90.0),
+    (0.03, 45.0),
+    (0.05, 135.0),
+])
+def test_poet_eclipse_model_matches_batman_for_eccentric_orbits(ecc, w):
+    """Benchmark POET eclipse geometry against batman, including small ecc."""
+    params = _params(limb_dark='uniform', rp=0.08, fp=0.01, per=3.0,
+                     t0=0.0, inc=88.5, a=12.0, ecc=ecc, w=w)
+    log = SimpleNamespace(writelog=lambda *args, **kwargs: None)
+    ref_model = models.BatmanTransitModel(
+        parameters=params, paramtitles=list(params.dict.keys()),
+        num_planets=1, ld_from_S4=False, ld_from_file=False
+    )
+    t_secondary = get_ecl_midpt(PlanetParams(ref_model))
+    time = np.linspace(t_secondary-0.12, t_secondary+0.12, 61)
+    batman = models.BatmanEclipseModel(
+        parameters=params, paramtitles=list(params.dict.keys()),
+        num_planets=1, compute_ltt=False, log=log
+    )
+    poet = models.PoetEclipseModel(
+        parameters=params, paramtitles=list(params.dict.keys()),
+        longparamlist=[list(params.dict.keys())],
+        num_planets=1, compute_ltt=False, log=log
+    )
+    batman.time = time
+    poet.time = time
+
+    np.testing.assert_allclose(poet.eval(), batman.eval(), atol=1e-10, rtol=0)
+
+
+def test_astro_model_combines_stellar_transit_eclipse_and_phase_components():
+    """AstroModel combines components with Eureka flux convention."""
+    class Component:
+        def __init__(self, name, values):
+            self.name = name
+            self.values = np.ma.array(values)
+
+        def eval(self, channel=None, pid=None, **kwargs):
+            return self.values
+
+    stellar = Component('stellar ramp', [2.0, 3.0])
+    transit = Component('transit', [0.9, 0.8])
+    eclipse = Component('eclipse', [0.1, 0.2])
+    phase = Component('phase curve', [1.5, 2.0])
+    model = models.AstroModel([stellar, transit, eclipse, phase],
+                              num_planets=1)
+    model.time = np.array([0.0, 1.0])
+
+    result = model.eval()
+
+    expected = np.array([2.0, 3.0])*np.array([0.9, 0.8])
+    expected += np.array([0.1, 0.2])*np.array([1.5, 2.0])
+    np.testing.assert_allclose(result, expected)
+
+
+def test_gp_model_normalizes_kernel_inputs_and_masks_zero_residual_output():
+    """GP inputs should normalize consistently and preserve masked samples."""
+    params = _params(A=np.log(4.0), m=np.log(2.0))
+    lc = SimpleNamespace(flux=np.ones(4), unc=np.full(4, 0.1),
+                         unc_fit=np.full(4, 0.1))
+    model = models.GPModel(['Matern32'], ['time'], lc,
+                           gp_code_name='celerite', parameters=params,
+                           normalize=True)
+    model.time = np.ma.array([0.0, 1.0, 2.0, 3.0],
+                             mask=[False, False, True, False])
+
+    model.setup_inputs()
+    result = model.eval(np.ones(4))
+
+    expected_inputs = (model.time-model.time.mean())/model.time.std()
+    np.testing.assert_allclose(model.kernel_inputs[0][0], expected_inputs)
+    np.testing.assert_allclose(result[~result.mask], 0.0, atol=1e-12)
+    np.testing.assert_array_equal(np.ma.getmaskarray(result),
+                                  [False, False, True, False])
+
+
+def test_gp_model_rejects_unsupported_celerite_kernel_configuration():
+    """Unsupported celerite kernels should fail before sampler execution."""
+    lc = SimpleNamespace(flux=np.ones(3), unc=np.full(3, 0.1),
+                         unc_fit=np.full(3, 0.1))
+
+    with pytest.raises(AssertionError, match='single kernel'):
+        models.GPModel(['Matern32', 'Matern32'], ['time'], lc,
+                       gp_code_name='celerite')
+
+    with pytest.raises(AssertionError, match='supports only'):
+        models.GPModel(['ExpSquared'], ['time'], lc, gp_code_name='celerite')
+
+
+def test_gp_model_loglikelihood_is_finite_for_simple_celerite_case():
+    params = _params(A=np.log(0.01), m=np.log(1.0))
+    lc = SimpleNamespace(flux=np.array([1.0, 1.01, 0.99, 1.0]),
+                         unc=np.full(4, 0.1), unc_fit=np.full(4, 0.1))
+    model = models.GPModel(['Matern32'], ['time'], lc,
+                           gp_code_name='celerite', parameters=params)
+    model.time = np.array([0.0, 1.0, 2.0, 3.0])
+
+    loglike = model.loglikelihood(np.ones(4))
+
+    assert np.isfinite(loglike)
+
+
+@pytest.mark.parametrize('ecc,w', [
+    (0.0, 90.0),
+    (0.03, 45.0),
+    (0.05, 135.0),
+    (0.08, -60.0),
+])
+def test_poet_transit_model_matches_batman_for_eccentric_orbits(ecc, w):
+    """Benchmark POET transits against batman geometry conventions."""
+    time = np.linspace(-0.12, 0.12, 61)
+    params = _transit_params(ecc=ecc, w=w)
+
+    batman_lc = _transit_model(models.BatmanTransitModel, params, time)
+    poet_lc = _transit_model(models.PoetTransitModel, params, time)
+
+    np.testing.assert_allclose(poet_lc, batman_lc, atol=1e-10, rtol=0)
+
+
+@pytest.mark.parametrize('ecc,w', [
+    (0.0, 90.0),
+    (0.03, 45.0),
+    (0.05, 135.0),
+    (0.08, -60.0),
+])
+def test_fleck_transit_model_matches_batman_for_spotless_eccentric_orbits(
+        ecc, w):
+    """A spotless Fleck transit should reduce to the batman light curve."""
+    time = np.linspace(-0.12, 0.12, 61)
+    params = _transit_params(ecc=ecc, w=w)
+
+    batman_lc = _transit_model(models.BatmanTransitModel, params, time)
+    fleck_lc = _transit_model(models.FleckTransitModel, params, time)
+
+    np.testing.assert_allclose(fleck_lc, batman_lc, atol=1e-6, rtol=0)
+
+
+@pytest.mark.parametrize('ecc,w', [
+    (0.0, 90.0),
+    (0.03, 45.0),
+    (0.05, 135.0),
+    (0.08, -60.0),
+])
+def test_harmonica_transit_model_matches_batman_for_eccentric_orbits(ecc, w):
+    """Harmonica with no map terms should match batman transit geometry."""
+    time = np.linspace(-0.12, 0.12, 61)
+    params = _transit_params(ecc=ecc, w=w)
+
+    batman_lc = _transit_model(models.BatmanTransitModel, params, time)
+    harmonica_lc = _transit_model(models.HarmonicaTransitModel, params, time)
+
+    np.testing.assert_allclose(harmonica_lc, batman_lc, atol=2e-6, rtol=0)
+
+
+def test_harmonica_transmission_coefficients_change_transit_shape():
+    """Non-zero Harmonica map coefficients should affect transit shape."""
+    time = np.linspace(-0.08, 0.08, 81)
+    base_params = _transit_params(ecc=0.0, w=90.0)
+    map_params = _transit_params(ecc=0.0, w=90.0)
+    map_params.a1 = 0.02, 'free'
+    map_params.b1 = -0.01, 'free'
+    map_params.a2 = 0.01, 'free'
+    map_params.b2 = 0.005, 'free'
+
+    base_lc = _transit_model(models.HarmonicaTransitModel, base_params, time)
+    map_lc = _transit_model(models.HarmonicaTransitModel, map_params, time)
+
+    assert np.max(np.abs(map_lc-base_lc)) > 5e-4
+
+
+def test_fleck_spot_on_transit_chord_changes_lightcurve():
+    """Check Fleck spot latitude convention using a non-equatorial chord."""
+    time = np.linspace(-0.08, 0.08, 81)
+    spotless = _transit_params(ecc=0.0, w=90.0)
+    spotless.inc.value = 88.5
+    spotted = _transit_params(ecc=0.0, w=90.0)
+    spotted.inc.value = 88.5
+    chord_lat = -np.degrees(np.arcsin(spotted.a.value *
+                                      np.cos(np.deg2rad(spotted.inc.value))))
+    spotted.spotcon = 0.5, 'free'
+    spotted.spotrad = 0.04, 'free'
+    spotted.spotlat = chord_lat, 'free'
+    spotted.spotlon = 0.0, 'free'
+
+    spotless_lc = _transit_model(models.FleckTransitModel, spotless, time)
+    spotted_lc = _transit_model(models.FleckTransitModel, spotted, time)
+
+    assert np.max(np.abs(spotted_lc-spotless_lc)) > 5e-4
+    assert spotted_lc[len(time)//2] > spotless_lc[len(time)//2]
+
+
+def test_fleck_invalid_spot_geometry_returns_penalty():
+    """Invalid spot geometry should produce the standard fitting penalty."""
+    time = np.linspace(-0.02, 0.02, 5)
+    params = _transit_params(ecc=0.0, w=90.0)
+    params.spotcon = 0.5, 'free'
+    params.spotrad = 1.5, 'free'
+    params.spotlat = 0.0, 'free'
+    params.spotlon = 0.0, 'free'
+
+    result = _transit_model(models.FleckTransitModel, params, time)
+
+    np.testing.assert_allclose(result, np.full(time.shape, 1e6))
+
+
+def test_catwoman_transit_model_matches_batman_for_circular_equal_radii():
+    """Equal-radius Catwoman planets should match circular batman transits."""
+    time = np.linspace(-0.12, 0.12, 61)
+    params = _transit_params(ecc=0.0, w=90.0)
+    params.rp2 = 0.08, 'free'
+    params.phi = 90.0, 'free'
+    batman_lc = _transit_model(models.BatmanTransitModel, params, time)
+    catwoman = models.CatwomanTransitModel(
+        parameters=params, paramtitles=list(params.dict.keys()),
+        longparamlist=[list(params.dict.keys())],
+        num_planets=1, ld_from_S4=False, ld_from_file=False,
+        max_err=0.001, fac=0.001
+    )
+    catwoman.time = time
+
+    catwoman_lc = catwoman.eval()
+
+    np.testing.assert_allclose(catwoman_lc, batman_lc, atol=1e-7, rtol=0)
+
+
+def test_catwoman_transit_model_requires_second_radius_parameter():
+    """Catwoman-specific geometry requires the second radius parameter."""
+    params = _transit_params(ecc=0.0, w=90.0)
+
+    with pytest.raises(AssertionError, match='rp2'):
+        models.CatwomanTransitModel(
+            parameters=params, paramtitles=list(params.dict.keys()),
+            longparamlist=[list(params.dict.keys())],
+            num_planets=1, ld_from_S4=False, ld_from_file=False,
+            max_err=0.001, fac=0.001
+        )


### PR DESCRIPTION
## Summary

This PR adds focused unit-test coverage for lower-level Eureka helpers and S5 model plumbing, while also making a few small code changes that improve testability and pin existing behavior.

## Main changes

- Adds a new `tests/unit/` suite covering:
  - selected `eureka.lib` helpers
  - Stage 3 helper behavior
  - Stage 4 wavelength-bin and spectral-lightcurve helpers
  - S5 model/helper plumbing
  - S5 systematic, GP/phase, and transit model behavior
- Refactors Stage 4 wavelength-bin construction into `compute_wavelength_bins`.
- Refactors Stage 4 spectral light-curve averaging/error propagation into `compute_spectral_lightcurve`.
- Updates pytest collection ordering so unit tests are prioritized while preserving the rest of the suite order.
- Adds small behavior fixes covered by the new tests, including:
  - using `np.prod` instead of deprecated `np.product`
  - avoiding in-place mutation of the input mask in `sigrej`
  - copying shifts before modifying them in `roll_columns`
  - applying `meta.gain` consistently in `dn2electrons`
  - tightening a wavelength-only S5 parameter error path
  - fixing a walker-parameter indexing path in `initialize_emcee_walkers`
  - adding eccentric-orbit support for POET-related transit modeling paths