### PR TITLE
Fix nested output directories causing FileNotFoundError on multi-aperture runs

### DIFF
--- a/src/eureka/S3_data_reduction/s3_reduce.py
+++ b/src/eureka/S3_data_reduction/s3_reduce.py
@@ -119,6 +119,9 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
     # create directories to store data
     # run_s3 used to make sure we're always looking at the right run for
     # each aperture/annulus pair
+    # Cache the clean base dir since meta.outputdir_raw gets overwritten
+    # below each time meta.outputdir is set to a per-pair directory
+    base_outputdir_raw = meta.outputdir_raw
     meta.run_s3 = None
     for spec_hw_val in meta.spec_hw_range:
         for bg_hw_val in meta.bg_hw_range:
@@ -126,8 +129,9 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
             # Directory structure should not use expanded HW values
             spec_hw_val, bg_hw_val = util.get_unexpanded_hws(
                 meta.expand, spec_hw_val, bg_hw_val)
-            meta.run_s3 = util.makedirectory(meta, 'S3', meta.run_s3,
-                                             ap=spec_hw_val, bg=bg_hw_val)
+            meta.run_s3 = util.makedirectory(
+                meta, 'S3', meta.run_s3, ap=spec_hw_val, bg=bg_hw_val,
+                outputdir_raw=base_outputdir_raw)
 
     # begin process
     for spec_hw_val in meta.spec_hw_range:
@@ -140,9 +144,9 @@ def reduce(eventlabel, ecf_path=None, s2_meta=None, input_meta=None):
             # Directory structure should not use expanded HW values
             spec_hw_val, bg_hw_val = util.get_unexpanded_hws(
                 meta.expand, spec_hw_val, bg_hw_val)
-            meta.outputdir = util.pathdirectory(meta, 'S3', meta.run_s3,
-                                                ap=spec_hw_val,
-                                                bg=bg_hw_val)
+            meta.outputdir = util.pathdirectory(
+                meta, 'S3', meta.run_s3, ap=spec_hw_val, bg=bg_hw_val,
+                outputdir_raw=base_outputdir_raw)
 
             event_ap_bg = (meta.eventlabel+"_ap"+str(spec_hw_val) +
                            '_bg' + str(bg_hw_val))

--- a/src/eureka/S4_generate_lightcurves/s4_genLC.py
+++ b/src/eureka/S4_generate_lightcurves/s4_genLC.py
@@ -91,14 +91,17 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
     meta = me.filter_allapers_inputdir(meta)
 
     # Create directories for Stage 4 outputs
+    # Cache the clean base dir since meta.outputdir_raw gets overwritten
+    # below each time meta.outputdir is set to a per-pair directory
+    base_outputdir_raw = meta.outputdir_raw
     meta.run_s4 = None
     for spec_hw_val, bg_hw_val in me.get_allapers_pairs(meta):
         # Directory structure should not use expanded HW values
         spec_hw_val, bg_hw_val = util.get_unexpanded_hws(
             meta.expand, spec_hw_val, bg_hw_val)
-        meta.run_s4 = util.makedirectory(meta, 'S4', meta.run_s4,
-                                         ap=spec_hw_val,
-                                         bg=bg_hw_val)
+        meta.run_s4 = util.makedirectory(
+            meta, 'S4', meta.run_s4, ap=spec_hw_val, bg=bg_hw_val,
+            outputdir_raw=base_outputdir_raw)
 
     allapers_pairs = me.get_allapers_pairs(meta)
     for spec_hw_val in meta.spec_hw_range:
@@ -123,9 +126,9 @@ def genlc(eventlabel, ecf_path=None, s3_meta=None, input_meta=None):
                 meta.expand, spec_hw_val, bg_hw_val)
 
             # Get directory for Stage 4 processing outputs
-            meta.outputdir = util.pathdirectory(meta, 'S4', meta.run_s4,
-                                                ap=spec_hw_val,
-                                                bg=bg_hw_val)
+            meta.outputdir = util.pathdirectory(
+                meta, 'S4', meta.run_s4, ap=spec_hw_val, bg=bg_hw_val,
+                outputdir_raw=base_outputdir_raw)
 
             # Copy existing S3 log file and resume log
             meta.s4_logname = meta.outputdir + 'S4_' + meta.eventlabel + ".log"

--- a/src/eureka/S5_lightcurve_fitting/s5_fit.py
+++ b/src/eureka/S5_lightcurve_fitting/s5_fit.py
@@ -78,13 +78,16 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
         chanrng = meta.nspecchan
 
     # Create directories for Stage 5 outputs
