### PR TITLE
Fix optimizer metadata serialization in xarray and S1 output

### DIFF
--- a/src/eureka/lib/util.py
+++ b/src/eureka/lib/util.py
@@ -1147,6 +1147,9 @@ def add_meta_to_xarray(meta, data):
         # None values cannot be saved, convert to string
         if attr_value is None:
             attr_value = 'None'
+        # Python ranges cannot be serialized as xarray attributes
+        if isinstance(attr_value, range):
+            attr_value = list(attr_value)
         # Bibliography needs special handling
         if attr == 'bibliography':
             # Can't have different sized lists, must collapse

--- a/src/eureka/optimizer/S1opt_optimizer.py
+++ b/src/eureka/optimizer/S1opt_optimizer.py
@@ -21,6 +21,23 @@ from . import objective_funcs, optimizers
 from .S1opt_meta import S1optMetaClass
 
 
+def _convert_to_native_types(value):
+    """Recursively convert numpy types to YAML-serializable Python types."""
+    if isinstance(value, dict):
+        return {k: _convert_to_native_types(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_convert_to_native_types(v) for v in value]
+    if isinstance(value, tuple):
+        return [_convert_to_native_types(v) for v in value]
+    if isinstance(value, np.ndarray):
+        return _convert_to_native_types(value.tolist())
+    if isinstance(value, (np.integer, np.floating)):
+        return value.item()
+    if isinstance(value, (np.bool_,)):
+        return bool(value)
+    return value
+
+
 def wrapper(eventlabel, ecf_path=None, initial_run=True, final_run=True):
     """
     Eureka! optimization wrapper for Stage 1.
@@ -99,7 +116,7 @@ def wrapper(eventlabel, ecf_path=None, initial_run=True, final_run=True):
     # Save the best dictionary to a JSON file
     with open(os.path.join(s1opt_meta.outputdir, "best_params.json"),
               "w") as f:
-        json.dump(best, f)
+        json.dump(_convert_to_native_types(best), f)
 
     # Define and create optimized ECF file path
     opt_path = os.path.join(s1opt_meta.outputdir, "opt_ECFs")

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -53,6 +53,27 @@ def test_trim(capsys):
                                   (trim_x1 - trim_x0))
 
 
+def test_add_meta_to_xarray_serializes_range_attrs(tmp_path):
+    meta = SimpleNamespace(params={
+        'sweep_jump_rejection_threshold': range(4, 15),
+        'none_value': None,
+        'bibliography': [['citation one', 'citation two']],
+        'string_array': np.array(['one', 'two']),
+        'scalar_value': 1.5,
+    })
+    data = xrio.makeDataset()
+
+    util.add_meta_to_xarray(meta, data)
+
+    assert data.attrs['sweep_jump_rejection_threshold'] == list(range(4, 15))
+    assert data.attrs['none_value'] == 'None'
+    assert data.attrs['bibliography'] == [
+        'citation one_ENDOFCITATION_citation two']
+    assert data.attrs['string_array'] == ['one', 'two']
+    assert data.attrs['scalar_value'] == 1.5
+    assert xrio.writeXR(str(tmp_path / 'metadata'), data, verbose=False)
+
+
 def test_medstddev(capsys):
     # eureka.lib.util.medstddev.medstddev test
     a = np.array([1, 3, 4, 5, 6, 7, 7])

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from types import SimpleNamespace
@@ -11,7 +12,7 @@ from astropy.io import fits
 from eureka.lib import util
 from eureka.lib.medstddev import medstddev
 from eureka.lib.readECF import MetaClass
-from eureka.optimizer import objective_funcs
+from eureka.optimizer import S1opt_optimizer, objective_funcs
 
 
 def test_trim(capsys):
@@ -72,6 +73,23 @@ def test_add_meta_to_xarray_serializes_range_attrs(tmp_path):
     assert data.attrs['string_array'] == ['one', 'two']
     assert data.attrs['scalar_value'] == 1.5
     assert xrio.writeXR(str(tmp_path / 'metadata'), data, verbose=False)
+
+
+def test_s1opt_best_params_are_json_serializable():
+    best = {
+        'sweep_jump_rejection_threshold': np.int64(4),
+        'nested_values': [np.float64(1.5), np.bool_(True)],
+        'array_values': np.array([np.int32(2), np.int32(3)]),
+    }
+
+    converted = S1opt_optimizer._convert_to_native_types(best)
+
+    assert converted == {
+        'sweep_jump_rejection_threshold': 4,
+        'nested_values': [1.5, True],
+        'array_values': [2, 3],
+    }
+    assert json.loads(json.dumps(converted)) == converted
 
 
 def test_medstddev(capsys):


### PR DESCRIPTION
## Summary

Fixes two serialization failures triggered by optimizer metadata and results:

- Stage 3 xarray output failed when metadata contained a Python `range`.
- S1 optimizer output failed when the selected parameter value was a NumPy scalar such as `np.int64`.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Code cleanup / restructure
- [ ] Documentation
- [ ] Other (describe in "What changed")


## Stages affected
- [x] S1 — Detector processing
- [ ] S2 — Calibrations
- [x] S3 — Data reduction
- [ ] S4 — Lightcurve generation
- [ ] S5 — Lightcurve fitting
- [ ] S6 — Planet spectra
- [x] lib / utilities
- [ ] CI/CD / GitHub Actions


## What changed

- Convert top-level Python `range` metadata values to lists before adding them to xarray attributes.
- Convert NumPy scalars, booleans, arrays, and nested containers to native Python values before S1 writes `best_params.json`.
- Add regression coverage for both serialization paths.

## Related issues

None

## Testing
- [x] I ran `pytest` locally and all relevant tests pass

**Test notes** (what was tested; if any tests are failing, explain why):

The regression test verifies both in-memory attributes and successful writing through `astraeus.xarrayIO.writeXR()`.


## Other Notes

The xarray normalization intentionally remains limited to top-level metadata values. Recursive normalization is applied to S1 optimizer results because JSON output may contain nested NumPy values.