### PR TITLE
Explicit SOSS X and Y offset parameters

### DIFF
--- a/src/eureka/S3_data_reduction/niriss.py
+++ b/src/eureka/S3_data_reduction/niriss.py
@@ -147,12 +147,28 @@ def get_wave(data, meta, log):
     log.writelog(f"  The NIRISS pupil position is {pwcpos:3f} degrees",
                  mute=(not meta.verbose))
 
-    # Calculate offset amount from header (given in arcsec) and
-    # NIRISS pixel scale (0.0653 arcsec/px in X direction)
-    pixscale = 0.0653
-    trace_xoffset = data.attrs['mhdr']['XOFFSET'] / pixscale
-    log.writelog(f"  There is an X offset of {trace_xoffset:.3f} pixels",
-                 mute=(not meta.verbose))
+
+    # Check meta for trace offsets, and if not present,
+    # calculate offset amounts from header (given in arcsec) and
+    # NIRISS pixel scale (0.0653 arcsec/px in X direction, 0.0658 in Y)
+    trace_xoffset = meta.trace_xoffset
+    if trace_xoffset is not None:
+            trace_xoffset = data.attrs['mhdr']['XOFFSET'] / 0.0653
+
+    trace_yoffset = meta.trace_yoffset
+    if trace_yoffset is not None:
+        trace_yoffset = data.attrs['mhdr']['YOFFSET'] / 0.0658
+
+    if np.abs(trace_xoffset) > 0.001:
+        log.writelog(f"  There is an X offset of {trace_xoffset:.3f} pixels",
+                    mute=(not meta.verbose))
+    else:
+        trace_xoffset = 0
+    if np.abs(trace_yoffset) > 0.001:
+        log.writelog(f"  There is a Y offset of {trace_yoffset:.3f} pixels",
+                    mute=(not meta.verbose))
+    else:
+        trace_yoffset = 0
 
     norders = len(meta.all_orders)
     data['trace'] = (['x', 'order'],
@@ -171,11 +187,11 @@ def get_wave(data, meta, log):
         else:
             trace = get_soss_traces(pwcpos=pwcpos,
                                     order=str(order), interp=True)
-        if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96' and \
-                meta.trace_yoffset is None:
+        #if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96' and \
+        #       meta.trace_yoffset is None:
             # PASTASOSS doesn't account for different substrip starting rows;
             # therefore, set trace offset to best guess (-12 pixels).
-            meta.trace_yoffset = -12
+        #    meta.trace_yoffset = -12
         if meta.trace_yoffset is not None:
             # Shift trace
             trace.y += meta.trace_yoffset

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -711,21 +711,12 @@ def median_frame(data, meta, m, medflux, order=None):
     # Overplot nominal spectral trace for NIRISS SOSS
     # (TODO: Probably also useful for NIRSpec, etc.)
     if meta.inst == "niriss":
-        if data.attrs['mhdr']['SUBARRAY'] == 'SUBSTRIP96':
-            order = 1
+        for order in meta.orders:
             trace = data["trace"].sel(order=order)
-
             plt.plot(data.flux.x.values, trace,
                      c="white", lw=2)
             plt.plot(data.flux.x.values, trace,
                      "--k", lw=1, label=f"Trace Order {order}")
-        else:
-            for order in meta.orders:
-                trace = data["trace"].sel(order=order)
-                plt.plot(data.flux.x.values, trace,
-                         c="white", lw=2)
-                plt.plot(data.flux.x.values, trace,
-                         "--k", lw=1, label=f"Trace Order {order}")
         plt.legend()
 
     plt.ylabel('Detector Pixel Position')

--- a/src/eureka/S3_data_reduction/plots_s3.py
+++ b/src/eureka/S3_data_reduction/plots_s3.py
@@ -720,7 +720,7 @@ def median_frame(data, meta, m, medflux, order=None):
             plt.plot(data.flux.x.values, trace,
                      "--k", lw=1, label=f"Trace Order {order}")
         else:
-            for order in meta.all_orders:
+            for order in meta.orders:
                 trace = data["trace"].sel(order=order)
                 plt.plot(data.flux.x.values, trace,
                          c="white", lw=2)

--- a/src/eureka/S3_data_reduction/s3_meta.py
+++ b/src/eureka/S3_data_reduction/s3_meta.py
@@ -302,7 +302,8 @@ class S3MetaClass(MetaClass):
         self.orders = getattr(self, 'orders', [1, 2])
         self.all_orders = getattr(self, 'all_orders', [1, 2])
         self.record_ypos = getattr(self, 'record_ypos', False)
-        self.trace_offset = getattr(self, 'trace_offset', None)
+        self.trace_yoffset = getattr(self, 'trace_yoffset', None)
+        self.trace_xoffset = getattr(self, 'trace_xoffset', None)
         self.xwindow = getattr(self, 'xwindow', [6, 2043])
         self.ywindow = getattr(self, 'ywindow', [0, -1])
 


### PR DESCRIPTION
Adding custom X offset capabilities to SOSS stage 3 analyses. While we previously allowed for custom Y offsets, we now let users pass in arbitrary X offsets. The code checks the FITS headers for `XOFFSET` and `YOFFSET` values in the dither information, which are superseded by explicit `trace_xoffset` and `trace_yoffset` values in the ECF. The defaults for these parameters are `None`, and no offset is applied from the header if the dither is less than 1/100 of a pixel (or ~0.7 mas).

Also, fixes S3 fig. 3308 to properly do trace plotting for Orders 1 and 2 in SUB96 vs SUB256 by checking `meta.orders` as opposed to `meta.all_orders`.