+    # Cache the clean base dir since meta.outputdir_raw gets overwritten
+    # below each time meta.outputdir is set to a per-pair directory
+    base_outputdir_raw = meta.outputdir_raw
     meta.run_s5 = None
     for spec_hw_val, bg_hw_val in me.get_allapers_pairs(meta):
         spec_hw_val, bg_hw_val = util.get_unexpanded_hws(
             meta.expand, spec_hw_val, bg_hw_val)
-        meta.run_s5 = util.makedirectory(meta, 'S5', meta.run_s5,
-                                         ap=spec_hw_val,
-                                         bg=bg_hw_val)
+        meta.run_s5 = util.makedirectory(
+            meta, 'S5', meta.run_s5, ap=spec_hw_val, bg=bg_hw_val,
+            outputdir_raw=base_outputdir_raw)
 
     allapers_pairs = me.get_allapers_pairs(meta)
     for spec_hw_val in meta.spec_hw_range:
@@ -153,9 +156,9 @@ def fitlc(eventlabel, ecf_path=None, s4_meta=None, input_meta=None):
             spec_hw_val, bg_hw_val = util.get_unexpanded_hws(
                 meta.expand, spec_hw_val, bg_hw_val)
             # Get the directory for Stage 5 processing outputs
-            meta.outputdir = util.pathdirectory(meta, 'S5', meta.run_s5,
-                                                ap=spec_hw_val,
-                                                bg=bg_hw_val)
+            meta.outputdir = util.pathdirectory(
+                meta, 'S5', meta.run_s5, ap=spec_hw_val, bg=bg_hw_val,
+                outputdir_raw=base_outputdir_raw)
 
             # Copy existing S4 log file and resume log
             meta.s5_logname = meta.outputdir + 'S5_' + meta.eventlabel + ".log"

--- a/src/eureka/S6_planet_spectra/s6_spectra.py
+++ b/src/eureka/S6_planet_spectra/s6_spectra.py
@@ -89,14 +89,17 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
         meta.bg_hw_range = [meta.bg_hw, ]
 
     # Create directories for Stage 6 outputs
+    # Cache the clean base dir since meta.outputdir_raw gets overwritten
+    # below each time meta.outputdir is set to a per-pair directory
+    base_outputdir_raw = meta.outputdir_raw
     meta.run_s6 = None
     for spec_hw_val, bg_hw_val in me.get_allapers_pairs(meta):
         # Directory structure should not use expanded HW values
         spec_hw_val, bg_hw_val = util.get_unexpanded_hws(
             meta.expand, spec_hw_val, bg_hw_val)
-        meta.run_s6 = util.makedirectory(meta, 'S6', meta.run_s6,
-                                         ap=spec_hw_val,
-                                         bg=bg_hw_val)
+        meta.run_s6 = util.makedirectory(
+            meta, 'S6', meta.run_s6, ap=spec_hw_val, bg=bg_hw_val,
+            outputdir_raw=base_outputdir_raw)
 
     allapers_pairs = me.get_allapers_pairs(meta)
     for spec_hw_val in meta.spec_hw_range:
@@ -120,9 +123,9 @@ def plot_spectra(eventlabel, ecf_path=None, s5_meta=None, input_meta=None):
             spec_hw_val, bg_hw_val = util.get_unexpanded_hws(
                 meta.expand, spec_hw_val, bg_hw_val)
             # Get the directory for Stage 6 processing outputs
-            meta.outputdir = util.pathdirectory(meta, 'S6', meta.run_s6,
-                                                ap=spec_hw_val,
-                                                bg=bg_hw_val)
+            meta.outputdir = util.pathdirectory(
+                meta, 'S6', meta.run_s6, ap=spec_hw_val, bg=bg_hw_val,
+                outputdir_raw=base_outputdir_raw)
 
             # Copy existing S5 log file and resume log
             meta.s6_logname = meta.outputdir+'S6_'+meta.eventlabel+'.log'

--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -323,7 +323,7 @@ def check_nans(data, mask, log, name='', mute=True):
     return mask
 
 
-def makedirectory(meta, stage, counter=None, **kwargs):
+def makedirectory(meta, stage, counter=None, outputdir_raw=None, **kwargs):
     """Creates a directory for the current stage.
 
     Parameters
@@ -335,6 +335,13 @@ def makedirectory(meta, stage, counter=None, **kwargs):
     counter : int; optional
         The run number if you want to force a particular run number.
         Defaults to None which automatically finds the run number.
+    outputdir_raw : str; optional
+        The stage's base output directory relative to topdir. Defaults to
+        None, in which case meta.outputdir_raw is used. Callers looping over
+        multiple aperture/annulus pairs on the same meta object should pass
+        this explicitly, since meta.outputdir_raw gets overwritten as a side
+        effect of assigning meta.outputdir to the per-pair directory returned
+        by this function on a previous iteration.
     **kwargs : dict
         Additional key,value pairs to add to the folder name
         (e.g. {'ap': 4, 'bg': 10}).
@@ -344,9 +351,12 @@ def makedirectory(meta, stage, counter=None, **kwargs):
     run : int
         The run number
     """
