### PR TITLE
Use compact tqdm bar_format for dynesty progress display

### DIFF
--- a/src/eureka/S5_lightcurve_fitting/fitters.py
+++ b/src/eureka/S5_lightcurve_fitting/fitters.py
@@ -2,6 +2,7 @@ import copy
 import os
 import sys
 import time as time_pkg
+from functools import partial
 from io import StringIO
 from multiprocessing import Pool
 
@@ -10,10 +11,12 @@ import h5py
 import lmfit
 import numpy as np
 import pandas as pd
+import tqdm as tqdm_module
 import xarray as xr
 from astraeus import xarrayIO as xrio
 from astropy import table
 from dynesty import DynamicNestedSampler, NestedSampler
+from dynesty.utils import print_fn as dynesty_print_fn
 from dynesty.utils import resample_equal
 from scipy.optimize import minimize
 
@@ -913,7 +916,10 @@ def dynestyfitter(lc, model, meta, log, **kwargs):
         log.writelog('  Resuming dynesty run from existing checkpoint: '
                      f'{meta.old_checkpoint_file}')
 
-    run_kwargs = {'print_progress': True}
+    # Use a custom tqdm bar showing only rate and dynesty diagnostics
+    _pbar = tqdm_module.tqdm(bar_format='[{rate_fmt}{postfix}]')
+    run_kwargs = {'print_progress': True,
+                  'print_func': partial(dynesty_print_fn, pbar=_pbar)}
     if meta.dynesty_checkpoint or meta.dynesty_resume:
         run_kwargs['checkpoint_file'] = meta.checkpoint_file
         run_kwargs['checkpoint_every'] = meta.dynesty_checkpoint_every
@@ -1014,6 +1020,8 @@ def dynestyfitter(lc, model, meta, log, **kwargs):
 
         # Run the sampler
         sampler.run_nested(dlogz=meta.run_tol, **run_kwargs)
+
+    _pbar.close()
 
     # Get the results from the sampler
     res = sampler.results

--- a/tests/test_lightcurve_fitting.py
+++ b/tests/test_lightcurve_fitting.py
@@ -2,7 +2,7 @@
 import os
 import sys
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import numpy as np
 import pytest
@@ -178,7 +178,7 @@ def test_dynesty_checkpoint_kwargs_passed_to_run_nested(tmp_path):
     assert meta.checkpoint_file == os.path.join(
         str(tmp_path), 'S5_dynesty_checkpoint_white.save')
     sampler.run_nested.assert_called_once_with(
-        dlogz=0.1, print_progress=True,
+        dlogz=0.1, print_progress=True, print_func=ANY,
         checkpoint_file=os.path.join(str(tmp_path),
                                      'S5_dynesty_checkpoint_white.save'),
         checkpoint_every=123.0)
@@ -205,7 +205,7 @@ def test_dynesty_resume_restores_sampler(tmp_path):
         str(tmp_path), 'S5_dynesty_checkpoint_white.save')
     restore.assert_called_once_with(str(old_checkpoint), pool=None)
     sampler.run_nested.assert_called_once_with(
-        dlogz=0.1, print_progress=True,
+        dlogz=0.1, print_progress=True, print_func=ANY,
         checkpoint_file=os.path.join(str(tmp_path),
                                      'S5_dynesty_checkpoint_white.save'),
         checkpoint_every=600.0, resume=True, maxiter=5, maxcall=6)


### PR DESCRIPTION
## Summary

Use compact tqdm `bar_format` for dynesty progress display.

## Problem

The dynesty sampler's default tqdm progress bar has recently changed to include several annoying, rapidly changing, and not particularly accurate statuses, namely: percentage, filled progress bar, iteration count, and elapsed/remaining-time fields. These obscure the useful dynesty diagnostics (logz, dlogz, eff, etc.):

```
31%|███       | 2275/7418 [00:22<00:56, 91.09it/s, batch: 0 | bound: 31 | nc: 66 | ncall: 73200 | eff(%): 3.104 | loglstar: 11391.943 | logz: 11363.531 +/- 0.537 | dlogz: 105.066 > 0.010]
```

## Change

In `dynestyfitter` (`src/eureka/S5_lightcurve_fitting/fitters.py`), a custom `tqdm` progress bar is created with `bar_format='[{rate_fmt}{postfix}]'` and passed to `run_nested` via `print_func=partial(dynesty_print_fn, pbar=_pbar)`. This retains all dynesty diagnostic fields while removing only the noisy prefix and time fields:

```
[91.09it/s, batch: 0 | bound: 31 | nc: 66 | ncall: 73200 | eff(%): 3.104 | loglstar: 11391.943 | logz: 11363.531 +/- 0.537 | dlogz: 105.066 > 0.010]
```

The approach uses dynesty's documented `print_func` hook, preserving all sampler behaviour.

## Testing

- Verified import and instantiation succeed in the `eureka_jwst2.0.1` environment (dynesty 3.0.0, tqdm 4.68.3).
- Updated two existing mock-based unit tests (`test_dynesty_checkpoint_kwargs_passed_to_run_nested`, `test_dynesty_resume_restores_sampler`) that assert exact `run_nested` call kwargs, replacing the hardcoded absence of `print_func` with `unittest.mock.ANY`.
- `pytest tests/test_lightcurve_fitting.py`: **24 passed, 0 failed**.
- `flake8` and all pre-commit hooks (isort, trim whitespace, etc.) pass.