+    if outputdir_raw is None:
+        outputdir_raw = meta.outputdir_raw
+
     # This code allows the input and output files to be stored outside
     # of the Eureka! folder
-    rootdir = os.path.join(meta.topdir, *meta.outputdir_raw.split(os.sep))
+    rootdir = os.path.join(meta.topdir, *outputdir_raw.split(os.sep))
     if rootdir[-1] != os.sep:
         rootdir += os.sep
 
@@ -390,7 +400,8 @@ def makedirectory(meta, stage, counter=None, **kwargs):
     return counter
 
 
-def pathdirectory(meta, stage, run, old_datetime=None, **kwargs):
+def pathdirectory(meta, stage, run, old_datetime=None, outputdir_raw=None,
+                  **kwargs):
     """Finds the directory for the requested stage, run, and datetime
     (or old_datetime).
 
@@ -405,6 +416,13 @@ def pathdirectory(meta, stage, run, old_datetime=None, **kwargs):
     old_datetime : str; optional
         The date that a previous run was made (for looking up old data).
         Defaults to None in which case meta.datetime is used instead.
+    outputdir_raw : str; optional
+        The stage's base output directory relative to topdir. Defaults to
+        None, in which case meta.outputdir_raw is used. Callers looping over
+        multiple aperture/annulus pairs on the same meta object should pass
+        this explicitly, since meta.outputdir_raw gets overwritten as a side
+        effect of assigning meta.outputdir to the per-pair directory returned
+        by this function on a previous iteration.
     **kwargs : dict
         Additional key,value pairs to add to the folder name
         (e.g. {'ap': 4, 'bg': 10}).
@@ -419,9 +437,12 @@ def pathdirectory(meta, stage, run, old_datetime=None, **kwargs):
     else:
         datetime = meta.datetime
 
+    if outputdir_raw is None:
+        outputdir_raw = meta.outputdir_raw
+
     # This code allows the input and output files to be stored outside
     # of the Eureka! folder
-    rootdir = os.path.join(meta.topdir, *meta.outputdir_raw.split(os.sep))
+    rootdir = os.path.join(meta.topdir, *outputdir_raw.split(os.sep))
     if rootdir[-1] != os.sep:
         rootdir += os.sep
 

--- a/tests/test_outputdir_raw.py
+++ b/tests/test_outputdir_raw.py
@@ -1,0 +1,69 @@
+import os
+import sys
+
+sys.path.insert(0, '..'+os.sep+'src'+os.sep)
+from eureka.lib import util
+from eureka.lib.readECF import MetaClass
+
+EVENTLABEL = 'testevent'
+
+
+def _make_meta(tmp_path):
+    # Set topdir before outputdir so the __setattr__ join logic in
+    # MetaClass triggers exactly as it does when reading a real ECF
+    meta = MetaClass()
+    meta.eventlabel = EVENTLABEL
+    meta.datetime = '2026-01-01'
+    meta.topdir = str(tmp_path)+os.sep
+    meta.outputdir = 'Stage3'
+    return meta
+
+
+def test_pathdirectory_without_base_reproduces_nesting_bug(tmp_path):
+    """Documents the hazard: reusing meta.outputdir_raw across repeated
+    meta.outputdir assignments (the old call pattern) nests each new
+    aperture/annulus directory inside the previous one."""
+    meta = _make_meta(tmp_path)
+
+    run = util.makedirectory(meta, 'S3', None, ap=4, bg=10)
+    outputdir1 = util.pathdirectory(meta, 'S3', run, ap=4, bg=10)
+    meta.outputdir = outputdir1
+
+    run = util.makedirectory(meta, 'S3', run, ap=6, bg=14)
+    outputdir2 = util.pathdirectory(meta, 'S3', run, ap=6, bg=14)
+
+    assert outputdir1.rstrip(os.sep) in outputdir2
+
+
+def test_pathdirectory_with_explicit_base_stays_flat(tmp_path):
+    """Passing the cached base outputdir_raw (as s3_reduce.py, s4_genLC.py,
+    s5_fit.py, and s6_spectra.py now do) keeps every aperture/annulus
+    directory a flat sibling, regardless of prior meta.outputdir mutation."""
+    meta = _make_meta(tmp_path)
+    base_outputdir_raw = meta.outputdir_raw
+
+    run = util.makedirectory(meta, 'S3', None, ap=4, bg=10,
+                             outputdir_raw=base_outputdir_raw)
+    outputdir1 = util.pathdirectory(meta, 'S3', run, ap=4, bg=10,
+                                    outputdir_raw=base_outputdir_raw)
+    meta.outputdir = outputdir1
+
+    run = util.makedirectory(meta, 'S3', run, ap=6, bg=14,
+                             outputdir_raw=base_outputdir_raw)
+    outputdir2 = util.pathdirectory(meta, 'S3', run, ap=6, bg=14,
+                                    outputdir_raw=base_outputdir_raw)
+    meta.outputdir = outputdir2
+
+    run = util.makedirectory(meta, 'S3', run, ap=8, bg=18,
+                             outputdir_raw=base_outputdir_raw)
+    outputdir3 = util.pathdirectory(meta, 'S3', run, ap=8, bg=18,
+                                    outputdir_raw=base_outputdir_raw)
+
+    assert outputdir1.rstrip(os.sep) not in outputdir2
+    assert outputdir2.rstrip(os.sep) not in outputdir3
+    assert (os.path.dirname(os.path.dirname(outputdir1.rstrip(os.sep))) ==
+           os.path.dirname(os.path.dirname(outputdir2.rstrip(os.sep))) ==
+           os.path.dirname(os.path.dirname(outputdir3.rstrip(os.sep))))
+    assert os.path.exists(outputdir1)
+    assert os.path.exists(outputdir2)
+    assert os.path.exists(outputdir3)


### PR DESCRIPTION
## Bug

`MetaClass.__setattr__` (`src/eureka/lib/readECF.py`) auto-derives
`outputdir_raw` from whatever `outputdir` is assigned:

```python
elif item == 'outputdir' and hasattr(self, 'topdir'):
    if self.topdir in value:
        value = value.replace(self.topdir, '')
    self.outputdir_raw = os.path.join(value, '')
    value = os.path.join(self.topdir, *value.split(os.sep))
```

Stages 3/4/5/6 reuse a single `meta` object across their loop over
(spec_hw, bg_hw) combinations, and each iteration does
`meta.outputdir = util.pathdirectory(meta, 'S#', run, ap=.., bg=..)` — a
fully-resolved absolute path. Assigning it re-triggers the setter above,
which strips `topdir` and stores the *already fully-resolved run+ap+bg
subfolder* back into `outputdir_raw`. On the next (ap, bg) iteration,
`util.pathdirectory`/`makedirectory` rebuild the root directory from that
corrupted `outputdir_raw`, so the new run+ap+bg folder gets nested **inside**
the previous one instead of being created alongside it. Only the flat
(non-nested) directory was pre-created by the dir-creation pre-loop, so
opening the per-aperture log file for the 2nd+ combination raises
`FileNotFoundError`.

This affects any Stage 3 run with more than one `photap`/`skyin`/`skywidth`
combination, and identically affects Stage 4/5/6 whenever `allapers=True`
processes more than one aperture pair from a prior stage. It is not caught
by the existing test suite since no test currently exercises a multi-value
aperture grid end-to-end. The Stage 1/3-4 optimizers are unaffected since
each sweep evaluates a single combination via a freshly deep-copied `meta`.

## Fix

- Added an optional `outputdir_raw` kwarg to `util.pathdirectory()` and
  `util.makedirectory()`. When provided, it's used instead of reading
  `meta.outputdir_raw`, so callers can supply an immutable, clean base path
  that isn't affected by the `outputdir` setter's side effect. Omitting it
  preserves the previous behavior, so unaffected callers (S1/S2/S4cal,
  optimizers) need no changes.
- In `s3_reduce.py`, `s4_genLC.py`, `s5_fit.py`, and `s6_spectra.py`: capture
  the clean base directory once, right after `set_defaults()`/before any
  aperture loop, and pass it explicitly to every `makedirectory()`/
  `pathdirectory()` call in both the directory-creation loop and the main
  processing loop.

## Tests

Added `tests/test_outputdir_raw.py`:
- `test_pathdirectory_without_base_reproduces_nesting_bug` documents the old
  hazard (nesting occurs if the base isn't passed explicitly).
- `test_pathdirectory_with_explicit_base_stays_flat` confirms the fix keeps
  three consecutive aperture/annulus directories as flat siblings.

Full `pytest tests/` suite (49 tests, including MIRI/NIRCam/NIRSpec/NIRISS
end-to-end pipeline runs) passes with no regressions.
